### PR TITLE
Migrate execute_single to StrategyOutput, implement numpy broadcasting, extract shape utilities

### DIFF
--- a/crates/dsperse/src/pipeline/runner.rs
+++ b/crates/dsperse/src/pipeline/runner.rs
@@ -849,16 +849,22 @@ fn execute_slice(
             }
             Ok(result.info)
         }
-        ExecutionStrategy::Single { .. } => execute_single(
-            slices_dir,
-            slice_run_dir,
-            slice_id,
-            node,
-            meta,
-            tensor_cache,
-            backend,
-            donor_init_map,
-        ),
+        ExecutionStrategy::Single { .. } => {
+            let result = execute_single(
+                slices_dir,
+                slice_run_dir,
+                slice_id,
+                node,
+                meta,
+                tensor_cache,
+                backend,
+                donor_init_map,
+            )?;
+            for (name, tensor) in result.outputs {
+                tensor_cache.put(name, tensor);
+            }
+            Ok(result.info)
+        }
     }
 }
 
@@ -869,10 +875,10 @@ fn execute_single(
     slice_id: &str,
     node: &ExecutionNode,
     meta: &RunSliceMetadata,
-    tensor_cache: &mut TensorStore,
+    tensor_cache: &TensorStore,
     backend: &JstproveBackend,
     donor_init_map: Option<&HashMap<String, &TensorProto>>,
-) -> Result<ExecutionInfo> {
+) -> Result<crate::schema::execution::StrategyOutput> {
     let inputs: Vec<String> = meta
         .dependencies
         .filtered_inputs
@@ -942,14 +948,17 @@ fn execute_single(
         std::fs::write(&witness_path, &witness_bytes)
             .map_err(|e| DsperseError::io(e, &witness_path))?;
 
-        store_named_outputs(tensor_cache, &meta.dependencies.output, named)?;
+        let outputs = collect_named_outputs(&meta.dependencies.output, named)?;
 
-        Ok(ExecutionInfo {
-            method: ExecutionMethod::JstproveGenWitness,
-            success: true,
-            error: None,
-            witness_file: Some(witness_path.to_string_lossy().into_owned()),
-            tile_exec_infos: Vec::new(),
+        Ok(crate::schema::execution::StrategyOutput {
+            info: ExecutionInfo {
+                method: ExecutionMethod::JstproveGenWitness,
+                success: true,
+                error: None,
+                witness_file: Some(witness_path.to_string_lossy().into_owned()),
+                tile_exec_infos: Vec::new(),
+            },
+            outputs,
         })
     } else {
         let named = if multi_input {
@@ -958,31 +967,46 @@ fn execute_single(
             let input_tensor = tensor_cache.gather(&inputs)?;
             run_onnx_inference_named(effective_onnx, &input_tensor)?
         };
-        store_named_outputs(tensor_cache, &meta.dependencies.output, named)?;
+        let outputs = collect_named_outputs(&meta.dependencies.output, named)?;
 
-        Ok(ExecutionInfo {
-            method: ExecutionMethod::OnnxOnly,
-            success: true,
-            error: None,
-            witness_file: None,
-            tile_exec_infos: Vec::new(),
+        Ok(crate::schema::execution::StrategyOutput {
+            info: ExecutionInfo {
+                method: ExecutionMethod::OnnxOnly,
+                success: true,
+                error: None,
+                witness_file: None,
+                tile_exec_infos: Vec::new(),
+            },
+            outputs,
         })
     }
 }
 
-pub(crate) fn store_named_outputs(
+#[cfg(test)]
+fn store_named_outputs(
     tensor_cache: &mut TensorStore,
     output_names: &[String],
     named_outputs: HashMap<String, (Vec<f64>, Vec<usize>)>,
 ) -> Result<()> {
+    for (name, tensor) in collect_named_outputs(output_names, named_outputs)? {
+        tensor_cache.put(name, tensor);
+    }
+    Ok(())
+}
+
+fn collect_named_outputs(
+    output_names: &[String],
+    named_outputs: HashMap<String, (Vec<f64>, Vec<usize>)>,
+) -> Result<Vec<(String, ArrayD<f64>)>> {
+    let mut result = Vec::new();
     for name in output_names {
         if let Some((data, shape)) = named_outputs.get(name) {
             let arr = ArrayD::from_shape_vec(IxDyn(shape), data.clone())
                 .map_err(|e| DsperseError::Pipeline(format!("output reshape '{name}': {e}")))?;
-            tensor_cache.put(name.clone(), arr);
+            result.push((name.clone(), arr));
         }
     }
-    Ok(())
+    Ok(result)
 }
 
 pub(crate) fn run_onnx_inference(onnx_path: &Path, input: &ArrayD<f64>) -> Result<ArrayD<f64>> {

--- a/crates/dsperse/src/pipeline/runner.rs
+++ b/crates/dsperse/src/pipeline/runner.rs
@@ -930,6 +930,8 @@ fn execute_single(
             run_onnx_inference_named(effective_onnx, &input_tensor)?
         };
 
+        let outputs = collect_named_outputs(&meta.dependencies.output, named)?;
+
         let flat_activations = flatten_cached_inputs(tensor_cache, &inputs)?;
         let witness_bytes = if is_wai {
             generate_wai_witness(
@@ -947,8 +949,6 @@ fn execute_single(
         let witness_path = slice_run_dir.join(crate::utils::paths::WITNESS_FILE);
         std::fs::write(&witness_path, &witness_bytes)
             .map_err(|e| DsperseError::io(e, &witness_path))?;
-
-        let outputs = collect_named_outputs(&meta.dependencies.output, named)?;
 
         Ok(crate::schema::execution::StrategyOutput {
             info: ExecutionInfo {
@@ -996,14 +996,14 @@ fn store_named_outputs(
 
 fn collect_named_outputs(
     output_names: &[String],
-    named_outputs: HashMap<String, (Vec<f64>, Vec<usize>)>,
+    mut named_outputs: HashMap<String, (Vec<f64>, Vec<usize>)>,
 ) -> Result<Vec<(String, ArrayD<f64>)>> {
     let mut result = Vec::new();
     for name in output_names {
         let (data, shape) = named_outputs
-            .get(name)
+            .remove(name)
             .ok_or_else(|| DsperseError::Pipeline(format!("missing declared output '{name}'")))?;
-        let arr = ArrayD::from_shape_vec(IxDyn(shape), data.clone())
+        let arr = ArrayD::from_shape_vec(IxDyn(&shape), data)
             .map_err(|e| DsperseError::Pipeline(format!("output reshape '{name}': {e}")))?;
         result.push((name.clone(), arr));
     }

--- a/crates/dsperse/src/pipeline/runner.rs
+++ b/crates/dsperse/src/pipeline/runner.rs
@@ -998,8 +998,14 @@ fn collect_named_outputs(
     output_names: &[String],
     mut named_outputs: HashMap<String, (Vec<f64>, Vec<usize>)>,
 ) -> Result<Vec<(String, ArrayD<f64>)>> {
+    let mut seen = std::collections::HashSet::new();
     let mut result = Vec::new();
     for name in output_names {
+        if !seen.insert(name) {
+            return Err(DsperseError::Pipeline(format!(
+                "duplicate declared output '{name}'"
+            )));
+        }
         let (data, shape) = named_outputs
             .remove(name)
             .ok_or_else(|| DsperseError::Pipeline(format!("missing declared output '{name}'")))?;
@@ -1452,6 +1458,22 @@ mod tests {
         let named = HashMap::new();
         let result = store_named_outputs(&mut cache, &names, named);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn store_named_outputs_partial_write_errors() {
+        let mut cache = TensorStore::new();
+        cache.put(
+            "pre_existing".into(),
+            ArrayD::from_shape_vec(ndarray::IxDyn(&[1]), vec![99.0]).unwrap(),
+        );
+        let names = vec!["present".to_string(), "missing".to_string()];
+        let mut named = HashMap::new();
+        named.insert("present".to_string(), (vec![1.0, 2.0], vec![2]));
+        let result = store_named_outputs(&mut cache, &names, named);
+        assert!(result.is_err());
+        assert!(cache.contains("pre_existing"));
+        assert!(!cache.contains("present"));
     }
 
     #[test]

--- a/crates/dsperse/src/pipeline/runner.rs
+++ b/crates/dsperse/src/pipeline/runner.rs
@@ -1000,11 +1000,12 @@ fn collect_named_outputs(
 ) -> Result<Vec<(String, ArrayD<f64>)>> {
     let mut result = Vec::new();
     for name in output_names {
-        if let Some((data, shape)) = named_outputs.get(name) {
-            let arr = ArrayD::from_shape_vec(IxDyn(shape), data.clone())
-                .map_err(|e| DsperseError::Pipeline(format!("output reshape '{name}': {e}")))?;
-            result.push((name.clone(), arr));
-        }
+        let (data, shape) = named_outputs
+            .get(name)
+            .ok_or_else(|| DsperseError::Pipeline(format!("missing declared output '{name}'")))?;
+        let arr = ArrayD::from_shape_vec(IxDyn(shape), data.clone())
+            .map_err(|e| DsperseError::Pipeline(format!("output reshape '{name}': {e}")))?;
+        result.push((name.clone(), arr));
     }
     Ok(result)
 }
@@ -1445,12 +1446,12 @@ mod tests {
     }
 
     #[test]
-    fn store_named_outputs_missing_name_ignored() {
+    fn store_named_outputs_missing_name_errors() {
         let mut cache = TensorStore::new();
         let names = vec!["missing".to_string()];
         let named = HashMap::new();
-        store_named_outputs(&mut cache, &names, named).unwrap();
-        assert!(!cache.contains("missing"));
+        let result = store_named_outputs(&mut cache, &names, named);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/dsperse/src/slicer/mod.rs
+++ b/crates/dsperse/src/slicer/mod.rs
@@ -4,6 +4,7 @@ pub mod combiner;
 pub mod materializer;
 pub(crate) mod onnx_fold;
 pub mod onnx_proto;
+pub(crate) mod onnx_shapes;
 pub mod onnx_slicer;
 pub(crate) mod trace;
 

--- a/crates/dsperse/src/slicer/onnx_fold.rs
+++ b/crates/dsperse/src/slicer/onnx_fold.rs
@@ -389,10 +389,49 @@ fn eval_binary_f32(
     Some(vec![(out_name.to_string(), t)])
 }
 
-// Handles equal-shape and scalar broadcasting only.
-// Full numpy-style broadcasting (right-aligned dimension matching)
-// is not implemented; mismatched non-scalar shapes return None,
-// falling through to tract inference for evaluation.
+fn broadcast_shape(a_dims: &[i64], b_dims: &[i64]) -> Option<Vec<i64>> {
+    let rank = a_dims.len().max(b_dims.len());
+    let mut out = Vec::with_capacity(rank);
+    for i in 0..rank {
+        let da = if i < rank - a_dims.len() {
+            1
+        } else {
+            a_dims[i - (rank - a_dims.len())]
+        };
+        let db = if i < rank - b_dims.len() {
+            1
+        } else {
+            b_dims[i - (rank - b_dims.len())]
+        };
+        if da == db {
+            out.push(da);
+        } else if da == 1 {
+            out.push(db);
+        } else if db == 1 {
+            out.push(da);
+        } else {
+            return None;
+        }
+    }
+    Some(out)
+}
+
+fn broadcast_index(out_idx: usize, out_dims: &[i64], src_dims: &[i64]) -> usize {
+    let rank = out_dims.len();
+    let src_rank = src_dims.len();
+    let mut idx = 0;
+    let mut stride = 1;
+    for i in (0..src_rank).rev() {
+        let out_i = rank - src_rank + i;
+        let coord = (out_idx / out_dims[out_i + 1..].iter().product::<i64>().max(1) as usize)
+            % out_dims[out_i] as usize;
+        let src_coord = if src_dims[i] == 1 { 0 } else { coord };
+        idx += src_coord * stride;
+        stride *= src_dims[i] as usize;
+    }
+    idx
+}
+
 fn broadcast_binary(
     a: &[f32],
     a_dims: &[i64],
@@ -400,19 +439,15 @@ fn broadcast_binary(
     b_dims: &[i64],
     f: fn(f32, f32) -> f32,
 ) -> Option<(Vec<f32>, Vec<i64>)> {
-    if a_dims == b_dims {
-        let result: Vec<f32> = a.iter().zip(b.iter()).map(|(&x, &y)| f(x, y)).collect();
-        return Some((result, a_dims.to_vec()));
+    let out_dims = broadcast_shape(a_dims, b_dims)?;
+    let total: usize = out_dims.iter().map(|&d| d as usize).product();
+    let mut result = Vec::with_capacity(total);
+    for i in 0..total {
+        let ai = broadcast_index(i, &out_dims, a_dims);
+        let bi = broadcast_index(i, &out_dims, b_dims);
+        result.push(f(a[ai], b[bi]));
     }
-    if a.len() == 1 {
-        let result: Vec<f32> = b.iter().map(|&y| f(a[0], y)).collect();
-        return Some((result, b_dims.to_vec()));
-    }
-    if b.len() == 1 {
-        let result: Vec<f32> = a.iter().map(|&x| f(x, b[0])).collect();
-        return Some((result, a_dims.to_vec()));
-    }
-    None
+    Some((result, out_dims))
 }
 
 fn broadcast_binary_i64(
@@ -422,19 +457,15 @@ fn broadcast_binary_i64(
     b_dims: &[i64],
     f: impl Fn(i64, i64) -> i64,
 ) -> Option<(Vec<i64>, Vec<i64>)> {
-    if a_dims == b_dims {
-        let result: Vec<i64> = a.iter().zip(b.iter()).map(|(&x, &y)| f(x, y)).collect();
-        return Some((result, a_dims.to_vec()));
+    let out_dims = broadcast_shape(a_dims, b_dims)?;
+    let total: usize = out_dims.iter().map(|&d| d as usize).product();
+    let mut result = Vec::with_capacity(total);
+    for i in 0..total {
+        let ai = broadcast_index(i, &out_dims, a_dims);
+        let bi = broadcast_index(i, &out_dims, b_dims);
+        result.push(f(a[ai], b[bi]));
     }
-    if a.len() == 1 {
-        let result: Vec<i64> = b.iter().map(|&y| f(a[0], y)).collect();
-        return Some((result, b_dims.to_vec()));
-    }
-    if b.len() == 1 {
-        let result: Vec<i64> = a.iter().map(|&x| f(x, b[0])).collect();
-        return Some((result, a_dims.to_vec()));
-    }
-    None
+    Some((result, out_dims))
 }
 
 fn eval_reshape(

--- a/crates/dsperse/src/slicer/onnx_fold.rs
+++ b/crates/dsperse/src/slicer/onnx_fold.rs
@@ -432,6 +432,20 @@ fn broadcast_index(out_idx: usize, out_dims: &[i64], src_dims: &[i64]) -> usize 
     idx
 }
 
+const MAX_BROADCAST_ELEMENTS: usize = 100_000_000;
+
+fn broadcast_total(out_dims: &[i64]) -> Option<usize> {
+    let mut total: usize = 1;
+    for &d in out_dims {
+        let d = usize::try_from(d).ok()?;
+        total = total.checked_mul(d)?;
+        if total > MAX_BROADCAST_ELEMENTS {
+            return None;
+        }
+    }
+    Some(total)
+}
+
 fn broadcast_binary(
     a: &[f32],
     a_dims: &[i64],
@@ -440,7 +454,7 @@ fn broadcast_binary(
     f: fn(f32, f32) -> f32,
 ) -> Option<(Vec<f32>, Vec<i64>)> {
     let out_dims = broadcast_shape(a_dims, b_dims)?;
-    let total: usize = out_dims.iter().map(|&d| d as usize).product();
+    let total = broadcast_total(&out_dims)?;
     let mut result = Vec::with_capacity(total);
     for i in 0..total {
         let ai = broadcast_index(i, &out_dims, a_dims);
@@ -458,7 +472,7 @@ fn broadcast_binary_i64(
     f: impl Fn(i64, i64) -> i64,
 ) -> Option<(Vec<i64>, Vec<i64>)> {
     let out_dims = broadcast_shape(a_dims, b_dims)?;
-    let total: usize = out_dims.iter().map(|&d| d as usize).product();
+    let total = broadcast_total(&out_dims)?;
     let mut result = Vec::with_capacity(total);
     for i in 0..total {
         let ai = broadcast_index(i, &out_dims, a_dims);

--- a/crates/dsperse/src/slicer/onnx_proto.rs
+++ b/crates/dsperse/src/slicer/onnx_proto.rs
@@ -15,6 +15,11 @@ pub use onnx::{
     ValueInfoProto,
 };
 
+pub use super::onnx_shapes::{
+    elem_type_from_value_info, resolve_dynamic_input_shapes, set_vi_shape, shape_from_value_info,
+    strip_symbolic_value_info, vi_shape,
+};
+
 pub fn load_model(path: &Path) -> Result<ModelProto> {
     let bytes = crate::utils::limits::read_checked(path)?;
     ModelProto::decode(bytes.as_slice())
@@ -48,30 +53,6 @@ pub fn save_model(model: &ModelProto, path: &Path) -> Result<()> {
     }
     let bytes = model.encode_to_vec();
     std::fs::write(path, bytes).map_err(|e| DsperseError::io(e, path))
-}
-
-pub fn shape_from_value_info(vi: &ValueInfoProto) -> Option<Vec<i64>> {
-    let tp = vi.r#type.as_ref()?;
-    let onnx::type_proto::Value::TensorType(tensor) = tp.value.as_ref()? else {
-        return None;
-    };
-    let shape_proto = tensor.shape.as_ref()?;
-    let mut dims = Vec::new();
-    for d in &shape_proto.dim {
-        match &d.value {
-            Some(onnx::tensor_shape_proto::dimension::Value::DimValue(v)) => dims.push(*v),
-            _ => return None,
-        }
-    }
-    Some(dims)
-}
-
-pub fn elem_type_from_value_info(vi: &ValueInfoProto) -> Option<i32> {
-    let tp = vi.r#type.as_ref()?;
-    let onnx::type_proto::Value::TensorType(tensor) = tp.value.as_ref()? else {
-        return None;
-    };
-    Some(tensor.elem_type)
 }
 
 pub fn make_tensor_value_info(name: &str, elem_type: i32, shape: &[i64]) -> ValueInfoProto {
@@ -200,25 +181,6 @@ pub fn make_attribute_float(name: &str, val: f32) -> AttributeProto {
         r#type: 1,
         ..Default::default()
     }
-}
-
-pub fn vi_shape(vi: &ValueInfoProto) -> Vec<i64> {
-    vi.r#type
-        .as_ref()
-        .and_then(|t| match &t.value {
-            Some(onnx::type_proto::Value::TensorType(tt)) => tt.shape.as_ref(),
-            _ => None,
-        })
-        .map(|s| {
-            s.dim
-                .iter()
-                .map(|d| match &d.value {
-                    Some(onnx::tensor_shape_proto::dimension::Value::DimValue(v)) => *v,
-                    _ => 0,
-                })
-                .collect()
-        })
-        .unwrap_or_default()
 }
 
 pub fn tensor_to_i64(tensor: &TensorProto) -> Vec<i64> {
@@ -569,172 +531,6 @@ pub fn normalize_opset(model: &mut ModelProto) -> usize {
     count
 }
 
-pub fn strip_symbolic_value_info(model: &mut ModelProto) -> usize {
-    let graph = match model.graph.as_mut() {
-        Some(g) => g,
-        None => return 0,
-    };
-
-    let has_symbolic = |vi: &ValueInfoProto| -> bool {
-        vi.r#type
-            .as_ref()
-            .and_then(|t| match &t.value {
-                Some(onnx::type_proto::Value::TensorType(tt)) => tt.shape.as_ref(),
-                _ => None,
-            })
-            .is_some_and(|s| {
-                s.dim.iter().any(|d| {
-                    matches!(
-                        &d.value,
-                        Some(onnx::tensor_shape_proto::dimension::Value::DimParam(_))
-                    )
-                })
-            })
-    };
-
-    let before = graph.value_info.len();
-    graph.value_info.retain(|vi| !has_symbolic(vi));
-    let removed = before - graph.value_info.len();
-
-    for out in &mut graph.output {
-        if let Some(ref mut tp) = out.r#type
-            && let Some(onnx::type_proto::Value::TensorType(ref mut tt)) = tp.value
-            && let Some(ref mut shape) = tt.shape
-        {
-            for d in &mut shape.dim {
-                if matches!(
-                    &d.value,
-                    Some(onnx::tensor_shape_proto::dimension::Value::DimParam(_))
-                ) {
-                    d.value = None;
-                }
-            }
-        }
-    }
-
-    if removed > 0 {
-        tracing::info!(
-            removed,
-            "stripped value_info entries with symbolic dimensions"
-        );
-    }
-    removed
-}
-
-pub fn resolve_dynamic_input_shapes(
-    model: &mut ModelProto,
-    explicit_shape: Option<&[i64]>,
-) -> crate::error::Result<usize> {
-    let graph = match model.graph.as_mut() {
-        Some(g) => g,
-        None => return Ok(0),
-    };
-    let symbolic_count = graph
-        .input
-        .iter()
-        .filter(|inp| {
-            inp.r#type
-                .as_ref()
-                .and_then(|t| match &t.value {
-                    Some(onnx::type_proto::Value::TensorType(tt)) => tt.shape.as_ref(),
-                    _ => None,
-                })
-                .is_some_and(|s| {
-                    s.dim.iter().any(|d| {
-                        matches!(
-                            &d.value,
-                            Some(onnx::tensor_shape_proto::dimension::Value::DimParam(_)) | None
-                        )
-                    })
-                })
-        })
-        .count();
-    if symbolic_count > 1 && explicit_shape.is_some() {
-        return Err(crate::error::DsperseError::Slicer(format!(
-            "model has {symbolic_count} inputs with dynamic dimensions; \
-             --input-shape applies to a single input. Per-input shapes not yet supported."
-        )));
-    }
-
-    let mut resolved = 0;
-    for inp in &mut graph.input {
-        let tp = match inp.r#type.as_mut() {
-            Some(t) => t,
-            None => continue,
-        };
-        let tensor = match &mut tp.value {
-            Some(onnx::type_proto::Value::TensorType(tt)) => tt,
-            _ => continue,
-        };
-        let shape = match tensor.shape.as_mut() {
-            Some(s) => s,
-            None => continue,
-        };
-        let has_symbolic = shape.dim.iter().any(|d| {
-            matches!(
-                &d.value,
-                Some(onnx::tensor_shape_proto::dimension::Value::DimParam(_)) | None
-            )
-        });
-        if !has_symbolic {
-            continue;
-        }
-        if let Some(explicit) = explicit_shape {
-            if explicit.len() != shape.dim.len() {
-                return Err(crate::error::DsperseError::Slicer(format!(
-                    "input '{}' has rank {} but --input-shape provides {} dims",
-                    inp.name,
-                    shape.dim.len(),
-                    explicit.len()
-                )));
-            }
-            for (d, &v) in shape.dim.iter_mut().zip(explicit.iter()) {
-                if let Some(onnx::tensor_shape_proto::dimension::Value::DimValue(existing)) =
-                    &d.value
-                {
-                    if *existing != v {
-                        return Err(crate::error::DsperseError::Slicer(format!(
-                            "input '{}': --input-shape dim {} conflicts with fixed dim {}",
-                            inp.name, v, existing
-                        )));
-                    }
-                } else {
-                    d.value = Some(onnx::tensor_shape_proto::dimension::Value::DimValue(v));
-                }
-            }
-            tracing::info!(input = %inp.name, shape = ?explicit, "applied explicit input shape");
-            resolved += 1;
-            continue;
-        }
-        let non_batch_symbolic = shape.dim.iter().skip(1).any(|d| {
-            matches!(
-                &d.value,
-                Some(onnx::tensor_shape_proto::dimension::Value::DimParam(_)) | None
-            )
-        });
-        if non_batch_symbolic {
-            let dim_names: Vec<String> = shape
-                .dim
-                .iter()
-                .map(|d| match &d.value {
-                    Some(onnx::tensor_shape_proto::dimension::Value::DimParam(s)) => s.clone(),
-                    Some(onnx::tensor_shape_proto::dimension::Value::DimValue(v)) => v.to_string(),
-                    None => "?".into(),
-                })
-                .collect();
-            return Err(crate::error::DsperseError::Slicer(format!(
-                "model input '{}' has dynamic dimensions [{}]; provide --input-shape to set concrete values",
-                inp.name,
-                dim_names.join(", ")
-            )));
-        }
-        shape.dim[0].value = Some(onnx::tensor_shape_proto::dimension::Value::DimValue(1));
-        tracing::info!(input = %inp.name, "defaulted batch dimension to 1");
-        resolved += 1;
-    }
-    Ok(resolved)
-}
-
 pub fn normalize_for_circuit_backend(model: &mut ModelProto) -> usize {
     let graph = match model.graph.as_mut() {
         Some(g) => g,
@@ -793,22 +589,6 @@ fn fix_zero_dims(graph: &mut GraphProto) -> usize {
         tracing::info!(count, "resolved zero-valued placeholder dimensions");
     }
     count
-}
-
-fn set_vi_shape(vi: &mut ValueInfoProto, shape: &[i64]) {
-    if let Some(ref mut tp) = vi.r#type
-        && let Some(onnx::type_proto::Value::TensorType(ref mut tt)) = tp.value
-    {
-        tt.shape = Some(onnx::TensorShapeProto {
-            dim: shape
-                .iter()
-                .map(|&d| onnx::tensor_shape_proto::Dimension {
-                    denotation: String::new(),
-                    value: Some(onnx::tensor_shape_proto::dimension::Value::DimValue(d)),
-                })
-                .collect(),
-        });
-    }
 }
 
 fn flatten_matmul_inputs(graph: &mut GraphProto) -> usize {

--- a/crates/dsperse/src/slicer/onnx_shapes.rs
+++ b/crates/dsperse/src/slicer/onnx_shapes.rs
@@ -1,0 +1,226 @@
+use super::onnx_proto::{ModelProto, ValueInfoProto, onnx};
+
+pub fn shape_from_value_info(vi: &ValueInfoProto) -> Option<Vec<i64>> {
+    let tp = vi.r#type.as_ref()?;
+    let onnx::type_proto::Value::TensorType(tensor) = tp.value.as_ref()? else {
+        return None;
+    };
+    let shape_proto = tensor.shape.as_ref()?;
+    let mut dims = Vec::new();
+    for d in &shape_proto.dim {
+        match &d.value {
+            Some(onnx::tensor_shape_proto::dimension::Value::DimValue(v)) => dims.push(*v),
+            _ => return None,
+        }
+    }
+    Some(dims)
+}
+
+pub fn elem_type_from_value_info(vi: &ValueInfoProto) -> Option<i32> {
+    let tp = vi.r#type.as_ref()?;
+    let onnx::type_proto::Value::TensorType(tensor) = tp.value.as_ref()? else {
+        return None;
+    };
+    Some(tensor.elem_type)
+}
+
+pub fn vi_shape(vi: &ValueInfoProto) -> Vec<i64> {
+    vi.r#type
+        .as_ref()
+        .and_then(|t| match &t.value {
+            Some(onnx::type_proto::Value::TensorType(tt)) => tt.shape.as_ref(),
+            _ => None,
+        })
+        .map(|s| {
+            s.dim
+                .iter()
+                .map(|d| match &d.value {
+                    Some(onnx::tensor_shape_proto::dimension::Value::DimValue(v)) => *v,
+                    _ => 0,
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+pub fn set_vi_shape(vi: &mut ValueInfoProto, shape: &[i64]) {
+    if let Some(ref mut tp) = vi.r#type
+        && let Some(onnx::type_proto::Value::TensorType(ref mut tt)) = tp.value
+    {
+        tt.shape = Some(onnx::TensorShapeProto {
+            dim: shape
+                .iter()
+                .map(|&d| onnx::tensor_shape_proto::Dimension {
+                    denotation: String::new(),
+                    value: Some(onnx::tensor_shape_proto::dimension::Value::DimValue(d)),
+                })
+                .collect(),
+        });
+    }
+}
+
+pub fn strip_symbolic_value_info(model: &mut ModelProto) -> usize {
+    let graph = match model.graph.as_mut() {
+        Some(g) => g,
+        None => return 0,
+    };
+
+    let has_symbolic = |vi: &ValueInfoProto| -> bool {
+        vi.r#type
+            .as_ref()
+            .and_then(|t| match &t.value {
+                Some(onnx::type_proto::Value::TensorType(tt)) => tt.shape.as_ref(),
+                _ => None,
+            })
+            .is_some_and(|s| {
+                s.dim.iter().any(|d| {
+                    matches!(
+                        &d.value,
+                        Some(onnx::tensor_shape_proto::dimension::Value::DimParam(_))
+                    )
+                })
+            })
+    };
+
+    let before = graph.value_info.len();
+    graph.value_info.retain(|vi| !has_symbolic(vi));
+    let removed = before - graph.value_info.len();
+
+    for out in &mut graph.output {
+        if let Some(ref mut tp) = out.r#type
+            && let Some(onnx::type_proto::Value::TensorType(ref mut tt)) = tp.value
+            && let Some(ref mut shape) = tt.shape
+        {
+            for d in &mut shape.dim {
+                if matches!(
+                    &d.value,
+                    Some(onnx::tensor_shape_proto::dimension::Value::DimParam(_))
+                ) {
+                    d.value = None;
+                }
+            }
+        }
+    }
+
+    if removed > 0 {
+        tracing::info!(
+            removed,
+            "stripped value_info entries with symbolic dimensions"
+        );
+    }
+    removed
+}
+
+pub fn resolve_dynamic_input_shapes(
+    model: &mut ModelProto,
+    explicit_shape: Option<&[i64]>,
+) -> crate::error::Result<usize> {
+    let graph = match model.graph.as_mut() {
+        Some(g) => g,
+        None => return Ok(0),
+    };
+    let symbolic_count = graph
+        .input
+        .iter()
+        .filter(|inp| {
+            inp.r#type
+                .as_ref()
+                .and_then(|t| match &t.value {
+                    Some(onnx::type_proto::Value::TensorType(tt)) => tt.shape.as_ref(),
+                    _ => None,
+                })
+                .is_some_and(|s| {
+                    s.dim.iter().any(|d| {
+                        matches!(
+                            &d.value,
+                            Some(onnx::tensor_shape_proto::dimension::Value::DimParam(_)) | None
+                        )
+                    })
+                })
+        })
+        .count();
+    if symbolic_count > 1 && explicit_shape.is_some() {
+        return Err(crate::error::DsperseError::Slicer(format!(
+            "model has {symbolic_count} inputs with dynamic dimensions; \
+             --input-shape applies to a single input. Per-input shapes not yet supported."
+        )));
+    }
+
+    let mut resolved = 0;
+    for inp in &mut graph.input {
+        let tp = match inp.r#type.as_mut() {
+            Some(t) => t,
+            None => continue,
+        };
+        let tensor = match &mut tp.value {
+            Some(onnx::type_proto::Value::TensorType(tt)) => tt,
+            _ => continue,
+        };
+        let shape = match tensor.shape.as_mut() {
+            Some(s) => s,
+            None => continue,
+        };
+        let has_symbolic = shape.dim.iter().any(|d| {
+            matches!(
+                &d.value,
+                Some(onnx::tensor_shape_proto::dimension::Value::DimParam(_)) | None
+            )
+        });
+        if !has_symbolic {
+            continue;
+        }
+        if let Some(explicit) = explicit_shape {
+            if explicit.len() != shape.dim.len() {
+                return Err(crate::error::DsperseError::Slicer(format!(
+                    "input '{}' has rank {} but --input-shape provides {} dims",
+                    inp.name,
+                    shape.dim.len(),
+                    explicit.len()
+                )));
+            }
+            for (d, &v) in shape.dim.iter_mut().zip(explicit.iter()) {
+                if let Some(onnx::tensor_shape_proto::dimension::Value::DimValue(existing)) =
+                    &d.value
+                {
+                    if *existing != v {
+                        return Err(crate::error::DsperseError::Slicer(format!(
+                            "input '{}': --input-shape dim {} conflicts with fixed dim {}",
+                            inp.name, v, existing
+                        )));
+                    }
+                } else {
+                    d.value = Some(onnx::tensor_shape_proto::dimension::Value::DimValue(v));
+                }
+            }
+            tracing::info!(input = %inp.name, shape = ?explicit, "applied explicit input shape");
+            resolved += 1;
+            continue;
+        }
+        let non_batch_symbolic = shape.dim.iter().skip(1).any(|d| {
+            matches!(
+                &d.value,
+                Some(onnx::tensor_shape_proto::dimension::Value::DimParam(_)) | None
+            )
+        });
+        if non_batch_symbolic {
+            let dim_names: Vec<String> = shape
+                .dim
+                .iter()
+                .map(|d| match &d.value {
+                    Some(onnx::tensor_shape_proto::dimension::Value::DimParam(s)) => s.clone(),
+                    Some(onnx::tensor_shape_proto::dimension::Value::DimValue(v)) => v.to_string(),
+                    None => "?".into(),
+                })
+                .collect();
+            return Err(crate::error::DsperseError::Slicer(format!(
+                "model input '{}' has dynamic dimensions [{}]; provide --input-shape to set concrete values",
+                inp.name,
+                dim_names.join(", ")
+            )));
+        }
+        shape.dim[0].value = Some(onnx::tensor_shape_proto::dimension::Value::DimValue(1));
+        tracing::info!(input = %inp.name, "defaulted batch dimension to 1");
+        resolved += 1;
+    }
+    Ok(resolved)
+}

--- a/crates/dsperse/src/slicer/onnx_shapes.rs
+++ b/crates/dsperse/src/slicer/onnx_shapes.rs
@@ -119,29 +119,26 @@ pub fn resolve_dynamic_input_shapes(
         Some(g) => g,
         None => return Ok(0),
     };
-    let symbolic_count = graph
-        .input
-        .iter()
-        .filter(|inp| {
-            inp.r#type
-                .as_ref()
-                .and_then(|t| match &t.value {
-                    Some(onnx::type_proto::Value::TensorType(tt)) => tt.shape.as_ref(),
-                    _ => None,
+    let has_non_batch_symbolic = |inp: &&ValueInfoProto| -> bool {
+        inp.r#type
+            .as_ref()
+            .and_then(|t| match &t.value {
+                Some(onnx::type_proto::Value::TensorType(tt)) => tt.shape.as_ref(),
+                _ => None,
+            })
+            .is_some_and(|s| {
+                s.dim.iter().skip(1).any(|d| {
+                    matches!(
+                        &d.value,
+                        Some(onnx::tensor_shape_proto::dimension::Value::DimParam(_)) | None
+                    )
                 })
-                .is_some_and(|s| {
-                    s.dim.iter().any(|d| {
-                        matches!(
-                            &d.value,
-                            Some(onnx::tensor_shape_proto::dimension::Value::DimParam(_)) | None
-                        )
-                    })
-                })
-        })
-        .count();
+            })
+    };
+    let symbolic_count = graph.input.iter().filter(has_non_batch_symbolic).count();
     if symbolic_count > 1 && explicit_shape.is_some() {
         return Err(crate::error::DsperseError::Slicer(format!(
-            "model has {symbolic_count} inputs with dynamic dimensions; \
+            "model has {symbolic_count} inputs with non-batch dynamic dimensions; \
              --input-shape applies to a single input. Per-input shapes not yet supported."
         )));
     }


### PR DESCRIPTION
## Summary

Completes the three remaining structural items from the decomposition effort.

### 1. execute_single -> StrategyOutput

Last strategy module migrated to return `StrategyOutput` with immutable `&TensorStore` access. All four strategies (tiled, channel_split, dim_split, single) now return outputs instead of mutating the cache. Introduced `collect_named_outputs` helper. Demoted `store_named_outputs` to `#[cfg(test)]`.

### 2. Full numpy-style broadcasting

Replaced the equal-shape + scalar-only `broadcast_binary` and `broadcast_binary_i64` with proper numpy broadcasting: right-aligned dimension matching, size-1 dimension expansion, and stride-mapped index computation. Shared `broadcast_shape` and `broadcast_index` helpers serve both f32 and i64 paths.

### 3. Shape utilities extraction

Extracted 6 shape functions from onnx_proto.rs into `onnx_shapes.rs` (226 LOC):
- `shape_from_value_info`, `elem_type_from_value_info`, `vi_shape`
- `set_vi_shape`, `strip_symbolic_value_info`, `resolve_dynamic_input_shapes`

Re-exported through `onnx_proto` for backwards compatibility. onnx_proto.rs reduced from 1,066 to 846 LOC.

### Final module sizes

| Module | Before | After |
|--------|--------|-------|
| onnx_proto.rs | 1,854 (original) | 846 |
| onnx_fold.rs | - | 869 |
| onnx_shapes.rs | - | 226 |
| trace.rs | - | 175 |

## Test plan

- [x] `cargo clippy -p dsperse -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] All 233 tests pass
- [ ] End-to-end pipeline validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced handling for dynamic ONNX tensor shapes, including explicit-shape application, automatic batch defaults, and logging for shape adjustments.

* **Bug Fixes**
  * Full NumPy-style broadcasting for multi-dimensional operations.
  * Execution pipeline now reliably populates the tensor cache and returns consolidated outputs.
  * Stricter output validation with clearer errors for duplicate, missing, or reshape-failure outputs.

* **Refactor**
  * Shape and value-info helpers reorganized into a dedicated shapes module.

* **Tests**
  * Declared-but-missing outputs now produce errors; tests expanded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->