### PR TITLE
Introduce per-slice failure tracking in CombinedRun

### DIFF
--- a/crates/dsperse/src/pipeline/combined.rs
+++ b/crates/dsperse/src/pipeline/combined.rs
@@ -160,7 +160,9 @@ impl CombinedRun {
 
     pub fn mark_slice_failed(&mut self, slice_id: &str) -> bool {
         let was_pending = self.pending_slices.remove(slice_id);
-        self.failed_slices.insert(slice_id.to_string());
+        if was_pending {
+            self.failed_slices.insert(slice_id.to_string());
+        }
         was_pending
     }
 

--- a/crates/dsperse/src/pipeline/combined.rs
+++ b/crates/dsperse/src/pipeline/combined.rs
@@ -19,6 +19,7 @@ pub struct CombinedRun {
     execution_chain: ExecutionChain,
     slices_dir: PathBuf,
     pending_slices: HashSet<String>,
+    failed_slices: HashSet<String>,
 }
 
 impl CombinedRun {
@@ -83,6 +84,7 @@ impl CombinedRun {
             execution_chain: chain,
             slices_dir: slices_dir.to_path_buf(),
             pending_slices,
+            failed_slices: HashSet::new(),
         })
     }
 
@@ -154,6 +156,16 @@ impl CombinedRun {
 
     pub fn mark_slice_done(&mut self, slice_id: &str) -> bool {
         self.pending_slices.remove(slice_id)
+    }
+
+    pub fn mark_slice_failed(&mut self, slice_id: &str) -> bool {
+        let was_pending = self.pending_slices.remove(slice_id);
+        self.failed_slices.insert(slice_id.to_string());
+        was_pending
+    }
+
+    pub fn failed_count(&self) -> usize {
+        self.failed_slices.len()
     }
 
     pub fn is_complete(&self) -> bool {


### PR DESCRIPTION
## Summary

- Adds `failed_slices: HashSet<String>` to `CombinedRun` for tracking slices that permanently fail
- `mark_slice_failed()` removes the slice from `pending_slices` and records it as failed
- `is_complete()` unchanged — returns true when `pending_slices` is empty, which now happens when all slices are either done or failed
- `failed_count()` exposes the number of failed slices for logging/reporting

This enables callers to continue a run past individual slice failures instead of tearing down the entire run.

## Test plan

- [x] `cargo test` — all 12 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [ ] Verify on validator that runs with failed slices finalize correctly instead of being torn down

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved pipeline failure tracking to explicitly record individual failed work units.
  * Added the ability to mark a unit as failed and to retrieve the current count of failures.
  * Completion semantics unchanged: overall completion still depends on remaining pending work, not on recorded failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->