### PR TITLE
Introduce sequence-tiled MatMul execution with K-dimension chunking

### DIFF
--- a/crates/dsperse/src/cli/mod.rs
+++ b/crates/dsperse/src/cli/mod.rs
@@ -201,7 +201,7 @@ pub struct PackageArgs {
     pub timeout: Option<u64>,
     #[arg(
         long,
-        help = "Finite field curve used as domain separator in content hashes (bn254, goldilocks, goldilocks_basefold)"
+        help = "Finite field curve used as domain separator in content hashes (bn254, goldilocks, goldilocks_basefold, goldilocks_ext2, goldilocks_whir, goldilocks_whir_pq)"
     )]
     pub curve: Option<String>,
 }

--- a/crates/dsperse/src/pipeline/dim_split.rs
+++ b/crates/dsperse/src/pipeline/dim_split.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use super::runner::{run_onnx_inference, run_onnx_inference_multi_named};
+use super::runner::run_onnx_inference;
 use super::tensor_store::TensorStore;
 use crate::backend::jstprove::JstproveBackend;
 use crate::error::{DsperseError, Result};
@@ -19,11 +19,6 @@ pub(crate) fn execute_dim_split(
     _backend: &JstproveBackend,
     donor_init_map: Option<&HashMap<String, &TensorProto>>,
 ) -> Result<crate::schema::execution::StrategyOutput> {
-    use ndarray::Axis;
-
-    let concat_axis = ds.concat_axis;
-    let epg = ds.elements_per_group;
-
     let tmpl_rel = ds.template_path.as_ref().ok_or_else(|| {
         DsperseError::Pipeline(format!("{slice_id}: dim_split has no template_path"))
     })?;
@@ -35,287 +30,146 @@ pub(crate) fn execute_dim_split(
         )));
     }
 
-    let use_matmul_split = matches!(
-        ds.split_kind,
-        crate::schema::tiling::DimSplitKind::MatMulOutputDim
-    );
+    let input_tensor = tensor_cache.get(&ds.input_name)?.clone();
+    let input_shape = input_tensor.shape().to_vec();
+    let k_dim = *input_shape.last().unwrap_or(&0);
+    let k_chunks = ds.k_chunks.max(1);
+    let k_chunk_size = k_dim.div_ceil(k_chunks);
+
+    let total_rows: usize = input_shape
+        .iter()
+        .take(input_shape.len().saturating_sub(1))
+        .product();
+    let flat_input = input_tensor
+        .as_standard_layout()
+        .into_owned()
+        .into_shape_with_order(ndarray::IxDyn(&[total_rows, k_dim]))
+        .map_err(|e| DsperseError::Pipeline(format!("{slice_id}: flatten input: {e}")))?;
 
     let slice_onnx_path = slices_dir
         .join(format!("slice_{}", ds.slice_idx))
         .join("payload")
         .join(format!("slice_{}.onnx", ds.slice_idx));
 
-    let fallback_model = if use_matmul_split && donor_init_map.is_none() {
-        Some(crate::slicer::onnx_proto::load_model(&slice_onnx_path)?)
-    } else {
-        None
-    };
-
-    let original_weights = if use_matmul_split {
-        let wn = ds.weight_name.as_ref().ok_or_else(|| {
-            DsperseError::Pipeline(format!(
-                "{slice_id}: MatMulOutputDim split requires weight_name in metadata"
-            ))
-        })?;
-        let tensor = if let Some(map) = donor_init_map
-            && let Some(t) = map.get(wn.as_str())
-        {
-            (*t).clone()
-        } else {
-            let graph = fallback_model
-                .as_ref()
-                .and_then(|m| m.graph.as_ref())
-                .ok_or_else(|| {
-                    DsperseError::Pipeline(format!("{slice_id}: slice ONNX has no graph"))
-                })?;
-            graph
+    let orig_model = crate::slicer::onnx_proto::load_model(&slice_onnx_path)?;
+    let orig_graph = orig_model
+        .graph
+        .as_ref()
+        .ok_or_else(|| DsperseError::Pipeline(format!("{slice_id}: slice ONNX has no graph")))?;
+    let matmul_node = orig_graph
+        .node
+        .iter()
+        .find(|n| matches!(n.op_type.as_str(), "MatMul" | "Gemm"));
+    let trans_b = matmul_node.is_some_and(|n| {
+        n.op_type == "Gemm"
+            && crate::slicer::onnx_proto::get_attribute_int(n, "transB").unwrap_or(0) == 1
+    });
+    let full_weight: Vec<f32> = ds
+        .weight_name
+        .as_ref()
+        .and_then(|wn| {
+            if let Some(map) = donor_init_map
+                && let Some(t) = map.get(wn.as_str())
+            {
+                return Some(crate::slicer::onnx_proto::tensor_to_f32(t));
+            }
+            orig_graph
                 .initializer
                 .iter()
                 .find(|i| i.name == *wn)
-                .ok_or_else(|| {
-                    DsperseError::Pipeline(format!(
-                        "{slice_id}: weight {wn:?} not found in slice ONNX"
-                    ))
-                })?
-                .clone()
-        };
-        Some(crate::slicer::onnx_proto::tensor_to_f32(&tensor))
-    } else {
-        None
-    };
+                .map(crate::slicer::onnx_proto::tensor_to_f32)
+        })
+        .unwrap_or_default();
 
-    let mut tmpl_model = crate::slicer::onnx_proto::load_model(&tmpl_path)?;
+    let n_dim = ds.n_dim;
+    let tmpl_model = crate::slicer::onnx_proto::load_model(&tmpl_path)?;
 
-    let mut group_outputs: Vec<ndarray::ArrayD<f64>> = Vec::new();
+    let tmp_dir = tempfile::tempdir()
+        .map_err(|e| DsperseError::Pipeline(format!("{slice_id}: tmpdir: {e}")))?;
 
