### PR TITLE
Resolve O(n^2) input remapping in elementwise tile graph construction

### DIFF
--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -1850,18 +1850,21 @@ pub fn create_elementwise_tile_slice(
 
     let initializers: Vec<_> = graph.initializer.to_vec();
 
+    let input_remap: std::collections::HashMap<&str, &str> = orig_to_tile
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+
     let mut nodes = Vec::new();
     for orig_node in &graph.node {
         let new_inputs: Vec<String> = orig_node
             .input
             .iter()
             .map(|name| {
-                for (orig, tile) in &orig_to_tile {
-                    if name == orig {
-                        return tile.clone();
-                    }
-                }
-                name.clone()
+                input_remap
+                    .get(name.as_str())
+                    .map(|s| (*s).to_string())
+                    .unwrap_or_else(|| name.clone())
             })
             .collect();
         let produces_output = orig_node.output.contains(orig_output_name);


### PR DESCRIPTION
## Summary

- Replaced linear scan through `orig_to_tile` Vec with HashMap lookup during tile graph node construction in `create_elementwise_tile_slice`.
- Reduces input remapping from O(nodes * inputs * mapping_size) to O(nodes * inputs).

## Metrics

| Metric | Main | This PR | Change |
|--------|------|---------|--------|
| Slice correctness | PASS | PASS | -- |
| JSTprove integration | PASS | PASS | -- |
| `cargo test --locked` | 233 pass | 233 pass | -- |
| `cargo clippy -D warnings` | PASS | PASS | -- |
| `cargo fmt --check` | PASS | PASS | -- |
| Input remap complexity | O(n * m) per node | O(1) per input | **O(n) -> O(1)** |

## Methodology

`create_elementwise_tile_slice` builds tile graphs by remapping input names. The original code iterated a `Vec<(String, String)>` for every input of every node — a linear scan that becomes quadratic with graph size. Converted to a `HashMap<&str, &str>` built once after the Vec is finalized (post-mutation at line 1838), then used for O(1) lookups during node construction.

## What changed

**`autotiler.rs:1851-1866`** — Added `input_remap` HashMap built from `orig_to_tile`, replaced inner `for (orig, tile)` loop with `input_remap.get()`.

## What did NOT work

N/A — single correct approach for replacing linear scan with hash lookup.

## Benchmark reproduction

```bash
cargo build --release --manifest-path crates/dsperse/Cargo.toml
cargo test --locked
cargo clippy --workspace --all-targets -- -D warnings
cargo fmt --check
```

## Files changed

- `crates/dsperse/src/slicer/autotiler.rs` — replaced Vec linear scan with HashMap lookup (+9/-6 lines)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized performance in the elementwise tile slicing component by improving the efficiency of input mapping lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->