### PR TITLE
Introduce per-bundle curve dispatch in JstproveBackend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "arith"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "ark-std",
  "criterion",
@@ -354,7 +354,7 @@ dependencies = [
 [[package]]
 name = "babybear"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "arith",
  "ark-std",
@@ -398,7 +398,7 @@ dependencies = [
 [[package]]
 name = "bin"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "arith",
  "babybear",
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "circuit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "arith",
  "ark-std",
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "circuit-std-rs"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "arith",
  "ark-bls12-381",
@@ -689,7 +689,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "config_macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "gkr_engine",
  "gkr_hashers",
@@ -857,7 +857,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 [[package]]
 name = "crosslayer_prototype"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "arith",
  "env_logger",
@@ -1093,7 +1093,7 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 [[package]]
 name = "expander_compiler"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "arith",
  "ark-std",
@@ -1324,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "gf2"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "arith",
  "ark-std",
@@ -1341,7 +1341,7 @@ dependencies = [
 [[package]]
 name = "gf2_128"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "arith",
  "ark-std",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "gkr"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "arith",
  "ark-std",
@@ -1386,7 +1386,7 @@ dependencies = [
 [[package]]
 name = "gkr_engine"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "arith",
  "babybear",
@@ -1404,7 +1404,7 @@ dependencies = [
 [[package]]
 name = "gkr_hashers"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "arith",
  "halo2curves",
@@ -1416,7 +1416,7 @@ dependencies = [
 [[package]]
 name = "goldilocks"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "arith",
  "ark-std",
@@ -2014,7 +2014,7 @@ dependencies = [
 [[package]]
 name = "jstprove-io"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "anyhow",
  "crc32c",
@@ -2026,7 +2026,7 @@ dependencies = [
 [[package]]
 name = "jstprove-onnx"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "anyhow",
  "prost 0.13.5",
@@ -2037,7 +2037,7 @@ dependencies = [
 [[package]]
 name = "jstprove_circuits"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "anyhow",
  "arith",
@@ -2213,7 +2213,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2287,7 +2287,7 @@ dependencies = [
 [[package]]
 name = "mersenne31"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "arith",
  "ark-std",
@@ -2781,7 +2781,7 @@ dependencies = [
 [[package]]
 name = "poly_commit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "arith",
  "ark-std",
@@ -2807,7 +2807,7 @@ dependencies = [
 [[package]]
 name = "polynomials"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "arith",
  "ark-std",
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "serdes"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "ethnum",
  "halo2curves",
@@ -3662,7 +3662,7 @@ dependencies = [
 [[package]]
 name = "serdes_derive"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3834,7 +3834,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "arith",
  "circuit",
@@ -4445,7 +4445,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "arith",
  "gkr_engine",
@@ -4468,7 +4468,7 @@ dependencies = [
 [[package]]
 name = "tree"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 dependencies = [
  "arith",
  "ark-std",
@@ -4628,7 +4628,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=a04ea446#a04ea44695237640915be1b383febcb88d795fbc"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -97,7 +97,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "arith"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "ark-std",
  "criterion",
@@ -354,7 +354,7 @@ dependencies = [
 [[package]]
 name = "babybear"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "ark-std",
@@ -398,7 +398,7 @@ dependencies = [
 [[package]]
 name = "bin"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "babybear",
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "circuit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "ark-std",
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "circuit-std-rs"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "ark-bls12-381",
@@ -689,7 +689,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "config_macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "gkr_engine",
  "gkr_hashers",
@@ -857,7 +857,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 [[package]]
 name = "crosslayer_prototype"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "env_logger",
@@ -1081,7 +1081,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1093,7 +1093,7 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 [[package]]
 name = "expander_compiler"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "ark-std",
@@ -1324,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "gf2"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "ark-std",
@@ -1341,7 +1341,7 @@ dependencies = [
 [[package]]
 name = "gf2_128"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "ark-std",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "gkr"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "ark-std",
@@ -1386,7 +1386,7 @@ dependencies = [
 [[package]]
 name = "gkr_engine"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "babybear",
@@ -1404,7 +1404,7 @@ dependencies = [
 [[package]]
 name = "gkr_hashers"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "halo2curves",
@@ -1416,7 +1416,7 @@ dependencies = [
 [[package]]
 name = "goldilocks"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "ark-std",
@@ -1923,7 +1923,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2014,7 +2014,7 @@ dependencies = [
 [[package]]
 name = "jstprove-io"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "anyhow",
  "crc32c",
@@ -2026,7 +2026,7 @@ dependencies = [
 [[package]]
 name = "jstprove-onnx"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "anyhow",
  "prost 0.13.5",
@@ -2037,7 +2037,7 @@ dependencies = [
 [[package]]
 name = "jstprove_circuits"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "anyhow",
  "arith",
@@ -2213,7 +2213,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2287,7 +2287,7 @@ dependencies = [
 [[package]]
 name = "mersenne31"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "ark-std",
@@ -2465,7 +2465,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2781,7 +2781,7 @@ dependencies = [
 [[package]]
 name = "poly_commit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "ark-std",
@@ -2807,7 +2807,7 @@ dependencies = [
 [[package]]
 name = "polynomials"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "ark-std",
@@ -3434,7 +3434,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "serdes"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "ethnum",
  "halo2curves",
@@ -3662,7 +3662,7 @@ dependencies = [
 [[package]]
 name = "serdes_derive"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3764,7 +3764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3834,7 +3834,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "circuit",
@@ -3951,7 +3951,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4445,7 +4445,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "gkr_engine",
@@ -4468,7 +4468,7 @@ dependencies = [
 [[package]]
 name = "tree"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 dependencies = [
  "arith",
  "ark-std",
@@ -4628,7 +4628,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e39e9373#e39e93737b27dc052013cff2b784da8142fd58cf"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
 
 [[package]]
 name = "uuid"
@@ -4864,7 +4864,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -97,7 +97,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "arith"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "ark-std",
  "criterion",
@@ -354,7 +354,7 @@ dependencies = [
 [[package]]
 name = "babybear"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "ark-std",
@@ -398,7 +398,7 @@ dependencies = [
 [[package]]
 name = "bin"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "babybear",
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "circuit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "ark-std",
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "circuit-std-rs"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "ark-bls12-381",
@@ -689,7 +689,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "config_macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "gkr_engine",
  "gkr_hashers",
@@ -857,7 +857,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 [[package]]
 name = "crosslayer_prototype"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "env_logger",
@@ -1081,7 +1081,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1093,7 +1093,7 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 [[package]]
 name = "expander_compiler"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "ark-std",
@@ -1324,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "gf2"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "ark-std",
@@ -1341,7 +1341,7 @@ dependencies = [
 [[package]]
 name = "gf2_128"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "ark-std",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "gkr"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "ark-std",
@@ -1386,7 +1386,7 @@ dependencies = [
 [[package]]
 name = "gkr_engine"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "babybear",
@@ -1404,7 +1404,7 @@ dependencies = [
 [[package]]
 name = "gkr_hashers"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "halo2curves",
@@ -1416,7 +1416,7 @@ dependencies = [
 [[package]]
 name = "goldilocks"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "ark-std",
@@ -1923,7 +1923,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2014,7 +2014,7 @@ dependencies = [
 [[package]]
 name = "jstprove-io"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "anyhow",
  "crc32c",
@@ -2026,7 +2026,7 @@ dependencies = [
 [[package]]
 name = "jstprove-onnx"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "anyhow",
  "prost 0.13.5",
@@ -2037,7 +2037,7 @@ dependencies = [
 [[package]]
 name = "jstprove_circuits"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "anyhow",
  "arith",
@@ -2213,7 +2213,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2287,7 +2287,7 @@ dependencies = [
 [[package]]
 name = "mersenne31"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "ark-std",
@@ -2465,7 +2465,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2781,7 +2781,7 @@ dependencies = [
 [[package]]
 name = "poly_commit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "ark-std",
@@ -2807,7 +2807,7 @@ dependencies = [
 [[package]]
 name = "polynomials"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "ark-std",
@@ -3434,7 +3434,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "serdes"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "ethnum",
  "halo2curves",
@@ -3662,7 +3662,7 @@ dependencies = [
 [[package]]
 name = "serdes_derive"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3764,7 +3764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3834,7 +3834,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "circuit",
@@ -3951,7 +3951,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4445,7 +4445,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "gkr_engine",
@@ -4468,7 +4468,7 @@ dependencies = [
 [[package]]
 name = "tree"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 dependencies = [
  "arith",
  "ark-std",
@@ -4628,7 +4628,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=d5e33590#d5e335901e7247ce1aab0b4c1b7bcc1164a07033"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=18b90f73#18b90f73e39df0c560fc0060e84cdc85a4e90634"
 
 [[package]]
 name = "uuid"
@@ -4864,7 +4864,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ sha2 = "0.10"
 tempfile = "3"
 prost = "0.13"
 pyo3 = { version = "0.24" }
-jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "a04ea446" }
+jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "e39e9373" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ sha2 = "0.10"
 tempfile = "3"
 prost = "0.13"
 pyo3 = { version = "0.24" }
-jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "e39e9373" }
+jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "d5e33590" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ sha2 = "0.10"
 tempfile = "3"
 prost = "0.13"
 pyo3 = { version = "0.24" }
-jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "d5e33590" }
+jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "18b90f73" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/crates/dsperse/src/backend/jstprove.rs
+++ b/crates/dsperse/src/backend/jstprove.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 pub use jstprove_circuits::api::CurveType as Curve;
+pub use jstprove_circuits::api::VerifiedOutputType as VerifiedOutput;
 use jstprove_circuits::api::{
     self, ArchitectureType as Architecture, CircuitParamsType as CircuitParams,
     CompiledCircuitType as CompiledCircuit, WANDBType as WANDB,
@@ -16,7 +17,6 @@ use super::traits::ProofBackend;
 #[derive(Debug)]
 pub struct JstproveBackend {
     compress: bool,
-    curve: Curve,
     bundle_cache: Mutex<HashMap<PathBuf, Arc<CompiledCircuit>>>,
 }
 
@@ -24,7 +24,6 @@ impl Default for JstproveBackend {
     fn default() -> Self {
         Self {
             compress: true,
-            curve: Curve::default(),
             bundle_cache: Mutex::new(HashMap::new()),
         }
     }
@@ -40,8 +39,11 @@ impl JstproveBackend {
         self
     }
 
-    pub fn with_curve(mut self, curve: Curve) -> Self {
-        self.curve = curve;
+    /// Deprecated: the curve is now resolved per-bundle from the manifest
+    /// at load time. This setter is a no-op retained for source
+    /// compatibility; it will be removed in a future release.
+    #[deprecated(note = "curve is now resolved per-bundle via CompiledCircuit::resolved_curve")]
+    pub fn with_curve(self, _curve: Curve) -> Self {
         self
     }
 
@@ -49,8 +51,12 @@ impl JstproveBackend {
         self.compress
     }
 
-    pub fn curve(&self) -> Curve {
-        self.curve
+    fn resolve_curve(bundle: &CompiledCircuit) -> Result<Curve> {
+        bundle.resolved_curve().ok_or_else(|| {
+            DsperseError::Backend(
+                "circuit bundle has no curve in metadata and field detection failed".into(),
+            )
+        })
     }
 
     pub fn load_bundle_cached(&self, path: &Path) -> Result<Arc<CompiledCircuit>> {
@@ -82,9 +88,34 @@ impl JstproveBackend {
         tracing::debug!(cleared = count, "bundle cache cleared");
     }
 
+    /// Evict cached bundles whose canonical path starts with the given
+    /// prefix. Used by callers that want to drop a model's entries
+    /// without clearing the entire cache.
+    pub fn evict_cache_by_prefix(&self, prefix: &Path) {
+        let mut cache = match self.bundle_cache.lock() {
+            Ok(cache) => cache,
+            Err(e) => {
+                tracing::warn!("bundle cache lock poisoned on evict: {e}");
+                e.into_inner()
+            }
+        };
+        let before = cache.len();
+        cache.retain(|k, _| !k.starts_with(prefix));
+        let evicted = before - cache.len();
+        if evicted > 0 {
+            tracing::info!(
+                prefix = %prefix.display(),
+                evicted,
+                remaining = cache.len(),
+                "evicted bundle cache entries"
+            );
+        }
+    }
+
     pub fn compile(
         &self,
         circuit_path: &Path,
+        curve: Curve,
         params: CircuitParams,
         architecture: Architecture,
         wandb: WANDB,
@@ -95,7 +126,7 @@ impl JstproveBackend {
 
         api::compile(
             circuit_path_str,
-            self.curve,
+            curve,
             params,
             architecture,
             wandb,
@@ -121,6 +152,7 @@ impl JstproveBackend {
         output_json: &[u8],
     ) -> Result<Vec<u8>> {
         let bundle = self.load_bundle_cached(circuit_path)?;
+        let curve = Self::resolve_curve(&bundle)?;
 
         let req = WitnessRequest {
             circuit: bundle.circuit.clone(),
@@ -130,7 +162,7 @@ impl JstproveBackend {
             metadata: bundle.metadata.clone(),
         };
 
-        let result = api::witness(self.curve, &req, self.compress)
+        let result = api::witness(curve, &req, self.compress)
             .map_err(|e| DsperseError::Backend(format!("witness: {e}")))?;
 
         Ok(result.witness)
@@ -143,6 +175,7 @@ impl JstproveBackend {
         initializers: &[(Vec<f64>, Vec<usize>)],
     ) -> Result<Vec<u8>> {
         let bundle = self.load_bundle_cached(circuit_path)?;
+        let curve = Self::resolve_curve(&bundle)?;
         let params = bundle.metadata.as_ref().ok_or_else(|| {
             DsperseError::Backend(
                 "circuit bundle missing metadata (required for quantization)".into(),
@@ -150,7 +183,7 @@ impl JstproveBackend {
         })?;
 
         let result = api::witness_f64(
-            self.curve,
+            curve,
             &bundle.circuit,
             &bundle.witness_solver,
             params,
@@ -170,8 +203,9 @@ impl JstproveBackend {
 
     pub fn prove(&self, circuit_path: &Path, witness_bytes: &[u8]) -> Result<Vec<u8>> {
         let bundle = self.load_bundle_cached(circuit_path)?;
+        let curve = Self::resolve_curve(&bundle)?;
 
-        api::prove(self.curve, &bundle.circuit, witness_bytes, self.compress)
+        api::prove(curve, &bundle.circuit, witness_bytes, self.compress)
             .map_err(|e| DsperseError::Backend(format!("prove: {e}")))
     }
 
@@ -197,9 +231,32 @@ impl JstproveBackend {
         proof_bytes: &[u8],
     ) -> Result<bool> {
         let bundle = self.load_bundle_cached(circuit_path)?;
+        let curve = Self::resolve_curve(&bundle)?;
 
-        api::verify(self.curve, &bundle.circuit, witness_bytes, proof_bytes)
+        api::verify(curve, &bundle.circuit, witness_bytes, proof_bytes)
             .map_err(|e| DsperseError::Backend(format!("verify: {e}")))
+    }
+
+    pub fn verify_and_extract(
+        &self,
+        circuit_path: &Path,
+        witness_bytes: &[u8],
+        proof_bytes: &[u8],
+        num_inputs: usize,
+        expected_inputs: Option<&[f64]>,
+    ) -> Result<VerifiedOutput> {
+        let bundle = self.load_bundle_cached(circuit_path)?;
+        let curve = Self::resolve_curve(&bundle)?;
+
+        api::verify_and_extract(
+            curve,
+            &bundle.circuit,
+            witness_bytes,
+            proof_bytes,
+            num_inputs,
+            expected_inputs,
+        )
+        .map_err(|e| DsperseError::Backend(format!("verify_and_extract: {e}")))
     }
 }
 
@@ -251,6 +308,7 @@ impl WarmCircuit {
         backend: &JstproveBackend,
     ) -> Result<Self> {
         let bundle = backend.load_bundle_cached(circuit_path)?;
+        let curve = JstproveBackend::resolve_curve(&bundle)?;
         let params = bundle
             .metadata
             .clone()
@@ -260,7 +318,7 @@ impl WarmCircuit {
             params,
             initializers,
             compress: backend.compress(),
-            curve: backend.curve(),
+            curve,
         })
     }
 
@@ -292,15 +350,9 @@ mod tests {
     }
 
     #[test]
-    fn default_curve_is_bn254() {
+    fn backend_constructs_without_curve_state() {
         let backend = JstproveBackend::default();
-        assert_eq!(backend.curve(), Curve::Bn254);
-    }
-
-    #[test]
-    fn with_curve_sets_curve() {
-        let backend = JstproveBackend::new().with_curve(Curve::Goldilocks);
-        assert_eq!(backend.curve(), Curve::Goldilocks);
+        assert!(backend.compress());
     }
 
     #[test]
@@ -318,6 +370,7 @@ mod tests {
             circuit: vec![1, 2, 3],
             witness_solver: vec![],
             metadata: None,
+            curve: None,
             version: None,
         });
         backend

--- a/crates/dsperse/src/cli/mod.rs
+++ b/crates/dsperse/src/cli/mod.rs
@@ -9,11 +9,16 @@ use crate::pipeline::{self, RunConfig};
 
 use jstprove_circuits::api::{CurveParseError, ProofSystemType as ProofSystem};
 
-fn build_backend(curve: &str) -> Result<JstproveBackend> {
-    let c: Curve = curve
+fn parse_curve(curve: &str) -> Result<Curve> {
+    curve
         .parse()
-        .map_err(|e: CurveParseError| DsperseError::Other(e.to_string()))?;
-    Ok(JstproveBackend::new().with_curve(c))
+        .map_err(|e: CurveParseError| DsperseError::Other(e.to_string()))
+}
+
+fn build_backend(_curve: &str) -> Result<JstproveBackend> {
+    // Curve is resolved per-bundle at load time; the backend no longer
+    // carries a curve. The parameter is retained for CLI validation.
+    Ok(JstproveBackend::new())
 }
 
 pub const VERSION: &str = env!("DSPERSE_DISPLAY_VERSION");
@@ -382,6 +387,7 @@ pub fn cmd_combine(args: CombineArgs) -> Result<()> {
 }
 
 pub fn cmd_compile(args: CompileArgs) -> Result<()> {
+    let curve = parse_curve(&args.curve)?;
     let backend = build_backend(&args.curve)?;
     let slices_dir = resolve_slices_dir(args.slices_dir, &args.model_dir);
 
@@ -396,6 +402,7 @@ pub fn cmd_compile(args: CompileArgs) -> Result<()> {
     pipeline::compile_slices(
         &slices_dir,
         &backend,
+        curve,
         args.parallel.get(),
         args.weights_as_inputs,
         layers.as_deref(),
@@ -508,6 +515,7 @@ pub fn cmd_publish(args: PublishArgs) -> Result<()> {
 }
 
 pub fn cmd_full_run(args: FullRunArgs) -> Result<()> {
+    let curve = parse_curve(&args.curve)?;
     let backend = build_backend(&args.curve)?;
 
     let slices_dir = resolve_slices_dir(args.slices_dir, &args.model_dir);
@@ -541,6 +549,7 @@ pub fn cmd_full_run(args: FullRunArgs) -> Result<()> {
     pipeline::compile_slices(
         &slices_dir,
         &backend,
+        curve,
         args.parallel.get(),
         args.weights_as_inputs,
         layers.as_deref(),

--- a/crates/dsperse/src/cli/mod.rs
+++ b/crates/dsperse/src/cli/mod.rs
@@ -15,14 +15,6 @@ fn parse_curve(curve: &str) -> Result<Curve> {
         .map_err(|e: CurveParseError| DsperseError::Other(e.to_string()))
 }
 
-fn build_backend(curve: &str) -> Result<JstproveBackend> {
-    // Curve is resolved per-bundle at load time; the backend no longer
-    // carries a curve. We still validate the argument here to surface
-    // typos as errors at CLI entry rather than silently accepting them.
-    let _: Curve = parse_curve(curve)?;
-    Ok(JstproveBackend::new())
-}
-
 pub const VERSION: &str = env!("DSPERSE_DISPLAY_VERSION");
 
 #[derive(Parser)]
@@ -164,12 +156,6 @@ pub struct RunArgs {
         help = "Run inference on combined monolithic ONNX instead of per-slice execution"
     )]
     pub combined: bool,
-    #[arg(
-        long,
-        default_value = "bn254",
-        help = "Finite field (bn254, goldilocks, goldilocks_basefold)"
-    )]
-    pub curve: String,
 }
 
 #[derive(Args)]
@@ -182,12 +168,6 @@ pub struct ProveArgs {
     pub slices_dir: Option<PathBuf>,
     #[arg(long, default_value = "1")]
     pub parallel: NonZeroUsize,
-    #[arg(
-        long,
-        default_value = "bn254",
-        help = "Finite field (bn254, goldilocks, goldilocks_basefold)"
-    )]
-    pub curve: String,
 }
 
 #[derive(Args)]
@@ -200,12 +180,6 @@ pub struct VerifyArgs {
     pub slices_dir: Option<PathBuf>,
     #[arg(long, default_value = "1")]
     pub parallel: NonZeroUsize,
-    #[arg(
-        long,
-        default_value = "bn254",
-        help = "Finite field (bn254, goldilocks, goldilocks_basefold)"
-    )]
-    pub curve: String,
 }
 
 #[derive(Args)]
@@ -390,7 +364,7 @@ pub fn cmd_combine(args: CombineArgs) -> Result<()> {
 
 pub fn cmd_compile(args: CompileArgs) -> Result<()> {
     let curve = parse_curve(&args.curve)?;
-    let backend = build_backend(&args.curve)?;
+    let backend = JstproveBackend::new();
     let slices_dir = resolve_slices_dir(args.slices_dir, &args.model_dir);
 
     let layers = args
@@ -421,7 +395,7 @@ pub fn cmd_run(args: RunArgs) -> Result<()> {
         )));
     }
 
-    let backend = build_backend(&args.curve)?;
+    let backend = JstproveBackend::new();
     let slices_dir = resolve_slices_dir(args.slices_dir, &args.model_dir);
 
     let run_dir = args
@@ -440,7 +414,7 @@ pub fn cmd_run(args: RunArgs) -> Result<()> {
 }
 
 pub fn cmd_prove(args: ProveArgs) -> Result<()> {
-    let backend = build_backend(&args.curve)?;
+    let backend = JstproveBackend::new();
     let slices_dir = resolve_slices_dir(args.slices_dir, &args.model_dir);
 
     pipeline::prove_run(&args.run_dir, &slices_dir, &backend, args.parallel.get())?;
@@ -448,7 +422,7 @@ pub fn cmd_prove(args: ProveArgs) -> Result<()> {
 }
 
 pub fn cmd_verify(args: VerifyArgs) -> Result<()> {
-    let backend = build_backend(&args.curve)?;
+    let backend = JstproveBackend::new();
     let slices_dir = resolve_slices_dir(args.slices_dir, &args.model_dir);
 
     pipeline::verify_run(&args.run_dir, &slices_dir, &backend, args.parallel.get())?;
@@ -518,7 +492,7 @@ pub fn cmd_publish(args: PublishArgs) -> Result<()> {
 
 pub fn cmd_full_run(args: FullRunArgs) -> Result<()> {
     let curve = parse_curve(&args.curve)?;
-    let backend = build_backend(&args.curve)?;
+    let backend = JstproveBackend::new();
 
     let slices_dir = resolve_slices_dir(args.slices_dir, &args.model_dir);
 

--- a/crates/dsperse/src/cli/mod.rs
+++ b/crates/dsperse/src/cli/mod.rs
@@ -15,9 +15,11 @@ fn parse_curve(curve: &str) -> Result<Curve> {
         .map_err(|e: CurveParseError| DsperseError::Other(e.to_string()))
 }
 
-fn build_backend(_curve: &str) -> Result<JstproveBackend> {
+fn build_backend(curve: &str) -> Result<JstproveBackend> {
     // Curve is resolved per-bundle at load time; the backend no longer
-    // carries a curve. The parameter is retained for CLI validation.
+    // carries a curve. We still validate the argument here to surface
+    // typos as errors at CLI entry rather than silently accepting them.
+    let _: Curve = parse_curve(curve)?;
     Ok(JstproveBackend::new())
 }
 

--- a/crates/dsperse/src/cli/mod.rs
+++ b/crates/dsperse/src/cli/mod.rs
@@ -10,9 +10,9 @@ use crate::pipeline::{self, RunConfig};
 use jstprove_circuits::api::{CurveParseError, ProofSystemType as ProofSystem};
 
 fn parse_curve(curve: &str) -> Result<Curve> {
-    curve
-        .parse()
-        .map_err(|e: CurveParseError| DsperseError::Other(e.to_string()))
+    curve.parse().map_err(|e: CurveParseError| {
+        DsperseError::Other(format!("invalid --curve '{curve}': {e}"))
+    })
 }
 
 pub const VERSION: &str = env!("DSPERSE_DISPLAY_VERSION");

--- a/crates/dsperse/src/pipeline/combined.rs
+++ b/crates/dsperse/src/pipeline/combined.rs
@@ -166,6 +166,10 @@ impl CombinedRun {
         was_pending
     }
 
+    pub fn is_slice_failed(&self, slice_id: &str) -> bool {
+        self.failed_slices.contains(slice_id)
+    }
+
     pub fn failed_count(&self) -> usize {
         self.failed_slices.len()
     }

--- a/crates/dsperse/src/pipeline/compiler.rs
+++ b/crates/dsperse/src/pipeline/compiler.rs
@@ -26,9 +26,11 @@ enum CompileOutcome {
     },
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn compile_slices(
     slices_dir: &Path,
     backend: &JstproveBackend,
+    curve: jstprove_circuits::api::CurveType,
     parallel: usize,
     weights_as_inputs: bool,
     layers: Option<&[usize]>,
@@ -103,6 +105,7 @@ pub fn compile_slices(
                 slices_dir,
                 slice,
                 backend,
+                curve,
                 weights_as_inputs,
                 jstprove_ops,
                 &exclude_from_wai,
@@ -377,6 +380,7 @@ fn compile_single_slice(
     slices_dir: &Path,
     slice: &crate::schema::metadata::SliceMetadata,
     backend: &JstproveBackend,
+    curve: jstprove_circuits::api::CurveType,
     weights_as_inputs: bool,
     jstprove_ops: &[&str],
     exclude_from_wai: &std::collections::HashSet<String>,
@@ -400,6 +404,7 @@ fn compile_single_slice(
             slice,
             cs,
             backend,
+            curve,
             jstprove_ops,
             exclude_from_wai,
             skip_compile_over_size,
@@ -417,6 +422,7 @@ fn compile_single_slice(
                 slice,
                 &tmpl_path,
                 backend,
+                curve,
                 jstprove_ops,
                 exclude_from_wai,
                 skip_compile_over_size,
@@ -484,7 +490,7 @@ fn compile_single_slice(
         traced_shapes,
     )?;
 
-    std::panic::catch_unwind(|| backend.compile(&circuit_path, params, architecture, wandb))
+    std::panic::catch_unwind(|| backend.compile(&circuit_path, curve, params, architecture, wandb))
         .map_err(|p| {
             let msg = p
                 .downcast_ref::<&str>()
@@ -562,6 +568,7 @@ fn compile_channel_split_slice(
     slice: &crate::schema::metadata::SliceMetadata,
     cs: &crate::schema::tiling::ChannelSplitInfo,
     backend: &JstproveBackend,
+    curve: jstprove_circuits::api::CurveType,
     jstprove_ops: &[&str],
     exclude_from_wai: &std::collections::HashSet<String>,
     skip_compile_over_size: Option<u64>,
@@ -623,7 +630,7 @@ fn compile_channel_split_slice(
         )?;
 
         std::panic::catch_unwind(|| {
-            backend.compile(&shared_circuit_path, params, architecture, wandb)
+            backend.compile(&shared_circuit_path, curve, params, architecture, wandb)
         })
         .map_err(|p| {
             let msg = p
@@ -666,6 +673,7 @@ fn compile_dim_split_template(
     slice: &crate::schema::metadata::SliceMetadata,
     tmpl_path: &Path,
     backend: &JstproveBackend,
+    curve: jstprove_circuits::api::CurveType,
     jstprove_ops: &[&str],
     exclude_from_wai: &std::collections::HashSet<String>,
     skip_compile_over_size: Option<u64>,
@@ -752,7 +760,7 @@ fn compile_dim_split_template(
         traced_shapes,
     )?;
 
-    std::panic::catch_unwind(|| backend.compile(&circuit_path, params, architecture, wandb))
+    std::panic::catch_unwind(|| backend.compile(&circuit_path, curve, params, architecture, wandb))
         .map_err(|p| {
             let msg = p
                 .downcast_ref::<&str>()

--- a/crates/dsperse/src/python.rs
+++ b/crates/dsperse/src/python.rs
@@ -95,10 +95,11 @@ fn slice_model(
 
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
-#[pyo3(signature = (slices_dir, parallel=1, weights_as_inputs=true, layers=None, proof_system="expander", circuit_ops=None, skip_compile_over_size=None))]
+#[pyo3(signature = (slices_dir, curve="bn254", parallel=1, weights_as_inputs=true, layers=None, proof_system="expander", circuit_ops=None, skip_compile_over_size=None))]
 fn compile_slices(
     py: Python<'_>,
     slices_dir: &str,
+    curve: &str,
     parallel: usize,
     weights_as_inputs: bool,
     layers: Option<Vec<usize>>,
@@ -108,6 +109,12 @@ fn compile_slices(
 ) -> PyResult<()> {
     require_nonzero(parallel)?;
     let backend = JstproveBackend::default();
+    let parsed_curve: jstprove_circuits::api::CurveType =
+        curve
+            .parse()
+            .map_err(|e: jstprove_circuits::api::CurveParseError| {
+                pyo3::exceptions::PyValueError::new_err(e.to_string())
+            })?;
     let dir = PathBuf::from(slices_dir);
     let ops = resolve_ops(proof_system, circuit_ops.as_deref())?;
     let ops_refs: Vec<&str> = ops.iter().map(String::as_str).collect();
@@ -115,6 +122,7 @@ fn compile_slices(
         pipeline::compile_slices(
             &dir,
             &backend,
+            parsed_curve,
             parallel,
             weights_as_inputs,
             layers.as_deref(),


### PR DESCRIPTION
## Summary

- Bump jstprove to a revision that stamps `params.curve` at compile time and exposes a top-level `curve` field on `CompiledCircuit` along with a `detect_base_field` primitive for bundles that predate manifest stamping.
- Make `JstproveBackend` curve-agnostic: the curve is now resolved per bundle via `CompiledCircuit::resolved_curve` at load time rather than carried as backend-global state. Callers no longer need to know the curve before loading; `prove`/`verify`/`witness`/`witness_f64` all look up the curve from the cached bundle.
- `compile()` now takes an explicit `curve` argument since compilation happens before any bundle exists. `compile_slices` and inner compile helpers thread the curve through to the backend.
- Deprecate `with_curve()` as a no-op setter retained for source compatibility.
- Restore `CombinedRun::is_slice_failed` for callers that need to guard against late replies for already-failed slices.

Depends on inference-labs-inc/JSTprove#259.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — all pass
- [ ] Downstream integration in subnet-2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated jstprove_circuits dependency to a new pinned revision.

* **New Features**
  * Added ability to check whether a specific slice failed during a run.
  * Added verification-and-extraction API and a cache-eviction operation by path prefix.

* **Refactor**
  * Compilation now requires an explicit curve parameter instead of backend state.
  * CLI and Python compile_slices accept/parse a curve parameter (Python default "bn254"); run/prove/verify no longer take curve args.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->