-    for g in 0..ds.num_groups {
-        let dim_start = g * epg;
-        if dim_start >= ds.dim_size {
-            break;
-        }
-        let dim_end = ((g + 1) * epg).min(ds.dim_size);
-        let actual_size = dim_end - dim_start;
+    let mut row_outputs: Vec<ndarray::ArrayD<f64>> = Vec::with_capacity(total_rows);
 
-        let group_input = if use_matmul_split {
-            tensor_cache.get(&ds.input_name)?.clone()
-        } else {
-            let split_dim = ds.split_dim;
-            let full = tensor_cache.get(&ds.input_name)?;
-            if split_dim >= full.ndim() {
-                return Err(DsperseError::Pipeline(format!(
-                    "{slice_id}: split_dim {split_dim} out of range for tensor with {} dimensions",
-                    full.ndim()
-                )));
+    for r in 0..total_rows {
+        let full_row: Vec<f64> = flat_input
+            .slice(ndarray::s![r, ..])
+            .iter()
+            .copied()
+            .collect();
+
+        let mut row_accum = vec![0.0f64; n_dim];
+
+        for kc in 0..k_chunks {
+            let k_start = kc * k_chunk_size;
+            let k_end = (k_start + k_chunk_size).min(k_dim);
+            let actual_k = k_end.saturating_sub(k_start);
+
+            let mut input_chunk = vec![0.0f64; k_chunk_size];
+            if actual_k > 0 {
+                input_chunk[..actual_k].copy_from_slice(&full_row[k_start..k_end]);
             }
-            let sliced = full
-                .slice_axis(Axis(split_dim), ndarray::Slice::from(dim_start..dim_end))
-                .to_owned();
-            if actual_size < epg {
-                let mut padded_shape = sliced.shape().to_vec();
-                padded_shape[split_dim] = epg;
-                let mut padded = ndarray::ArrayD::zeros(padded_shape);
-                for (mut dst, src) in padded
-                    .axis_iter_mut(Axis(split_dim))
-                    .zip(sliced.axis_iter(Axis(split_dim)))
-                {
-                    dst.assign(&src);
+
+            let weight_chunk: Vec<f32> = if trans_b {
+                let mut w = Vec::with_capacity(n_dim * k_chunk_size);
+                for row_idx in 0..n_dim {
+                    let row_start = row_idx * k_dim + k_start;
+                    let avail = actual_k.min(full_weight.len().saturating_sub(row_start));
+                    w.extend_from_slice(&full_weight[row_start..row_start + avail]);
+                    if avail < k_chunk_size {
+                        w.resize(w.len() + k_chunk_size - avail, 0.0);
+                    }
                 }
-                padded
+                w
             } else {
-                sliced
-            }
-        };
-
-        if use_matmul_split
-            && let Some(ref weights) = original_weights
-            && let Some(graph) = tmpl_model.graph.as_mut()
-        {
-            let matmul_node = graph
-                .node
-                .iter()
-                .find(|n| matches!(n.op_type.as_str(), "MatMul" | "Gemm"));
-            let trans_b = matmul_node.is_some_and(|n| {
-                n.op_type == "Gemm"
-                    && crate::slicer::onnx_proto::get_attribute_int(n, "transB").unwrap_or(0) == 1
-            });
-
-            if let Some(w_init) = graph.initializer.iter_mut().find(|i| i.name == "W") {
-                if w_init.dims.len() < 2 {
-                    return Err(DsperseError::Pipeline(format!(
-                        "{slice_id}: weight initializer 'W' has {} dims, expected at least 2",
-                        w_init.dims.len()
-                    )));
-                }
-                let rows = usize::try_from(w_init.dims[0]).map_err(|_| {
-                    DsperseError::Pipeline(format!(
-                        "{slice_id}: weight dim[0]={} is negative",
-                        w_init.dims[0]
-                    ))
-                })?;
-                let cols = usize::try_from(w_init.dims[1]).map_err(|_| {
-                    DsperseError::Pipeline(format!(
-                        "{slice_id}: weight dim[1]={} is negative",
-                        w_init.dims[1]
-                    ))
-                })?;
-                let k = if trans_b { cols } else { rows };
-                let orig_cols = ds.dim_size;
-                let mut chunk = Vec::with_capacity(k * epg);
-                if trans_b {
-                    for r in dim_start..dim_end.min(ds.dim_size) {
-                        let start = r * k;
-                        let end = start + k;
-                        let slice = weights.get(start..end).ok_or_else(|| {
-                            DsperseError::Pipeline(format!(
-                                "{slice_id}: weight slice [{start}..{end}] out of bounds \
-                                 (weights len={})",
-                                weights.len()
-                            ))
-                        })?;
-                        chunk.extend_from_slice(slice);
-                    }
-                    chunk.resize(epg * k, 0.0);
-                } else {
-                    for r in 0..k {
-                        let start = r * orig_cols + dim_start;
-                        let end = start + actual_size;
-                        let row = weights.get(start..end).ok_or_else(|| {
-                            DsperseError::Pipeline(format!(
-                                "{slice_id}: weight slice [{start}..{end}] out of bounds \
-                                 (weights len={})",
-                                weights.len()
-                            ))
-                        })?;
-                        chunk.extend_from_slice(row);
-                        let row_target = (r + 1) * epg;
-                        chunk.resize(row_target, 0.0);
+                let mut w = Vec::with_capacity(k_chunk_size * n_dim);
+                for ki in k_start..k_start + actual_k {
+                    let start = ki * n_dim;
+                    let end = start + n_dim;
+                    if end <= full_weight.len() {
+                        w.extend_from_slice(&full_weight[start..end]);
+                    } else {
+                        w.resize(w.len() + n_dim, 0.0);
                     }
                 }
-                w_init.float_data = chunk;
+                if actual_k < k_chunk_size {
+                    w.resize(k_chunk_size * n_dim, 0.0);
+                }
+                w
+            };
+
+            let mut patched = tmpl_model.clone();
+            if let Some(graph) = patched.graph.as_mut()
+                && let Some(w_init) = graph.initializer.iter_mut().find(|i| i.name == "W")
+            {
+                w_init.float_data = weight_chunk;
                 w_init.raw_data.clear();
             }
 
-            if let Some(bias_init) = graph.initializer.iter_mut().find(|i| i.name == "C") {
-                let bias_name = matmul_node.and_then(|n| n.input.get(2).cloned());
-                let bias_data: Option<Vec<f32>> = bias_name.as_ref().and_then(|bn| {
-                    if let Some(map) = donor_init_map
-                        && let Some(t) = map.get(bn.as_str())
-                    {
-                        return Some(crate::slicer::onnx_proto::tensor_to_f32(t));
-                    }
-                    fallback_model
-                        .as_ref()
-                        .and_then(|m| m.graph.as_ref())
-                        .and_then(|g| {
-                            g.initializer
-                                .iter()
-                                .find(|i| i.name == *bn)
-                                .map(crate::slicer::onnx_proto::tensor_to_f32)
-                        })
-                });
-                if let Some(bd) = bias_data {
-                    if bd.len() == ds.dim_size {
-                        let mut sliced = bd[dim_start..dim_end].to_vec();
-                        sliced.resize(epg, 0.0);
-                        bias_init.float_data = sliced;
-                        bias_init.raw_data.clear();
-                    } else {
-                        tracing::warn!(
-                            slice = %slice_id,
-                            bias_len = bd.len(),
-                            dim_size = ds.dim_size,
-                            group = g,
-                            "bias length mismatch; skipping bias patching for this group"
-                        );
-                    }
-                }
+            let patched_path = tmp_dir.path().join(format!("chunk_{kc}.onnx"));
+            crate::slicer::onnx_proto::save_model(&patched, &patched_path)?;
+
+            let input_arr =
+                ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&[1, 1, k_chunk_size]), input_chunk)
+                    .map_err(|e| DsperseError::Pipeline(format!("{slice_id}: input chunk: {e}")))?;
+
+            let out = run_onnx_inference(&patched_path, &input_arr)?;
+            for (acc, v) in row_accum.iter_mut().zip(out.iter().copied()) {
+                *acc += v;
             }
         }
 
-        let tmp_dir = tempfile::tempdir()
-            .map_err(|e| DsperseError::Pipeline(format!("{slice_id}: tmpdir: {e}")))?;
-        let patched_path = tmp_dir.path().join("dim_chunk.onnx");
-        crate::slicer::onnx_proto::save_model(&tmpl_model, &patched_path)?;
-
-        let group_output = if use_matmul_split {
-            run_onnx_inference(&patched_path, &group_input)?
-        } else {
-            let tmpl_graph = tmpl_model.graph.as_ref().ok_or_else(|| {
-                DsperseError::Pipeline(format!("{slice_id}: template has no graph"))
-            })?;
-            let tmpl_init_names: std::collections::HashSet<&str> = tmpl_graph
-                .initializer
-                .iter()
-                .map(|i| i.name.as_str())
-                .collect();
-            let mut group_cache = TensorStore::new();
-            for vi in &tmpl_graph.input {
-                if tmpl_init_names.contains(vi.name.as_str()) {
-                    continue;
-                }
-                if vi.name == "dim_tmpl_in" {
-                    group_cache.put(vi.name.clone(), group_input.clone());
-                } else {
-                    let arr = tensor_cache.try_get(&vi.name).ok_or_else(|| {
-                        DsperseError::Pipeline(format!(
-                            "{slice_id}: template input {:?} not found in tensor cache",
-                            vi.name
-                        ))
-                    })?;
-                    let shape = arr.shape();
-                    if ds.split_dim < shape.len() && shape[ds.split_dim] == ds.dim_size {
-                        let sliced = arr
-                            .slice_axis(
-                                Axis(ds.split_dim),
-                                ndarray::Slice::from(dim_start..dim_end),
-                            )
-                            .to_owned();
-                        group_cache.put(vi.name.clone(), sliced);
-                    } else {
-                        group_cache.put(vi.name.clone(), arr.clone());
-                    }
-                }
-            }
-            let input_names: Vec<String> = tmpl_graph
-                .input
-                .iter()
-                .filter(|vi| !tmpl_init_names.contains(vi.name.as_str()))
-                .map(|vi| vi.name.clone())
-                .collect();
-            let named = run_onnx_inference_multi_named(&patched_path, &group_cache, &input_names)?;
-            if named.len() != 1 {
-                return Err(DsperseError::Pipeline(format!(
-                    "{slice_id}: dim-split group produced {} outputs, expected exactly 1",
-                    named.len()
-                )));
-            }
-            let (data, shape) = named.into_values().next().ok_or_else(|| {
-                DsperseError::Pipeline(format!("{slice_id}: dim-split group produced no output"))
-            })?;
-            ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&shape), data).map_err(|e| {
-                DsperseError::Pipeline(format!("{slice_id}: dim-split array reshape: {e}"))
-            })?
-        };
-
-        let trimmed = if actual_size < epg && concat_axis < group_output.ndim() {
-            group_output
-                .slice_axis(Axis(concat_axis), ndarray::Slice::from(0..actual_size))
-                .to_owned()
-        } else {
-            group_output
-        };
-
-        group_outputs.push(trimmed);
+        let row_arr = ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&[1, 1, n_dim]), row_accum)
+            .map_err(|e| DsperseError::Pipeline(format!("{slice_id}: row output: {e}")))?;
+        row_outputs.push(row_arr);
     }
 
-    let result = ndarray::concatenate(
-        Axis(concat_axis),
-        &group_outputs.iter().map(|a| a.view()).collect::<Vec<_>>(),
+    let stacked = ndarray::concatenate(
+        ndarray::Axis(0),
+        &row_outputs.iter().map(|a| a.view()).collect::<Vec<_>>(),
     )
-    .map_err(|e| DsperseError::Pipeline(format!("{slice_id}: dim-split concat failed: {e}")))?;
+    .map_err(|e| DsperseError::Pipeline(format!("{slice_id}: row concat: {e}")))?;
 
-    let final_result = if let Some(target) = target_shape {
-        let target_usize: Vec<usize> = target
+    let output_shape_vec: Vec<usize> = if let Some(target) = target_shape {
+        target
             .iter()
             .map(|&d| {
                 usize::try_from(d).map_err(|_| {
@@ -324,24 +178,26 @@ pub(crate) fn execute_dim_split(
                     ))
                 })
             })
-            .collect::<Result<Vec<_>>>()?;
-        result
-            .as_standard_layout()
-            .into_owned()
-            .into_shape_with_order(ndarray::IxDyn(&target_usize))
-            .map_err(|e| {
-                DsperseError::Pipeline(format!(
-                    "{slice_id}: dim-split reshape to target failed: {e}"
-                ))
-            })?
+            .collect::<Result<Vec<_>>>()?
     } else {
-        result
+        let mut s = input_shape.clone();
+        if let Some(last) = s.last_mut() {
+            *last = n_dim;
+        }
+        s
     };
+
+    let final_result = stacked
+        .as_standard_layout()
+        .into_owned()
+        .into_shape_with_order(ndarray::IxDyn(&output_shape_vec))
+        .map_err(|e| DsperseError::Pipeline(format!("{slice_id}: dim-split reshape: {e}")))?;
 
     tracing::info!(
         slice = %slice_id,
-        groups = ds.num_groups,
-        "executed dim-split"
+        rows = total_rows,
+        k_chunks = k_chunks,
+        "executed dim-split (sequence + K tiled)"
     );
 
     Ok(crate::schema::execution::StrategyOutput {

--- a/crates/dsperse/src/pipeline/dim_split.rs
+++ b/crates/dsperse/src/pipeline/dim_split.rs
@@ -230,11 +230,20 @@ pub(crate) fn execute_dim_split(
         row_outputs.push(row_arr);
     }
 
-    let stacked = ndarray::concatenate(
-        ndarray::Axis(0),
-        &row_outputs.iter().map(|a| a.view()).collect::<Vec<_>>(),
-    )
-    .map_err(|e| DsperseError::Pipeline(format!("{slice_id}: row concat: {e}")))?;
+    // ndarray::concatenate panics / errors on an empty slice list, so a
+    // zero-row activation (empty batch, dynamic-dim collapse) would surface
+    // as an opaque ShapeError. Short-circuit to an empty [0, n_dim] tensor
+    // and let the downstream reshape produce the correctly shaped empty
+    // output.
+    let stacked: ndarray::ArrayD<f64> = if row_outputs.is_empty() {
+        ndarray::ArrayD::zeros(ndarray::IxDyn(&[0, n_dim]))
+    } else {
+        ndarray::concatenate(
+            ndarray::Axis(0),
+            &row_outputs.iter().map(|a| a.view()).collect::<Vec<_>>(),
+        )
+        .map_err(|e| DsperseError::Pipeline(format!("{slice_id}: row concat: {e}")))?
+    };
 
     let output_shape_vec: Vec<usize> = if let Some(target) = target_shape {
         target

--- a/crates/dsperse/src/pipeline/dim_split.rs
+++ b/crates/dsperse/src/pipeline/dim_split.rs
@@ -33,6 +33,17 @@ pub(crate) fn execute_dim_split(
     let input_tensor = tensor_cache.get(&ds.input_name)?.clone();
     let input_shape = input_tensor.shape().to_vec();
     let k_dim = *input_shape.last().unwrap_or(&0);
+    // The runtime activation width must equal the k_dim recorded during
+    // detection. If they diverge (shape inference drift, weight reuse with
+    // different transB orientation, etc.) the chunking math would silently
+    // pad or truncate against a mismatched weight layout and produce wrong
+    // outputs. Refuse to proceed.
+    if ds.k_dim != 0 && k_dim != ds.k_dim {
+        return Err(DsperseError::Pipeline(format!(
+            "{slice_id}: runtime k_dim {} from input {:?} does not match metadata k_dim {}",
+            k_dim, ds.input_name, ds.k_dim
+        )));
+    }
     let k_chunks = ds.k_chunks.max(1);
     let k_chunk_size = k_dim.div_ceil(k_chunks);
 

--- a/crates/dsperse/src/pipeline/dim_split.rs
+++ b/crates/dsperse/src/pipeline/dim_split.rs
@@ -56,19 +56,25 @@ pub(crate) fn execute_dim_split(
         .graph
         .as_ref()
         .ok_or_else(|| DsperseError::Pipeline(format!("{slice_id}: slice ONNX has no graph")))?;
-    let matmul_node = orig_graph
-        .node
-        .iter()
-        .find(|n| matches!(n.op_type.as_str(), "MatMul" | "Gemm"));
-    let trans_b = matmul_node.is_some_and(|n| {
-        n.op_type == "Gemm"
-            && crate::slicer::onnx_proto::get_attribute_int(n, "transB").unwrap_or(0) == 1
-    });
     let weight_name = ds.weight_name.as_ref().ok_or_else(|| {
         DsperseError::Pipeline(format!(
             "{slice_id}: dim_split missing weight_name in metadata"
         ))
     })?;
+    let matmul_node = orig_graph
+        .node
+        .iter()
+        .find(|n| {
+            matches!(n.op_type.as_str(), "MatMul" | "Gemm")
+                && n.input.iter().any(|i| i == weight_name)
+        })
+        .ok_or_else(|| {
+            DsperseError::Pipeline(format!(
+                "{slice_id}: no MatMul/Gemm node references weight {weight_name:?}"
+            ))
+        })?;
+    let trans_b = matmul_node.op_type == "Gemm"
+        && crate::slicer::onnx_proto::get_attribute_int(matmul_node, "transB").unwrap_or(0) == 1;
     let full_weight: Vec<f32> = if let Some(map) = donor_init_map
         && let Some(t) = map.get(weight_name.as_str())
     {

--- a/crates/dsperse/src/pipeline/dim_split.rs
+++ b/crates/dsperse/src/pipeline/dim_split.rs
@@ -64,22 +64,37 @@ pub(crate) fn execute_dim_split(
         n.op_type == "Gemm"
             && crate::slicer::onnx_proto::get_attribute_int(n, "transB").unwrap_or(0) == 1
     });
-    let full_weight: Vec<f32> = ds
-        .weight_name
-        .as_ref()
-        .and_then(|wn| {
-            if let Some(map) = donor_init_map
-                && let Some(t) = map.get(wn.as_str())
-            {
-                return Some(crate::slicer::onnx_proto::tensor_to_f32(t));
-            }
-            orig_graph
-                .initializer
-                .iter()
-                .find(|i| i.name == *wn)
-                .map(crate::slicer::onnx_proto::tensor_to_f32)
-        })
-        .unwrap_or_default();
+    let weight_name = ds.weight_name.as_ref().ok_or_else(|| {
+        DsperseError::Pipeline(format!(
+            "{slice_id}: dim_split missing weight_name in metadata"
+        ))
+    })?;
+    let full_weight: Vec<f32> = if let Some(map) = donor_init_map
+        && let Some(t) = map.get(weight_name.as_str())
+    {
+        crate::slicer::onnx_proto::tensor_to_f32(t)
+    } else {
+        let init = orig_graph
+            .initializer
+            .iter()
+            .find(|i| i.name == *weight_name)
+            .ok_or_else(|| {
+                DsperseError::Pipeline(format!(
+                    "{slice_id}: weight {weight_name:?} not found in slice ONNX initializers"
+                ))
+            })?;
+        crate::slicer::onnx_proto::tensor_to_f32(init)
+    };
+    let expected_weight_len = ds.k_dim.saturating_mul(ds.n_dim);
+    if expected_weight_len > 0 && full_weight.len() != expected_weight_len {
+        return Err(DsperseError::Pipeline(format!(
+            "{slice_id}: weight {weight_name:?} length {} does not match expected k_dim*n_dim = {}*{} = {}",
+            full_weight.len(),
+            ds.k_dim,
+            ds.n_dim,
+            expected_weight_len
+        )));
+    }
 
     let n_dim = ds.n_dim;
     let tmpl_model = crate::slicer::onnx_proto::load_model(&tmpl_path)?;
@@ -148,16 +163,22 @@ pub(crate) fn execute_dim_split(
             crate::slicer::onnx_proto::save_model(&patched, &patched_path)?;
 
             let input_arr =
-                ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&[1, 1, k_chunk_size]), input_chunk)
+                ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&[1, k_chunk_size]), input_chunk)
                     .map_err(|e| DsperseError::Pipeline(format!("{slice_id}: input chunk: {e}")))?;
 
             let out = run_onnx_inference(&patched_path, &input_arr)?;
+            if out.len() != n_dim {
+                return Err(DsperseError::Pipeline(format!(
+                    "{slice_id}: dim-split k-chunk {kc} produced {} outputs, expected n_dim={n_dim}",
+                    out.len()
+                )));
+            }
             for (acc, v) in row_accum.iter_mut().zip(out.iter().copied()) {
                 *acc += v;
             }
         }
 
-        let row_arr = ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&[1, 1, n_dim]), row_accum)
+        let row_arr = ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&[1, n_dim]), row_accum)
             .map_err(|e| DsperseError::Pipeline(format!("{slice_id}: row output: {e}")))?;
         row_outputs.push(row_arr);
     }

--- a/crates/dsperse/src/pipeline/dim_split.rs
+++ b/crates/dsperse/src/pipeline/dim_split.rs
@@ -175,12 +175,24 @@ pub(crate) fn execute_dim_split(
             };
 
             let mut patched = tmpl_model.clone();
-            if let Some(graph) = patched.graph.as_mut()
-                && let Some(w_init) = graph.initializer.iter_mut().find(|i| i.name == "W")
-            {
-                w_init.float_data = weight_chunk;
-                w_init.raw_data.clear();
-            }
+            let graph = patched.graph.as_mut().ok_or_else(|| {
+                DsperseError::Pipeline(format!(
+                    "{slice_id}: dim-split template at {} has no graph",
+                    tmpl_path.display()
+                ))
+            })?;
+            let w_init = graph
+                .initializer
+                .iter_mut()
+                .find(|i| i.name == "W")
+                .ok_or_else(|| {
+                    DsperseError::Pipeline(format!(
+                        "{slice_id}: dim-split template at {} missing 'W' initializer",
+                        tmpl_path.display()
+                    ))
+                })?;
+            w_init.float_data = weight_chunk;
+            w_init.raw_data.clear();
 
             let patched_path = tmp_dir.path().join(format!("chunk_{kc}.onnx"));
             crate::slicer::onnx_proto::save_model(&patched, &patched_path)?;

--- a/crates/dsperse/src/pipeline/dim_split.rs
+++ b/crates/dsperse/src/pipeline/dim_split.rs
@@ -44,6 +44,17 @@ pub(crate) fn execute_dim_split(
             k_dim, ds.input_name, ds.k_dim
         )));
     }
+    // The equality check above only fires when ds.k_dim is populated.
+    // Legacy metadata with ds.k_dim == 0 paired with a degenerate runtime
+    // tensor (last dim 0) would otherwise produce k_chunk_size = 0 and
+    // silently drive empty inferences. Reject the zero-width activation
+    // explicitly so the failure mode is loud.
+    if k_dim == 0 {
+        return Err(DsperseError::Pipeline(format!(
+            "{slice_id}: dim-split input {:?} has zero-width last dim; expected k_dim > 0",
+            ds.input_name
+        )));
+    }
     let k_chunks = ds.k_chunks.max(1);
     let k_chunk_size = k_dim.div_ceil(k_chunks);
 

--- a/crates/dsperse/src/pipeline/dim_split.rs
+++ b/crates/dsperse/src/pipeline/dim_split.rs
@@ -61,16 +61,22 @@ pub(crate) fn execute_dim_split(
             "{slice_id}: dim_split missing weight_name in metadata"
         ))
     })?;
+    // Tighten the lookup with weight + IO match so that slices reusing the
+    // same initializer (tied weights, etc.) cannot bind a sibling op with
+    // a different transB orientation.
     let matmul_node = orig_graph
         .node
         .iter()
         .find(|n| {
             matches!(n.op_type.as_str(), "MatMul" | "Gemm")
                 && n.input.iter().any(|i| i == weight_name)
+                && n.input.iter().any(|i| i == &ds.input_name)
+                && n.output.iter().any(|o| o == &ds.output_name)
         })
         .ok_or_else(|| {
             DsperseError::Pipeline(format!(
-                "{slice_id}: no MatMul/Gemm node references weight {weight_name:?}"
+                "{slice_id}: no MatMul/Gemm node matches weight={weight_name:?} input={:?} output={:?}",
+                ds.input_name, ds.output_name
             ))
         })?;
     let trans_b = matmul_node.op_type == "Gemm"

--- a/crates/dsperse/src/pipeline/dim_split.rs
+++ b/crates/dsperse/src/pipeline/dim_split.rs
@@ -125,6 +125,69 @@ pub(crate) fn execute_dim_split(
     let tmp_dir = tempfile::tempdir()
         .map_err(|e| DsperseError::Pipeline(format!("{slice_id}: tmpdir: {e}")))?;
 
+    // Precompute one patched ONNX per K-chunk. The weight slice and the
+    // patched model both depend only on kc (and the immutable template),
+    // so hoisting them out of the row loop turns O(rows * k_chunks)
+    // weight builds + clones + save_model writes into O(k_chunks) work.
+    let mut patched_paths: Vec<std::path::PathBuf> = Vec::with_capacity(k_chunks);
+    for kc in 0..k_chunks {
+        let k_start = kc * k_chunk_size;
+        let k_end = (k_start + k_chunk_size).min(k_dim);
+        let actual_k = k_end.saturating_sub(k_start);
+
+        let weight_chunk: Vec<f32> = if trans_b {
+            let mut w = Vec::with_capacity(n_dim * k_chunk_size);
+            for row_idx in 0..n_dim {
+                let row_start = row_idx * k_dim + k_start;
+                let avail = actual_k.min(full_weight.len().saturating_sub(row_start));
+                w.extend_from_slice(&full_weight[row_start..row_start + avail]);
+                if avail < k_chunk_size {
+                    w.resize(w.len() + k_chunk_size - avail, 0.0);
+                }
+            }
+            w
+        } else {
+            let mut w = Vec::with_capacity(k_chunk_size * n_dim);
+            for ki in k_start..k_start + actual_k {
+                let start = ki * n_dim;
+                let end = start + n_dim;
+                if end <= full_weight.len() {
+                    w.extend_from_slice(&full_weight[start..end]);
+                } else {
+                    w.resize(w.len() + n_dim, 0.0);
+                }
+            }
+            if actual_k < k_chunk_size {
+                w.resize(k_chunk_size * n_dim, 0.0);
+            }
+            w
+        };
+
+        let mut patched = tmpl_model.clone();
+        let graph = patched.graph.as_mut().ok_or_else(|| {
+            DsperseError::Pipeline(format!(
+                "{slice_id}: dim-split template at {} has no graph",
+                tmpl_path.display()
+            ))
+        })?;
+        let w_init = graph
+            .initializer
+            .iter_mut()
+            .find(|i| i.name == "W")
+            .ok_or_else(|| {
+                DsperseError::Pipeline(format!(
+                    "{slice_id}: dim-split template at {} missing 'W' initializer",
+                    tmpl_path.display()
+                ))
+            })?;
+        w_init.float_data = weight_chunk;
+        w_init.raw_data.clear();
+
+        let patched_path = tmp_dir.path().join(format!("chunk_{kc}.onnx"));
+        crate::slicer::onnx_proto::save_model(&patched, &patched_path)?;
+        patched_paths.push(patched_path);
+    }
+
     let mut row_outputs: Vec<ndarray::ArrayD<f64>> = Vec::with_capacity(total_rows);
 
     for r in 0..total_rows {
@@ -136,7 +199,7 @@ pub(crate) fn execute_dim_split(
 
         let mut row_accum = vec![0.0f64; n_dim];
 
-        for kc in 0..k_chunks {
+        for (kc, patched_path) in patched_paths.iter().enumerate() {
             let k_start = kc * k_chunk_size;
             let k_end = (k_start + k_chunk_size).min(k_dim);
             let actual_k = k_end.saturating_sub(k_start);
@@ -146,62 +209,11 @@ pub(crate) fn execute_dim_split(
                 input_chunk[..actual_k].copy_from_slice(&full_row[k_start..k_end]);
             }
 
-            let weight_chunk: Vec<f32> = if trans_b {
-                let mut w = Vec::with_capacity(n_dim * k_chunk_size);
-                for row_idx in 0..n_dim {
-                    let row_start = row_idx * k_dim + k_start;
-                    let avail = actual_k.min(full_weight.len().saturating_sub(row_start));
-                    w.extend_from_slice(&full_weight[row_start..row_start + avail]);
-                    if avail < k_chunk_size {
-                        w.resize(w.len() + k_chunk_size - avail, 0.0);
-                    }
-                }
-                w
-            } else {
-                let mut w = Vec::with_capacity(k_chunk_size * n_dim);
-                for ki in k_start..k_start + actual_k {
-                    let start = ki * n_dim;
-                    let end = start + n_dim;
-                    if end <= full_weight.len() {
-                        w.extend_from_slice(&full_weight[start..end]);
-                    } else {
-                        w.resize(w.len() + n_dim, 0.0);
-                    }
-                }
-                if actual_k < k_chunk_size {
-                    w.resize(k_chunk_size * n_dim, 0.0);
-                }
-                w
-            };
-
-            let mut patched = tmpl_model.clone();
-            let graph = patched.graph.as_mut().ok_or_else(|| {
-                DsperseError::Pipeline(format!(
-                    "{slice_id}: dim-split template at {} has no graph",
-                    tmpl_path.display()
-                ))
-            })?;
-            let w_init = graph
-                .initializer
-                .iter_mut()
-                .find(|i| i.name == "W")
-                .ok_or_else(|| {
-                    DsperseError::Pipeline(format!(
-                        "{slice_id}: dim-split template at {} missing 'W' initializer",
-                        tmpl_path.display()
-                    ))
-                })?;
-            w_init.float_data = weight_chunk;
-            w_init.raw_data.clear();
-
-            let patched_path = tmp_dir.path().join(format!("chunk_{kc}.onnx"));
-            crate::slicer::onnx_proto::save_model(&patched, &patched_path)?;
-
             let input_arr =
                 ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&[1, k_chunk_size]), input_chunk)
                     .map_err(|e| DsperseError::Pipeline(format!("{slice_id}: input chunk: {e}")))?;
 
-            let out = run_onnx_inference(&patched_path, &input_arr)?;
+            let out = run_onnx_inference(patched_path, &input_arr)?;
             if out.len() != n_dim {
                 return Err(DsperseError::Pipeline(format!(
                     "{slice_id}: dim-split k-chunk {kc} produced {} outputs, expected n_dim={n_dim}",

--- a/crates/dsperse/src/pipeline/packager.rs
+++ b/crates/dsperse/src/pipeline/packager.rs
@@ -102,7 +102,14 @@ struct DagNode {
     output_shape: Vec<Vec<i64>>,
 }
 
-const VALID_CURVES: &[&str] = &["bn254", "goldilocks", "goldilocks_basefold"];
+const VALID_CURVES: &[&str] = &[
+    "bn254",
+    "goldilocks",
+    "goldilocks_basefold",
+    "goldilocks_ext2",
+    "goldilocks_whir",
+    "goldilocks_whir_pq",
+];
 
 fn normalize_curve(curve: Option<&str>) -> Result<Option<String>> {
     let Some(c) = curve else { return Ok(None) };

--- a/crates/dsperse/src/schema/tiling.rs
+++ b/crates/dsperse/src/schema/tiling.rs
@@ -187,6 +187,12 @@ pub struct DimSplitInfo {
     pub estimated_group_constraints: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub weight_name: Option<String>,
+    #[serde(default)]
+    pub k_dim: usize,
+    #[serde(default)]
+    pub n_dim: usize,
+    #[serde(default = "default_one")]
+    pub k_chunks: usize,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub template_path: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -1704,17 +1704,24 @@ fn create_matmul_dim_template(
         ))
     })?;
 
+    // Match the exact split node by weight, activation input, and output
+    // name. A graph may reuse the same weight initializer in multiple
+    // MatMul/Gemm ops (tied weights, weight sharing across heads); without
+    // checking IO we could bind the wrong op and emit a template that
+    // doesn't match the slice the runner will execute.
     let matmul_node = graph
         .node
         .iter()
         .find(|n| {
             matches!(n.op_type.as_str(), "MatMul" | "Gemm")
                 && n.input.iter().any(|i| i == weight_name)
+                && n.input.iter().any(|i| i == &info.input_name)
+                && n.output.iter().any(|o| o == &info.output_name)
         })
         .ok_or_else(|| {
             crate::error::DsperseError::Slicer(format!(
-                "create_matmul_dim_template: slice {} no MatMul/Gemm references weight {weight_name:?}",
-                info.slice_idx
+                "create_matmul_dim_template: slice {} no MatMul/Gemm matches weight={weight_name:?} input={:?} output={:?}",
+                info.slice_idx, info.input_name, info.output_name
             ))
         })?;
 
@@ -2575,6 +2582,8 @@ mod tests {
         let info = crate::schema::tiling::DimSplitInfo {
             slice_idx: 0,
             weight_name: Some("w_big".to_string()),
+            input_name: "mid".to_string(),
+            output_name: "output".to_string(),
             k_dim: 64,
             n_dim: 2048,
             k_chunks: 1,
@@ -2588,6 +2597,71 @@ mod tests {
         let w = g.initializer.iter().find(|i| i.name == "W").unwrap();
         // Template weight shape must reflect w_big (64, 2048), not w_small.
         assert_eq!(w.dims, vec![64, 2048]);
+    }
+
+    #[test]
+    fn create_matmul_dim_template_disambiguates_shared_weight() {
+        // Two MatMul ops share the same weight initializer (e.g. tied
+        // weights). The template builder must select the op whose
+        // input/output names match info, not the first node that happens
+        // to reference the initializer.
+        let x = onnx_proto::make_tensor_value_info("input", TensorProto::FLOAT, &[4, 64]);
+        let y_a = onnx_proto::make_tensor_value_info("out_a", TensorProto::FLOAT, &[4, 32]);
+        let y_b = onnx_proto::make_tensor_value_info("out_b", TensorProto::FLOAT, &[1, 32]);
+
+        let shared_w = onnx_proto::make_tensor(
+            "tied_w",
+            TensorProto::FLOAT,
+            &[64, 32],
+            vec![0.0f32; 64 * 32],
+        );
+
+        // First op: input -> tied_w -> out_a (shape [4, 32])
+        let n_a = onnx_proto::make_node(
+            "MatMul",
+            vec!["input".into(), "tied_w".into()],
+            vec!["out_a".into()],
+            vec![],
+        );
+        // Second op: alt_in -> tied_w -> out_b (shape [1, 32])
+        let alt_in = onnx_proto::make_tensor_value_info("alt_in", TensorProto::FLOAT, &[1, 64]);
+        let n_b = onnx_proto::make_node(
+            "MatMul",
+            vec!["alt_in".into(), "tied_w".into()],
+            vec!["out_b".into()],
+            vec![],
+        );
+
+        let graph = onnx_proto::make_graph(
+            "shared_weight",
+            vec![n_a, n_b],
+            vec![x, alt_in],
+            vec![y_a, y_b],
+            vec![shared_w],
+        );
+        let model = onnx_proto::make_model(graph, 13);
+
+        // Target the second op explicitly via input_name/output_name.
+        let info = crate::schema::tiling::DimSplitInfo {
+            slice_idx: 0,
+            weight_name: Some("tied_w".to_string()),
+            input_name: "alt_in".to_string(),
+            output_name: "out_b".to_string(),
+            k_dim: 64,
+            n_dim: 32,
+            k_chunks: 1,
+            ..Default::default()
+        };
+
+        let tmp = tempfile::tempdir().unwrap();
+        // Builder should succeed by binding the second op (the one whose
+        // IO matches info), even though the first op also references the
+        // same weight initializer.
+        let tmpl_path = create_dim_split_template(&model, &info, tmp.path()).unwrap();
+        let tmpl_model = onnx_proto::load_model(&tmpl_path).unwrap();
+        let g = tmpl_model.graph.as_ref().unwrap();
+        let w = g.initializer.iter().find(|i| i.name == "W").unwrap();
+        assert_eq!(w.dims, vec![64, 32]);
     }
 
     fn make_maxpool_node(

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -682,16 +682,9 @@ pub struct DimSplitDetection {
     pub concat_axis: usize,
     pub estimated_constraints: u64,
     pub weight_name: Option<String>,
-}
-
-fn normalize_dim_split_size(raw_epg: usize, dim_size: usize) -> usize {
-    const BUCKETS: &[usize] = &[1, 2, 4, 8, 16, 32, 64, 128, 256];
-    for &b in BUCKETS {
-        if b >= raw_epg {
-            return b.min(dim_size);
-        }
-    }
-    raw_epg.min(dim_size)
+    pub k_dim: usize,
+    pub n_dim: usize,
+    pub k_chunks: usize,
 }
 
 pub fn estimate_slice_constraints(nodes: &[NodeProto], shapes: &HashMap<String, Vec<i64>>) -> u64 {
@@ -754,21 +747,33 @@ pub fn detect_dim_split(
             }
             let trans_b = node.op_type == "Gemm"
                 && super::onnx_proto::get_attribute_int(node, "transB").unwrap_or(0) == 1;
-            let (n_dim, split_dim) = if trans_b {
-                (weight_shape[0] as usize, 0)
+            let k_dim = if trans_b {
+                weight_shape[1] as usize
             } else {
-                (weight_shape[1] as usize, 1)
+                weight_shape[0] as usize
             };
-            if n_dim <= 1 {
+            let n_dim = if trans_b {
+                weight_shape[0] as usize
+            } else {
+                weight_shape[1] as usize
+            };
+            let Some(inp_shape) = node.input.first().and_then(|name| shapes.get(name)) else {
+                continue;
+            };
+            let total_rows: usize = inp_shape
+                .iter()
+                .take(inp_shape.len().saturating_sub(1))
+                .map(|&d| d.max(1) as usize)
+                .product();
+            if total_rows <= 1 {
                 continue;
             }
-            let raw_epg = n_dim.div_ceil(target_groups.min(n_dim));
-            let elements_per_group = normalize_dim_split_size(raw_epg, n_dim);
-            let num_groups = n_dim.div_ceil(elements_per_group);
-            let Some(output_shape) = node.output.first().and_then(|name| shapes.get(name)) else {
-                continue;
+            let row_cost = k_dim.saturating_mul(n_dim).saturating_mul(2);
+            let k_chunks = if row_cost > MAX_ESTIMATED_CONSTRAINTS as usize {
+                row_cost.div_ceil(MAX_ESTIMATED_CONSTRAINTS as usize)
+            } else {
+                1
             };
-            let concat_axis = output_shape.len().saturating_sub(1);
             let Some(input_name) = node.input.first().filter(|s| !s.is_empty()).cloned() else {
                 continue;
             };
@@ -777,15 +782,18 @@ pub fn detect_dim_split(
             };
             return Some(DimSplitDetection {
                 split_kind: DimSplitKind::MatMulOutputDim,
-                split_dim,
-                dim_size: n_dim,
-                num_groups,
-                elements_per_group,
+                split_dim: 0,
+                dim_size: total_rows,
+                num_groups: total_rows,
+                elements_per_group: 1,
                 input_name,
                 output_name,
-                concat_axis,
+                concat_axis: 0,
                 estimated_constraints: estimated,
                 weight_name: Some(weight_name.clone()),
+                k_dim,
+                n_dim,
+                k_chunks,
             });
         }
     }
@@ -817,6 +825,9 @@ pub fn detect_dim_split(
                     concat_axis: 1,
                     estimated_constraints: estimated,
                     weight_name: None,
+                    k_dim: 0,
+                    n_dim: 0,
+                    k_chunks: 1,
                 });
             }
         }
@@ -849,6 +860,9 @@ pub fn detect_dim_split(
             concat_axis: 0,
             estimated_constraints: estimated,
             weight_name: None,
+            k_dim: 0,
+            n_dim: 0,
+            k_chunks: 1,
         });
     }
 
@@ -1693,42 +1707,30 @@ fn create_matmul_dim_template(
         weight_tensor.dims[0] as usize,
         weight_tensor.dims[1] as usize,
     );
-    let k_dim = if trans_b { cols } else { rows };
-    let epg = info.elements_per_group;
-
-    let tmpl_weight_dims: Vec<i64> = if trans_b {
-        vec![epg as i64, k_dim as i64]
-    } else {
-        vec![k_dim as i64, epg as i64]
-    };
-    let tmpl_weight_data = vec![0.0f32; k_dim * epg];
-
-    let input_name_orig = matmul_node.input.first().cloned().unwrap_or_default();
-    let input_shape: Vec<i64> = graph
-        .input
-        .iter()
-        .chain(graph.value_info.iter())
-        .find(|vi| vi.name == input_name_orig)
-        .and_then(onnx_proto::shape_from_value_info)
-        .unwrap_or_default();
+    let (k_dim, n_dim) = if trans_b { (cols, rows) } else { (rows, cols) };
+    let k_chunk_size = k_dim.div_ceil(info.k_chunks.max(1));
 
     let tmpl_input_name = "dim_tmpl_in".to_string();
     let tmpl_output_name = "dim_tmpl_out".to_string();
     let tmpl_weight_name = "W".to_string();
 
-    let mut output_shape = input_shape.clone();
-    if let Some(last) = output_shape.last_mut() {
-        *last = epg as i64;
-    }
+    let tmpl_input_shape: Vec<i64> = vec![1, 1, k_chunk_size as i64];
+    let output_shape: Vec<i64> = vec![1, 1, n_dim as i64];
 
-    let x = onnx_proto::make_tensor_value_info(&tmpl_input_name, TensorProto::FLOAT, &input_shape);
+    let x =
+        onnx_proto::make_tensor_value_info(&tmpl_input_name, TensorProto::FLOAT, &tmpl_input_shape);
     let y =
         onnx_proto::make_tensor_value_info(&tmpl_output_name, TensorProto::FLOAT, &output_shape);
+    let tmpl_weight_dims: Vec<i64> = if trans_b {
+        vec![n_dim as i64, k_chunk_size as i64]
+    } else {
+        vec![k_chunk_size as i64, n_dim as i64]
+    };
     let w = onnx_proto::make_tensor(
         &tmpl_weight_name,
         TensorProto::FLOAT,
         &tmpl_weight_dims,
-        tmpl_weight_data,
+        vec![0.0f32; k_chunk_size * n_dim],
     );
 
     let mut attrs = Vec::new();
@@ -1751,8 +1753,12 @@ fn create_matmul_dim_template(
         if let Some(bias_name) = matmul_node.input.get(2).filter(|s| !s.is_empty())
             && graph.initializer.iter().any(|i| i.name == *bias_name)
         {
-            let tmpl_bias =
-                onnx_proto::make_tensor("C", TensorProto::FLOAT, &[epg as i64], vec![0.0f32; epg]);
+            let tmpl_bias = onnx_proto::make_tensor(
+                "C",
+                TensorProto::FLOAT,
+                &[n_dim as i64],
+                vec![0.0f32; n_dim],
+            );
             node_inputs.push("C".to_string());
             initializers.push(tmpl_bias);
         }
@@ -2275,7 +2281,11 @@ mod tests {
         assert!(detection.is_some());
         let d = detection.unwrap();
         assert_eq!(d.split_dim, 0);
-        assert_eq!(d.dim_size, 1536);
+        assert_eq!(d.dim_size, 580);
+        assert_eq!(d.num_groups, 580);
+        assert_eq!(d.elements_per_group, 1);
+        assert_eq!(d.k_dim, 384);
+        assert_eq!(d.n_dim, 1536);
         assert!(matches!(d.split_kind, DimSplitKind::MatMulOutputDim));
     }
 
@@ -2299,8 +2309,12 @@ mod tests {
         let detection = detect_dim_split(&[node], &shapes, &init_names);
         assert!(detection.is_some());
         let d = detection.unwrap();
-        assert_eq!(d.split_dim, 1);
-        assert_eq!(d.dim_size, 1536);
+        assert_eq!(d.split_dim, 0);
+        assert_eq!(d.dim_size, 580);
+        assert_eq!(d.num_groups, 580);
+        assert_eq!(d.elements_per_group, 1);
+        assert_eq!(d.k_dim, 384);
+        assert_eq!(d.n_dim, 1536);
         assert!(matches!(d.split_kind, DimSplitKind::MatMulOutputDim));
     }
 

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -1784,8 +1784,8 @@ fn create_matmul_dim_template(
     );
 
     let mut attrs = Vec::new();
-    let mut node_inputs = vec![tmpl_input_name, tmpl_weight_name];
-    let mut initializers = vec![w];
+    let node_inputs = vec![tmpl_input_name, tmpl_weight_name];
+    let initializers = vec![w];
 
     if matmul_node.op_type == "Gemm" {
         if let Some(alpha) = onnx_proto::get_attribute_float(matmul_node, "alpha") {
@@ -1798,18 +1798,8 @@ fn create_matmul_dim_template(
         if trans_b {
             attrs.push(onnx_proto::make_attribute_int("transB", 1));
         }
-        if let Some(bias_name) = matmul_node.input.get(2).filter(|s| !s.is_empty())
-            && graph.initializer.iter().any(|i| i.name == *bias_name)
-        {
-            let tmpl_bias = onnx_proto::make_tensor(
-                "C",
-                TensorProto::FLOAT,
-                &[n_dim as i64],
-                vec![0.0f32; n_dim],
-            );
-            node_inputs.push("C".to_string());
-            initializers.push(tmpl_bias);
-        }
+        // Biased Gemm is rejected above, so no C initializer is ever folded
+        // into the template.
     }
 
     let node = onnx_proto::make_node(

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -765,15 +765,28 @@ pub fn detect_dim_split(
                 .take(inp_shape.len().saturating_sub(1))
                 .map(|&d| d.max(1) as usize)
                 .product();
-            if total_rows <= 1 {
+            if total_rows == 0 || k_dim == 0 || n_dim == 0 {
                 continue;
             }
             let row_cost = k_dim.saturating_mul(n_dim).saturating_mul(2);
-            let k_chunks = if row_cost > MAX_ESTIMATED_CONSTRAINTS as usize {
-                row_cost.div_ceil(MAX_ESTIMATED_CONSTRAINTS as usize)
+            let max_per_chunk = MAX_ESTIMATED_CONSTRAINTS as usize;
+            let mut k_chunks = if row_cost > max_per_chunk {
+                row_cost.div_ceil(max_per_chunk).max(1)
             } else {
                 1
             };
+            while k_chunks < k_dim
+                && k_dim
+                    .div_ceil(k_chunks)
+                    .saturating_mul(n_dim)
+                    .saturating_mul(2)
+                    > max_per_chunk
+            {
+                k_chunks += 1;
+            }
+            if total_rows == 1 && k_chunks == 1 {
+                continue;
+            }
             let Some(input_name) = node.input.first().filter(|s| !s.is_empty()).cloned() else {
                 continue;
             };
@@ -1714,8 +1727,8 @@ fn create_matmul_dim_template(
     let tmpl_output_name = "dim_tmpl_out".to_string();
     let tmpl_weight_name = "W".to_string();
 
-    let tmpl_input_shape: Vec<i64> = vec![1, 1, k_chunk_size as i64];
-    let output_shape: Vec<i64> = vec![1, 1, n_dim as i64];
+    let tmpl_input_shape: Vec<i64> = vec![1, k_chunk_size as i64];
+    let output_shape: Vec<i64> = vec![1, n_dim as i64];
 
     let x =
         onnx_proto::make_tensor_value_info(&tmpl_input_name, TensorProto::FLOAT, &tmpl_input_shape);
@@ -2316,6 +2329,92 @@ mod tests {
         assert_eq!(d.k_dim, 384);
         assert_eq!(d.n_dim, 1536);
         assert!(matches!(d.split_kind, DimSplitKind::MatMulOutputDim));
+    }
+
+    #[test]
+    fn detect_dim_split_k_chunks_saturate_budget() {
+        // k_dim=10, n_dim=100_000: row_cost=2M, naive k_chunks=4 yields
+        // chunk_size=3 -> per-chunk=600K > 500K. Loop should bump k_chunks
+        // until per-chunk <= MAX_ESTIMATED_CONSTRAINTS.
+        let node = NodeProto {
+            op_type: "MatMul".to_string(),
+            input: vec!["input".to_string(), "weight".to_string()],
+            output: vec!["output".to_string()],
+            ..Default::default()
+        };
+        let mut shapes = HashMap::new();
+        shapes.insert("input".to_string(), vec![4, 10]);
+        shapes.insert("weight".to_string(), vec![10, 100_000]);
+        shapes.insert("output".to_string(), vec![4, 100_000]);
+        let mut init_names = HashSet::new();
+        init_names.insert("weight".to_string());
+
+        let d = detect_dim_split(&[node], &shapes, &init_names).unwrap();
+        assert_eq!(d.k_dim, 10);
+        assert_eq!(d.n_dim, 100_000);
+        let chunk_size = d.k_dim.div_ceil(d.k_chunks);
+        assert!(
+            chunk_size * d.n_dim * 2 <= MAX_ESTIMATED_CONSTRAINTS as usize,
+            "per-chunk cost {} exceeds MAX {}",
+            chunk_size * d.n_dim * 2,
+            MAX_ESTIMATED_CONSTRAINTS
+        );
+    }
+
+    #[test]
+    fn detect_dim_split_single_row_with_k_chunking() {
+        // total_rows=1 but k*n*2 > MAX: still detect, K-chunk it.
+        let node = NodeProto {
+            op_type: "MatMul".to_string(),
+            input: vec!["input".to_string(), "weight".to_string()],
+            output: vec!["output".to_string()],
+            ..Default::default()
+        };
+        let mut shapes = HashMap::new();
+        shapes.insert("input".to_string(), vec![1, 2048]);
+        shapes.insert("weight".to_string(), vec![2048, 2048]);
+        shapes.insert("output".to_string(), vec![1, 2048]);
+        let mut init_names = HashSet::new();
+        init_names.insert("weight".to_string());
+
+        let d = detect_dim_split(&[node], &shapes, &init_names).unwrap();
+        assert_eq!(d.dim_size, 1);
+        assert_eq!(d.num_groups, 1);
+        assert!(d.k_chunks > 1, "expected K-chunking for single row");
+        let chunk_size = d.k_dim.div_ceil(d.k_chunks);
+        assert!(chunk_size * d.n_dim * 2 <= MAX_ESTIMATED_CONSTRAINTS as usize);
+    }
+
+    #[test]
+    fn detect_dim_split_skips_single_row_single_chunk() {
+        // total_rows=1 and k*n*2 <= MAX: nothing to split via MatMul path.
+        // The slice is still over budget (forced via a second MatMul), but
+        // dim-split should decline and let the caller fall through.
+        let node1 = NodeProto {
+            op_type: "MatMul".to_string(),
+            input: vec!["input".to_string(), "w1".to_string()],
+            output: vec!["mid".to_string()],
+            ..Default::default()
+        };
+        let node2 = NodeProto {
+            op_type: "MatMul".to_string(),
+            input: vec!["mid".to_string(), "w2".to_string()],
+            output: vec!["output".to_string()],
+            ..Default::default()
+        };
+        let mut shapes = HashMap::new();
+        shapes.insert("input".to_string(), vec![1, 64]);
+        shapes.insert("w1".to_string(), vec![64, 64]);
+        shapes.insert("mid".to_string(), vec![1, 64]);
+        shapes.insert("w2".to_string(), vec![64, 64]);
+        shapes.insert("output".to_string(), vec![1, 64]);
+        let mut init_names = HashSet::new();
+        init_names.insert("w1".to_string());
+        init_names.insert("w2".to_string());
+        // Tiny per-op cost; slice estimate stays under MAX so detect_dim_split
+        // returns None at the outer gate, which is what we want for a
+        // single-row single-chunk MatMul.
+        assert!(detect_dim_split(&[node1, node2], &shapes, &init_names).is_none());
     }
 
     fn make_maxpool_node(

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -731,12 +731,28 @@ pub fn detect_dim_split(
 
     let target_groups = estimated.div_ceil(MAX_ESTIMATED_CONSTRAINTS) as usize;
 
-    for node in nodes {
+    for (idx, node) in nodes.iter().enumerate() {
         if matches!(node.op_type.as_str(), "MatMul" | "Gemm") {
             // Gemm with a bias (input C) is not yet supported by the dim-split
             // template builder; skip so the template construction downstream
             // stays in sync with the detector.
             if node.op_type == "Gemm" && node.input.get(2).is_some_and(|s: &String| !s.is_empty()) {
+                continue;
+            }
+            // The dim-split runner replaces the entire slice execution with
+            // the patched MatMul template and only writes ds.output_name to
+            // the tensor cache. If this MatMul/Gemm output is consumed by a
+            // later node in the same slice, those downstream ops would never
+            // execute and the slice would publish the wrong tensor. Decline
+            // and let the search continue or fall through to other paths.
+            let Some(node_out) = node.output.first().filter(|s| !s.is_empty()) else {
+                continue;
+            };
+            let consumed_downstream = nodes
+                .iter()
+                .skip(idx + 1)
+                .any(|later| later.input.iter().any(|i| i == node_out));
+            if consumed_downstream {
                 continue;
             }
             let Some(weight_name) = node.input.get(1) else {
@@ -2472,6 +2488,76 @@ mod tests {
                 .is_none_or(|d| !matches!(d.split_kind, DimSplitKind::MatMulOutputDim)),
             "expected MatMul dim-split to decline, got {got:?}"
         );
+    }
+
+    #[test]
+    fn detect_dim_split_skips_non_terminal_matmul() {
+        // MatMul output is consumed by a later Add inside the same slice.
+        // The dim-split runner only writes MatMul output to the cache, so
+        // the Add would never run; detection must decline this MatMul and
+        // either pick a later terminal MatMul or fall through.
+        let matmul = NodeProto {
+            op_type: "MatMul".to_string(),
+            input: vec!["input".to_string(), "weight".to_string()],
+            output: vec!["mid".to_string()],
+            ..Default::default()
+        };
+        let add = NodeProto {
+            op_type: "Add".to_string(),
+            input: vec!["mid".to_string(), "bias".to_string()],
+            output: vec!["output".to_string()],
+            ..Default::default()
+        };
+        let mut shapes = HashMap::new();
+        shapes.insert("input".to_string(), vec![1, 145, 384]);
+        shapes.insert("weight".to_string(), vec![384, 1536]);
+        shapes.insert("bias".to_string(), vec![1536]);
+        shapes.insert("mid".to_string(), vec![1, 145, 1536]);
+        shapes.insert("output".to_string(), vec![1, 145, 1536]);
+        let mut init_names = HashSet::new();
+        init_names.insert("weight".to_string());
+        init_names.insert("bias".to_string());
+
+        let got = detect_dim_split(&[matmul, add], &shapes, &init_names);
+        assert!(
+            got.as_ref()
+                .is_none_or(|d| !matches!(d.split_kind, DimSplitKind::MatMulOutputDim)),
+            "expected non-terminal MatMul to be declined, got {got:?}"
+        );
+    }
+
+    #[test]
+    fn detect_dim_split_picks_terminal_matmul_after_consumed_one() {
+        // First MatMul feeds a second MatMul; only the second is terminal,
+        // so detection must skip the first and select the second when both
+        // are otherwise eligible.
+        let m1 = NodeProto {
+            op_type: "MatMul".to_string(),
+            input: vec!["input".to_string(), "w1".to_string()],
+            output: vec!["mid".to_string()],
+            ..Default::default()
+        };
+        let m2 = NodeProto {
+            op_type: "MatMul".to_string(),
+            input: vec!["mid".to_string(), "w2".to_string()],
+            output: vec!["output".to_string()],
+            ..Default::default()
+        };
+        let mut shapes = HashMap::new();
+        shapes.insert("input".to_string(), vec![4, 145, 384]);
+        shapes.insert("w1".to_string(), vec![384, 1536]);
+        shapes.insert("mid".to_string(), vec![4, 145, 1536]);
+        shapes.insert("w2".to_string(), vec![1536, 384]);
+        shapes.insert("output".to_string(), vec![4, 145, 384]);
+        let mut init_names = HashSet::new();
+        init_names.insert("w1".to_string());
+        init_names.insert("w2".to_string());
+
+        let d = detect_dim_split(&[m1, m2], &shapes, &init_names).unwrap();
+        assert_eq!(d.weight_name.as_deref(), Some("w2"));
+        assert_eq!(d.output_name, "output");
+        assert_eq!(d.k_dim, 1536);
+        assert_eq!(d.n_dim, 384);
     }
 
     #[test]

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -733,6 +733,12 @@ pub fn detect_dim_split(
 
     for node in nodes {
         if matches!(node.op_type.as_str(), "MatMul" | "Gemm") {
+            // Gemm with a bias (input C) is not yet supported by the dim-split
+            // template builder; skip so the template construction downstream
+            // stays in sync with the detector.
+            if node.op_type == "Gemm" && node.input.get(2).is_some_and(|s: &String| !s.is_empty()) {
+                continue;
+            }
             let Some(weight_name) = node.input.get(1) else {
                 continue;
             };
@@ -770,11 +776,19 @@ pub fn detect_dim_split(
             }
             let row_cost = k_dim.saturating_mul(n_dim).saturating_mul(2);
             let max_per_chunk = MAX_ESTIMATED_CONSTRAINTS as usize;
+            // Even with k_chunks == k_dim (chunk_size == 1), the per-chunk
+            // cost is at minimum n_dim * 2. If that alone exceeds the budget
+            // the split is infeasible; let the caller fall through to other
+            // detection paths.
+            if n_dim.saturating_mul(2) > max_per_chunk {
+                continue;
+            }
             let mut k_chunks = if row_cost > max_per_chunk {
                 row_cost.div_ceil(max_per_chunk).max(1)
             } else {
                 1
             };
+            k_chunks = k_chunks.min(k_dim);
             while k_chunks < k_dim
                 && k_dim
                     .div_ceil(k_chunks)
@@ -1675,28 +1689,34 @@ fn create_matmul_dim_template(
     info: &crate::schema::tiling::DimSplitInfo,
     output_dir: &Path,
 ) -> Result<std::path::PathBuf> {
+    let weight_name = info.weight_name.as_ref().ok_or_else(|| {
+        crate::error::DsperseError::Slicer(format!(
+            "create_matmul_dim_template: slice {} DimSplitInfo missing weight_name",
+            info.slice_idx
+        ))
+    })?;
+
     let matmul_node = graph
         .node
         .iter()
-        .find(|n| matches!(n.op_type.as_str(), "MatMul" | "Gemm"))
+        .find(|n| {
+            matches!(n.op_type.as_str(), "MatMul" | "Gemm")
+                && n.input.iter().any(|i| i == weight_name)
+        })
         .ok_or_else(|| {
-            crate::error::DsperseError::Slicer(
-                "create_matmul_dim_template: no MatMul/Gemm node found".into(),
-            )
+            crate::error::DsperseError::Slicer(format!(
+                "create_matmul_dim_template: slice {} no MatMul/Gemm references weight {weight_name:?}",
+                info.slice_idx
+            ))
         })?;
 
-    if matmul_node.op_type == "Gemm" && matmul_node.input.len() > 2 {
+    if matmul_node.op_type == "Gemm" && matmul_node.input.get(2).is_some_and(|s| !s.is_empty()) {
         return Err(crate::error::DsperseError::Slicer(format!(
             "create_matmul_dim_template: slice {} Gemm with bias not supported for dim-split",
             info.slice_idx
         )));
     }
 
-    let weight_name = matmul_node.input.get(1).ok_or_else(|| {
-        crate::error::DsperseError::Slicer(
-            "create_matmul_dim_template: MatMul has no weight input".into(),
-        )
-    })?;
     let weight_tensor = graph
         .initializer
         .iter()
@@ -2270,13 +2290,11 @@ mod tests {
     fn detect_dim_split_gemm_trans_b() {
         use super::onnx_proto::{NodeProto, make_attribute_int};
 
+        // Unbiased Gemm with transB=1. Biased Gemm is rejected upstream by
+        // create_matmul_dim_template, so the detector now skips it as well.
         let node = NodeProto {
             op_type: "Gemm".to_string(),
-            input: vec![
-                "input".to_string(),
-                "weight".to_string(),
-                "bias".to_string(),
-            ],
+            input: vec!["input".to_string(), "weight".to_string()],
             output: vec!["output".to_string()],
             attribute: vec![make_attribute_int("transB", 1)],
             ..Default::default()
@@ -2415,6 +2433,129 @@ mod tests {
         // returns None at the outer gate, which is what we want for a
         // single-row single-chunk MatMul.
         assert!(detect_dim_split(&[node1, node2], &shapes, &init_names).is_none());
+    }
+
+    #[test]
+    fn detect_dim_split_declines_infeasible_n() {
+        // n_dim * 2 > MAX means even k_chunks == k_dim (chunk_size = 1)
+        // cannot fit inside the per-chunk budget, so the MatMul branch must
+        // decline. Use batch=1 so the BatchDim fallback path is not taken.
+        let node = NodeProto {
+            op_type: "MatMul".to_string(),
+            input: vec!["input".to_string(), "weight".to_string()],
+            output: vec!["output".to_string()],
+            ..Default::default()
+        };
+        let mut shapes = HashMap::new();
+        // n_dim = 400_000 -> n*2 = 800_000 > MAX (500_000)
+        shapes.insert("input".to_string(), vec![1, 4]);
+        shapes.insert("weight".to_string(), vec![4, 400_000]);
+        shapes.insert("output".to_string(), vec![1, 400_000]);
+        let mut init_names = HashSet::new();
+        init_names.insert("weight".to_string());
+
+        let got = detect_dim_split(&[node], &shapes, &init_names);
+        assert!(
+            got.as_ref()
+                .is_none_or(|d| !matches!(d.split_kind, DimSplitKind::MatMulOutputDim)),
+            "expected MatMul dim-split to decline, got {got:?}"
+        );
+    }
+
+    #[test]
+    fn detect_dim_split_skips_gemm_with_bias() {
+        use super::onnx_proto::make_attribute_int;
+        let node = NodeProto {
+            op_type: "Gemm".to_string(),
+            input: vec![
+                "input".to_string(),
+                "weight".to_string(),
+                "bias".to_string(),
+            ],
+            output: vec!["output".to_string()],
+            attribute: vec![make_attribute_int("transB", 1)],
+            ..Default::default()
+        };
+        let mut shapes = HashMap::new();
+        // Use batch=1 so the BatchDim fallback path does not mask the
+        // MatMul-branch decline we want to assert.
+        shapes.insert("input".to_string(), vec![1, 145, 384]);
+        shapes.insert("weight".to_string(), vec![1536, 384]);
+        shapes.insert("bias".to_string(), vec![1536]);
+        shapes.insert("output".to_string(), vec![1, 145, 1536]);
+        let mut init_names = HashSet::new();
+        init_names.insert("weight".to_string());
+        init_names.insert("bias".to_string());
+
+        // Detector should decline the MatMul branch since the template
+        // builder cannot handle biased Gemm, forcing fall-through.
+        let got = detect_dim_split(&[node], &shapes, &init_names);
+        assert!(
+            got.as_ref()
+                .is_none_or(|d| !matches!(d.split_kind, DimSplitKind::MatMulOutputDim)),
+            "expected Gemm-with-bias MatMul decline, got {got:?}"
+        );
+    }
+
+    #[test]
+    fn create_matmul_dim_template_uses_info_weight_name() {
+        // Graph has two MatMul nodes referencing different weights. The
+        // template builder must pick the node whose input is info.weight_name,
+        // not the first MatMul encountered.
+        let x = onnx_proto::make_tensor_value_info("input", TensorProto::FLOAT, &[4, 64]);
+        let y = onnx_proto::make_tensor_value_info("output", TensorProto::FLOAT, &[4, 2048]);
+
+        let w_small = onnx_proto::make_tensor(
+            "w_small",
+            TensorProto::FLOAT,
+            &[64, 64],
+            vec![0.0f32; 64 * 64],
+        );
+        let w_big = onnx_proto::make_tensor(
+            "w_big",
+            TensorProto::FLOAT,
+            &[64, 2048],
+            vec![0.0f32; 64 * 2048],
+        );
+
+        let n1 = onnx_proto::make_node(
+            "MatMul",
+            vec!["input".into(), "w_small".into()],
+            vec!["mid".into()],
+            vec![],
+        );
+        let n2 = onnx_proto::make_node(
+            "MatMul",
+            vec!["mid".into(), "w_big".into()],
+            vec!["output".into()],
+            vec![],
+        );
+
+        let graph = onnx_proto::make_graph(
+            "two_matmul",
+            vec![n1, n2],
+            vec![x],
+            vec![y],
+            vec![w_small, w_big],
+        );
+        let model = onnx_proto::make_model(graph, 13);
+
+        let info = crate::schema::tiling::DimSplitInfo {
+            slice_idx: 0,
+            weight_name: Some("w_big".to_string()),
+            k_dim: 64,
+            n_dim: 2048,
+            k_chunks: 1,
+            ..Default::default()
+        };
+
+        let tmp = tempfile::tempdir().unwrap();
+        let tmpl_path = create_dim_split_template(&model, &info, tmp.path()).unwrap();
+        let tmpl_model = onnx_proto::load_model(&tmpl_path).unwrap();
+        let g = tmpl_model.graph.as_ref().unwrap();
+        let w = g.initializer.iter().find(|i| i.name == "W").unwrap();
+        // Template weight shape must reflect w_big (64, 2048), not w_small.
+        assert_eq!(w.dims, vec![64, 2048]);
     }
 
     fn make_maxpool_node(

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -751,6 +751,14 @@ pub fn detect_dim_split(
             if weight_shape.len() != 2 {
                 continue;
             }
+            // Gemm with transA=1 transposes the activation matrix, which the
+            // single-row sequence tile and the rank-2 template do not model.
+            // Skip so detection stays consistent with the template builder.
+            if node.op_type == "Gemm"
+                && super::onnx_proto::get_attribute_int(node, "transA").unwrap_or(0) == 1
+            {
+                continue;
+            }
             let trans_b = node.op_type == "Gemm"
                 && super::onnx_proto::get_attribute_int(node, "transB").unwrap_or(0) == 1;
             let k_dim = if trans_b {
@@ -1733,6 +1741,15 @@ fn create_matmul_dim_template(
         )));
     }
 
+    if matmul_node.op_type == "Gemm"
+        && onnx_proto::get_attribute_int(matmul_node, "transA").unwrap_or(0) == 1
+    {
+        return Err(crate::error::DsperseError::Slicer(format!(
+            "create_matmul_dim_template: slice {} Gemm with transA=1 is not supported for dim-split",
+            info.slice_idx
+        )));
+    }
+
     let trans_b = matmul_node.op_type == "Gemm"
         && onnx_proto::get_attribute_int(matmul_node, "transB").unwrap_or(0) == 1;
 
@@ -1777,9 +1794,7 @@ fn create_matmul_dim_template(
         if let Some(beta) = onnx_proto::get_attribute_float(matmul_node, "beta") {
             attrs.push(onnx_proto::make_attribute_float("beta", beta));
         }
-        if let Some(trans_a) = onnx_proto::get_attribute_int(matmul_node, "transA") {
-            attrs.push(onnx_proto::make_attribute_int("transA", trans_a));
-        }
+        // transA is rejected above; the template always uses A non-transposed.
         if trans_b {
             attrs.push(onnx_proto::make_attribute_int("transB", 1));
         }
@@ -2459,6 +2474,33 @@ mod tests {
             got.as_ref()
                 .is_none_or(|d| !matches!(d.split_kind, DimSplitKind::MatMulOutputDim)),
             "expected MatMul dim-split to decline, got {got:?}"
+        );
+    }
+
+    #[test]
+    fn detect_dim_split_skips_gemm_trans_a() {
+        use super::onnx_proto::make_attribute_int;
+        let node = NodeProto {
+            op_type: "Gemm".to_string(),
+            input: vec!["input".to_string(), "weight".to_string()],
+            output: vec!["output".to_string()],
+            attribute: vec![make_attribute_int("transA", 1)],
+            ..Default::default()
+        };
+        let mut shapes = HashMap::new();
+        // Use batch=1 so the BatchDim fallback path does not mask the
+        // MatMul-branch decline we want to assert.
+        shapes.insert("input".to_string(), vec![1, 384, 145]);
+        shapes.insert("weight".to_string(), vec![384, 1536]);
+        shapes.insert("output".to_string(), vec![1, 145, 1536]);
+        let mut init_names = HashSet::new();
+        init_names.insert("weight".to_string());
+
+        let got = detect_dim_split(&[node], &shapes, &init_names);
+        assert!(
+            got.as_ref()
+                .is_none_or(|d| !matches!(d.split_kind, DimSplitKind::MatMulOutputDim)),
+            "expected Gemm transA=1 MatMul decline, got {got:?}"
         );
     }
 

--- a/crates/dsperse/src/slicer/onnx_slicer.rs
+++ b/crates/dsperse/src/slicer/onnx_slicer.rs
@@ -308,8 +308,17 @@ fn build_slice_metadata(
             input_name: d.input_name.clone(),
             output_name: d.output_name.clone(),
             concat_axis: d.concat_axis,
-            estimated_group_constraints: d.estimated_constraints / d.num_groups as u64,
+            estimated_group_constraints: if d.k_chunks > 1 {
+                (d.k_dim.div_ceil(d.k_chunks) * d.n_dim * 2) as u64
+            } else if d.num_groups > 0 {
+                d.estimated_constraints / d.num_groups as u64
+            } else {
+                d.estimated_constraints
+            },
             weight_name: d.weight_name.clone(),
+            k_dim: d.k_dim,
+            n_dim: d.n_dim,
+            k_chunks: d.k_chunks,
             template_path: None,
             jstprove_circuit_path: None,
         });


### PR DESCRIPTION
## Summary

- Replace MatMul output-dim splitting with input-row (sequence) tiling. Template becomes `[1, 1, K_chunk] x [K_chunk, N]` - a single row, single K chunk, full N. Runner iterates every `B*S` input row through the same circuit; an inner K-chunk loop sums partial products into the row accumulator. Circuit signatures collapse per `(K_chunk, N)` pair rather than per slice, enabling broad circuit cache reuse across structurally identical MatMuls.
- Activate K-dimension chunking when `row_cost = K * N * 2` exceeds the per-slice constraint threshold (500K). Every MatMul dim-split slice now lands under the threshold regardless of `K x N` product.
- Extend packager `VALID_CURVES` to accept `goldilocks_ext2`, `goldilocks_whir`, and `goldilocks_whir_pq`, matching the set supported by the jstprove curve dispatch facade.

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --lib` (203 passing)
- [ ] Slice + compile rf-detr-nano on goldilocks_whir_pq and confirm numerical fidelity vs ORT baseline
- [ ] `dsperse package` + `dsperse publish` end-to-end on a whir curve

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for additional curve options: goldilocks_ext2, goldilocks_whir, goldilocks_whir_pq; CLI help updated accordingly.

* **Improvements**
  * Matrix execution changed to per-row, K-chunk tiled processing to reduce peak memory and handle large matrices more robustly.
  * Tiling metadata and runtime logs now expose k_dim, n_dim, k_chunks and row counts for better diagnostics.
  * Stricter validation with clearer errors for model/weight mismatches and explicit empty-output handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->