### PR TITLE
Implement HeadDim/BatchDim dim-split templates and resolve metadata output mismatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "arith"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
 dependencies = [
  "ark-std",
  "criterion",
@@ -354,7 +354,7 @@ dependencies = [
 [[package]]
 name = "babybear"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
 dependencies = [
  "arith",
  "ark-std",
@@ -398,7 +398,7 @@ dependencies = [
 [[package]]
 name = "bin"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
 dependencies = [
  "arith",
  "babybear",
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "circuit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
 dependencies = [
  "arith",
  "ark-std",
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "circuit-std-rs"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
 dependencies = [
  "arith",
  "ark-bls12-381",
@@ -689,7 +689,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "config_macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
 dependencies = [
  "gkr_engine",
  "gkr_hashers",
@@ -857,7 +857,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 [[package]]
 name = "crosslayer_prototype"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
 dependencies = [
  "arith",
  "env_logger",
@@ -1093,7 +1093,7 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 [[package]]
 name = "expander_compiler"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
 dependencies = [
  "arith",
  "ark-std",
@@ -1324,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "gf2"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
 dependencies = [
  "arith",
  "ark-std",
@@ -1341,7 +1341,7 @@ dependencies = [
 [[package]]
 name = "gf2_128"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
 dependencies = [
  "arith",
  "ark-std",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "gkr"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
 dependencies = [
  "arith",
  "ark-std",
@@ -1386,7 +1386,7 @@ dependencies = [
 [[package]]
 name = "gkr_engine"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
 dependencies = [
  "arith",
  "babybear",
@@ -1404,7 +1404,7 @@ dependencies = [
 [[package]]
 name = "gkr_hashers"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
 dependencies = [
  "arith",
  "halo2curves",
@@ -1416,7 +1416,7 @@ dependencies = [
 [[package]]
 name = "goldilocks"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
 dependencies = [
  "arith",
  "ark-std",
@@ -2014,7 +2014,7 @@ dependencies = [
 [[package]]
 name = "jstprove-io"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
 dependencies = [
  "anyhow",
  "crc32c",
@@ -2026,7 +2026,7 @@ dependencies = [
 [[package]]
 name = "jstprove-onnx"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
 dependencies = [
  "anyhow",
  "prost 0.13.5",
@@ -2037,7 +2037,7 @@ dependencies = [
 [[package]]
 name = "jstprove_circuits"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
 dependencies = [
  "anyhow",
  "arith",
@@ -2213,7 +2213,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2287,7 +2287,7 @@ dependencies = [
 [[package]]
 name = "mersenne31"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
 dependencies = [
  "arith",
  "ark-std",
@@ -2781,7 +2781,7 @@ dependencies = [
 [[package]]
 name = "poly_commit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
 dependencies = [
  "arith",
  "ark-std",
@@ -2807,7 +2807,7 @@ dependencies = [
 [[package]]
 name = "polynomials"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
 dependencies = [
  "arith",
  "ark-std",
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "serdes"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
 dependencies = [
  "ethnum",
  "halo2curves",
@@ -3662,7 +3662,7 @@ dependencies = [
 [[package]]
 name = "serdes_derive"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3834,7 +3834,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
 dependencies = [
  "arith",
  "circuit",
@@ -4445,7 +4445,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
 dependencies = [
  "arith",
  "gkr_engine",
@@ -4468,7 +4468,7 @@ dependencies = [
 [[package]]
 name = "tree"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
 dependencies = [
  "arith",
  "ark-std",
@@ -4628,7 +4628,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1d2aba5a#1d2aba5a082fef609f40510d5b62787537928a85"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "arith"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "ark-std",
  "criterion",
@@ -354,7 +354,7 @@ dependencies = [
 [[package]]
 name = "babybear"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "ark-std",
@@ -398,7 +398,7 @@ dependencies = [
 [[package]]
 name = "bin"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "babybear",
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "circuit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "ark-std",
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "circuit-std-rs"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "ark-bls12-381",
@@ -689,7 +689,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "config_macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "gkr_engine",
  "gkr_hashers",
@@ -857,7 +857,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 [[package]]
 name = "crosslayer_prototype"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "env_logger",
@@ -1093,7 +1093,7 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 [[package]]
 name = "expander_compiler"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "ark-std",
@@ -1324,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "gf2"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "ark-std",
@@ -1341,7 +1341,7 @@ dependencies = [
 [[package]]
 name = "gf2_128"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "ark-std",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "gkr"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "ark-std",
@@ -1386,7 +1386,7 @@ dependencies = [
 [[package]]
 name = "gkr_engine"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "babybear",
@@ -1404,7 +1404,7 @@ dependencies = [
 [[package]]
 name = "gkr_hashers"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "halo2curves",
@@ -1416,7 +1416,7 @@ dependencies = [
 [[package]]
 name = "goldilocks"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "ark-std",
@@ -2014,7 +2014,7 @@ dependencies = [
 [[package]]
 name = "jstprove-io"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "anyhow",
  "crc32c",
@@ -2026,7 +2026,7 @@ dependencies = [
 [[package]]
 name = "jstprove-onnx"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "anyhow",
  "prost 0.13.5",
@@ -2037,7 +2037,7 @@ dependencies = [
 [[package]]
 name = "jstprove_circuits"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "anyhow",
  "arith",
@@ -2213,7 +2213,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2287,7 +2287,7 @@ dependencies = [
 [[package]]
 name = "mersenne31"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "ark-std",
@@ -2781,7 +2781,7 @@ dependencies = [
 [[package]]
 name = "poly_commit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "ark-std",
@@ -2807,7 +2807,7 @@ dependencies = [
 [[package]]
 name = "polynomials"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "ark-std",
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "serdes"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "ethnum",
  "halo2curves",
@@ -3662,7 +3662,7 @@ dependencies = [
 [[package]]
 name = "serdes_derive"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3834,7 +3834,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "circuit",
@@ -4445,7 +4445,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "gkr_engine",
@@ -4468,7 +4468,7 @@ dependencies = [
 [[package]]
 name = "tree"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 dependencies = [
  "arith",
  "ark-std",
@@ -4628,7 +4628,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=b05adcfe#b05adcfe0f7c4d084b7158ba5ae7f8cf7fbf0424"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ sha2 = "0.10"
 tempfile = "3"
 prost = "0.13"
 pyo3 = { version = "0.24" }
-jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "b05adcfe" }
+jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "ec0172f5" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ sha2 = "0.10"
 tempfile = "3"
 prost = "0.13"
 pyo3 = { version = "0.24" }
-jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "1d2aba5a" }
+jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "b05adcfe" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/crates/dsperse/src/pipeline/compiler.rs
+++ b/crates/dsperse/src/pipeline/compiler.rs
@@ -69,6 +69,25 @@ pub fn compile_slices(
             }
         }
     }
+    // Strip dim_split metadata from slices where template creation failed
+    // (axis-separability rejection, unsupported split kind). Leaving stale
+    // dim_split entries in the metadata causes downstream runners and the
+    // packager to emit bundles that fail at the strategy validation stage
+    // ("dim_split present but template_path is missing").
+    for slice in &mut metadata.slices {
+        if slice
+            .dim_split
+            .as_ref()
+            .is_some_and(|ds| ds.template_path.is_none())
+        {
+            tracing::info!(
+                slice = slice.index,
+                "stripping dim_split metadata (no template materialized)"
+            );
+            slice.dim_split = None;
+            metadata_dirty = true;
+        }
+    }
     if metadata_dirty {
         metadata.save(&meta_path)?;
         tracing::info!("persisted materialized split groups to metadata");

--- a/crates/dsperse/src/pipeline/dim_split.rs
+++ b/crates/dsperse/src/pipeline/dim_split.rs
@@ -367,16 +367,12 @@ fn execute_generic_dim_split(
             }
         }
 
-        let named = run_onnx_inference_multi_named(&tmpl_on_disk, &group_cache, &input_names)?;
-        if named.len() != 1 {
-            return Err(DsperseError::Pipeline(format!(
-                "{slice_id}: dim-split group {g} produced {} outputs, expected 1",
-                named.len()
-            )));
-        }
-        let (data, shape) = named.into_values().next().ok_or_else(|| {
+        let mut named = run_onnx_inference_multi_named(&tmpl_on_disk, &group_cache, &input_names)?;
+        let (data, shape) = named.remove(&ds.output_name).ok_or_else(|| {
             DsperseError::Pipeline(format!(
-                "{slice_id}: dim-split group {g} produced no output"
+                "{slice_id}: dim-split group {g} missing output {:?} (available: {:?})",
+                ds.output_name,
+                named.keys().collect::<Vec<_>>()
             ))
         })?;
         let group_output = ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&shape), data)

--- a/crates/dsperse/src/pipeline/dim_split.rs
+++ b/crates/dsperse/src/pipeline/dim_split.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use super::runner::run_onnx_inference;
+use super::runner::{run_onnx_inference, run_onnx_inference_multi_named};
 use super::tensor_store::TensorStore;
 use crate::backend::jstprove::JstproveBackend;
 use crate::error::{DsperseError, Result};
 use crate::schema::execution::ExecutionInfo;
+use crate::schema::tiling::DimSplitKind;
 use crate::slicer::onnx_proto::TensorProto;
 
 #[allow(clippy::too_many_arguments)]
@@ -30,25 +31,53 @@ pub(crate) fn execute_dim_split(
         )));
     }
 
+    let use_matmul_split = matches!(ds.split_kind, DimSplitKind::MatMulOutputDim);
+
+    let final_result = if use_matmul_split {
+        execute_matmul_dim_split(
+            slices_dir,
+            slice_id,
+            ds,
+            target_shape,
+            tensor_cache,
+            &tmpl_path,
+            donor_init_map,
+        )?
+    } else {
+        execute_generic_dim_split(slice_id, ds, target_shape, tensor_cache, &tmpl_path)?
+    };
+
+    Ok(crate::schema::execution::StrategyOutput {
+        info: ExecutionInfo {
+            method: crate::schema::execution::ExecutionMethod::DimSplit,
+            success: true,
+            error: None,
+            witness_file: None,
+            tile_exec_infos: Vec::new(),
+        },
+        outputs: vec![(ds.output_name.clone(), final_result)],
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn execute_matmul_dim_split(
+    slices_dir: &Path,
+    slice_id: &str,
+    ds: &crate::schema::tiling::DimSplitInfo,
+    target_shape: Option<&[i64]>,
+    tensor_cache: &TensorStore,
+    tmpl_path: &Path,
+    donor_init_map: Option<&HashMap<String, &TensorProto>>,
+) -> Result<ndarray::ArrayD<f64>> {
     let input_tensor = tensor_cache.get(&ds.input_name)?.clone();
     let input_shape = input_tensor.shape().to_vec();
     let k_dim = *input_shape.last().unwrap_or(&0);
-    // The runtime activation width must equal the k_dim recorded during
-    // detection. If they diverge (shape inference drift, weight reuse with
-    // different transB orientation, etc.) the chunking math would silently
-    // pad or truncate against a mismatched weight layout and produce wrong
-    // outputs. Refuse to proceed.
     if ds.k_dim != 0 && k_dim != ds.k_dim {
         return Err(DsperseError::Pipeline(format!(
             "{slice_id}: runtime k_dim {} from input {:?} does not match metadata k_dim {}",
             k_dim, ds.input_name, ds.k_dim
         )));
     }
-    // The equality check above only fires when ds.k_dim is populated.
-    // Legacy metadata with ds.k_dim == 0 paired with a degenerate runtime
-    // tensor (last dim 0) would otherwise produce k_chunk_size = 0 and
-    // silently drive empty inferences. Reject the zero-width activation
-    // explicitly so the failure mode is loud.
     if k_dim == 0 {
         return Err(DsperseError::Pipeline(format!(
             "{slice_id}: dim-split input {:?} has zero-width last dim; expected k_dim > 0",
@@ -83,9 +112,6 @@ pub(crate) fn execute_dim_split(
             "{slice_id}: dim_split missing weight_name in metadata"
         ))
     })?;
-    // Tighten the lookup with weight + IO match so that slices reusing the
-    // same initializer (tied weights, etc.) cannot bind a sibling op with
-    // a different transB orientation.
     let matmul_node = orig_graph
         .node
         .iter()
@@ -131,15 +157,11 @@ pub(crate) fn execute_dim_split(
     }
 
     let n_dim = ds.n_dim;
-    let tmpl_model = crate::slicer::onnx_proto::load_model(&tmpl_path)?;
+    let tmpl_model = crate::slicer::onnx_proto::load_model(tmpl_path)?;
 
     let tmp_dir = tempfile::tempdir()
         .map_err(|e| DsperseError::Pipeline(format!("{slice_id}: tmpdir: {e}")))?;
 
-    // Precompute one patched ONNX per K-chunk. The weight slice and the
-    // patched model both depend only on kc (and the immutable template),
-    // so hoisting them out of the row loop turns O(rows * k_chunks)
-    // weight builds + clones + save_model writes into O(k_chunks) work.
     let mut patched_paths: Vec<std::path::PathBuf> = Vec::with_capacity(k_chunks);
     for kc in 0..k_chunks {
         let k_start = kc * k_chunk_size;
@@ -241,11 +263,6 @@ pub(crate) fn execute_dim_split(
         row_outputs.push(row_arr);
     }
 
-    // ndarray::concatenate panics / errors on an empty slice list, so a
-    // zero-row activation (empty batch, dynamic-dim collapse) would surface
-    // as an opaque ShapeError. Short-circuit to an empty [0, n_dim] tensor
-    // and let the downstream reshape produce the correctly shaped empty
-    // output.
     let stacked: ndarray::ArrayD<f64> = if row_outputs.is_empty() {
         ndarray::ArrayD::zeros(ndarray::IxDyn(&[0, n_dim]))
     } else {
@@ -256,24 +273,7 @@ pub(crate) fn execute_dim_split(
         .map_err(|e| DsperseError::Pipeline(format!("{slice_id}: row concat: {e}")))?
     };
 
-    let output_shape_vec: Vec<usize> = if let Some(target) = target_shape {
-        target
-            .iter()
-            .map(|&d| {
-                usize::try_from(d).map_err(|_| {
-                    DsperseError::Pipeline(format!(
-                        "{slice_id}: invalid target dimension {d} in dim-split reshape"
-                    ))
-                })
-            })
-            .collect::<Result<Vec<_>>>()?
-    } else {
-        let mut s = input_shape.clone();
-        if let Some(last) = s.last_mut() {
-            *last = n_dim;
-        }
-        s
-    };
+    let output_shape_vec = resolve_output_shape(slice_id, &input_shape, n_dim, target_shape)?;
 
     let final_result = stacked
         .as_standard_layout()
@@ -288,14 +288,170 @@ pub(crate) fn execute_dim_split(
         "executed dim-split (sequence + K tiled)"
     );
 
-    Ok(crate::schema::execution::StrategyOutput {
-        info: ExecutionInfo {
-            method: crate::schema::execution::ExecutionMethod::DimSplit,
-            success: true,
-            error: None,
-            witness_file: None,
-            tile_exec_infos: Vec::new(),
-        },
-        outputs: vec![(ds.output_name.clone(), final_result)],
-    })
+    Ok(final_result)
+}
+
+fn execute_generic_dim_split(
+    slice_id: &str,
+    ds: &crate::schema::tiling::DimSplitInfo,
+    target_shape: Option<&[i64]>,
+    tensor_cache: &TensorStore,
+    tmpl_path: &Path,
+) -> Result<ndarray::ArrayD<f64>> {
+    use ndarray::Axis;
+
+    let concat_axis = ds.concat_axis;
+    let split_dim = ds.split_dim;
+    let epg = ds.elements_per_group;
+
+    let tmpl_model = crate::slicer::onnx_proto::load_model(tmpl_path)?;
+    let tmpl_graph = tmpl_model
+        .graph
+        .as_ref()
+        .ok_or_else(|| DsperseError::Pipeline(format!("{slice_id}: template has no graph")))?;
+    let tmpl_init_names: std::collections::HashSet<&str> = tmpl_graph
+        .initializer
+        .iter()
+        .map(|i| i.name.as_str())
+        .collect();
+    let input_names: Vec<String> = tmpl_graph
+        .input
+        .iter()
+        .filter(|vi| !tmpl_init_names.contains(vi.name.as_str()))
+        .map(|vi| vi.name.clone())
+        .collect();
+
+    let tmp_dir = tempfile::tempdir()
+        .map_err(|e| DsperseError::Pipeline(format!("{slice_id}: tmpdir: {e}")))?;
+    let tmpl_on_disk = tmp_dir.path().join("dim_tmpl.onnx");
+    crate::slicer::onnx_proto::save_model(&tmpl_model, &tmpl_on_disk)?;
+
+    let mut group_outputs: Vec<ndarray::ArrayD<f64>> = Vec::new();
+
+    for g in 0..ds.num_groups {
+        let dim_start = g * epg;
+        if dim_start >= ds.dim_size {
+            break;
+        }
+        let dim_end = ((g + 1) * epg).min(ds.dim_size);
+        let actual_size = dim_end - dim_start;
+
+        let mut group_cache = TensorStore::new();
+        for vi_name in &input_names {
+            let arr = tensor_cache.try_get(vi_name).ok_or_else(|| {
+                DsperseError::Pipeline(format!(
+                    "{slice_id}: template input {vi_name:?} not found in tensor cache"
+                ))
+            })?;
+            let shape = arr.shape();
+            if split_dim < shape.len() && shape[split_dim] == ds.dim_size {
+                let sliced = arr
+                    .slice_axis(Axis(split_dim), ndarray::Slice::from(dim_start..dim_end))
+                    .to_owned();
+                if actual_size < epg {
+                    let mut padded_shape = sliced.shape().to_vec();
+                    padded_shape[split_dim] = epg;
+                    let mut padded = ndarray::ArrayD::zeros(padded_shape);
+                    for (mut dst, src) in padded
+                        .axis_iter_mut(Axis(split_dim))
+                        .zip(sliced.axis_iter(Axis(split_dim)))
+                    {
+                        dst.assign(&src);
+                    }
+                    group_cache.put(vi_name.clone(), padded);
+                } else {
+                    group_cache.put(vi_name.clone(), sliced);
+                }
+            } else {
+                group_cache.put(vi_name.clone(), arr.clone());
+            }
+        }
+
+        let named = run_onnx_inference_multi_named(&tmpl_on_disk, &group_cache, &input_names)?;
+        if named.len() != 1 {
+            return Err(DsperseError::Pipeline(format!(
+                "{slice_id}: dim-split group {g} produced {} outputs, expected 1",
+                named.len()
+            )));
+        }
+        let (data, shape) = named.into_values().next().ok_or_else(|| {
+            DsperseError::Pipeline(format!(
+                "{slice_id}: dim-split group {g} produced no output"
+            ))
+        })?;
+        let group_output = ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&shape), data)
+            .map_err(|e| DsperseError::Pipeline(format!("{slice_id}: group {g} reshape: {e}")))?;
+
+        let trimmed = if actual_size < epg && concat_axis < group_output.ndim() {
+            group_output
+                .slice_axis(Axis(concat_axis), ndarray::Slice::from(0..actual_size))
+                .to_owned()
+        } else {
+            group_output
+        };
+
+        group_outputs.push(trimmed);
+    }
+
+    let result = ndarray::concatenate(
+        Axis(concat_axis),
+        &group_outputs.iter().map(|a| a.view()).collect::<Vec<_>>(),
+    )
+    .map_err(|e| DsperseError::Pipeline(format!("{slice_id}: dim-split concat: {e}")))?;
+
+    let output_shape_vec = if let Some(target) = target_shape {
+        target
+            .iter()
+            .map(|&d| {
+                usize::try_from(d).map_err(|_| {
+                    DsperseError::Pipeline(format!(
+                        "{slice_id}: invalid target dim {d} in dim-split reshape"
+                    ))
+                })
+            })
+            .collect::<Result<Vec<_>>>()?
+    } else {
+        result.shape().to_vec()
+    };
+
+    let final_result = result
+        .as_standard_layout()
+        .into_owned()
+        .into_shape_with_order(ndarray::IxDyn(&output_shape_vec))
+        .map_err(|e| DsperseError::Pipeline(format!("{slice_id}: dim-split reshape: {e}")))?;
+
+    tracing::info!(
+        slice = %slice_id,
+        groups = ds.num_groups,
+        split_kind = ?ds.split_kind,
+        "executed dim-split (generic)"
+    );
+
+    Ok(final_result)
+}
+
+fn resolve_output_shape(
+    slice_id: &str,
+    input_shape: &[usize],
+    n_dim: usize,
+    target_shape: Option<&[i64]>,
+) -> Result<Vec<usize>> {
+    if let Some(target) = target_shape {
+        target
+            .iter()
+            .map(|&d| {
+                usize::try_from(d).map_err(|_| {
+                    DsperseError::Pipeline(format!(
+                        "{slice_id}: invalid target dimension {d} in dim-split reshape"
+                    ))
+                })
+            })
+            .collect::<Result<Vec<_>>>()
+    } else {
+        let mut s = input_shape.to_vec();
+        if let Some(last) = s.last_mut() {
+            *last = n_dim;
+        }
+        Ok(s)
+    }
 }

--- a/crates/dsperse/src/pipeline/strategy.rs
+++ b/crates/dsperse/src/pipeline/strategy.rs
@@ -27,12 +27,20 @@ impl<'a> ExecutionStrategy<'a> {
             Some(SplitStrategy::ChannelSplit(cs)) => Ok(Self::ChannelSplit(cs)),
             Some(SplitStrategy::DimSplit(ds)) => {
                 if ds.template_path.is_none() {
-                    return Err(DsperseError::Metadata(format!(
-                        "dim_split present but template_path is missing (slice path: {:?})",
-                        meta.path
-                    )));
+                    // Template creation may have been rejected (axis-
+                    // separability, unsupported split kind) or the template
+                    // was not included in the bundle. Fall back to monolithic
+                    // ORT execution so already-published bundles with
+                    // template-less dim_split metadata remain runnable.
+                    tracing::debug!(
+                        path = ?meta.path,
+                        split_kind = ?ds.split_kind,
+                        "dim_split template_path missing, falling back to single execution"
+                    );
+                    Ok(Self::Single { use_circuit })
+                } else {
+                    Ok(Self::DimSplit(ds))
                 }
-                Ok(Self::DimSplit(ds))
             }
             Some(SplitStrategy::Tiled(t)) => Ok(Self::Tiled(t)),
             None => Ok(Self::Single { use_circuit }),

--- a/crates/dsperse/src/pipeline/strategy.rs
+++ b/crates/dsperse/src/pipeline/strategy.rs
@@ -29,9 +29,11 @@ impl<'a> ExecutionStrategy<'a> {
                 if ds.template_path.is_none() {
                     // Template creation may have been rejected (axis-
                     // separability, unsupported split kind) or the template
-                    // was not included in the bundle. Fall back to monolithic
-                    // ORT execution so already-published bundles with
-                    // template-less dim_split metadata remain runnable.
+                    // was not included in the bundle. Fall back to the
+                    // non-template Single execution path (which may still
+                    // use circuit-based witness generation if use_circuit is
+                    // set) so already-published bundles with template-less
+                    // dim_split metadata remain runnable.
                     tracing::debug!(
                         path = ?meta.path,
                         split_kind = ?ds.split_kind,

--- a/crates/dsperse/src/schema/tiling.rs
+++ b/crates/dsperse/src/schema/tiling.rs
@@ -199,6 +199,40 @@ pub struct DimSplitInfo {
     pub jstprove_circuit_path: Option<String>,
 }
 
+impl DimSplitInfo {
+    pub fn from_detection(
+        d: &crate::slicer::autotiler::DimSplitDetection,
+        slice_idx: usize,
+        template_path: Option<String>,
+    ) -> Self {
+        let estimated_group_constraints = if d.k_chunks > 1 {
+            (d.k_dim.div_ceil(d.k_chunks) * d.n_dim * 2) as u64
+        } else if d.num_groups > 0 {
+            d.estimated_constraints / d.num_groups as u64
+        } else {
+            d.estimated_constraints
+        };
+        Self {
+            slice_idx,
+            split_kind: d.split_kind.clone(),
+            split_dim: d.split_dim,
+            dim_size: d.dim_size,
+            num_groups: d.num_groups,
+            elements_per_group: d.elements_per_group,
+            input_name: d.input_name.clone(),
+            output_name: d.output_name.clone(),
+            concat_axis: d.concat_axis,
+            estimated_group_constraints,
+            weight_name: d.weight_name.clone(),
+            k_dim: d.k_dim,
+            n_dim: d.n_dim,
+            k_chunks: d.k_chunks,
+            template_path,
+            jstprove_circuit_path: None,
+        }
+    }
+}
+
 fn default_input_name() -> String {
     "input".to_string()
 }

--- a/crates/dsperse/src/slicer/analyzer.rs
+++ b/crates/dsperse/src/slicer/analyzer.rs
@@ -186,20 +186,41 @@ pub fn get_segment_dependencies(
         .collect();
     sorted_nodes.sort_by_key(|n| n.index);
 
+    let mut consumed_in_segment: HashSet<String> = HashSet::new();
     for node in &sorted_nodes {
         for out in &node.dependencies.output {
             output_map.insert(out.clone(), true);
         }
         for inp in &node.dependencies.input {
+            if output_map.contains_key(inp) {
+                consumed_in_segment.insert(inp.clone());
+            }
             if !output_map.contains_key(inp) && !inputs.contains(inp) {
                 inputs.push(inp.clone());
             }
         }
     }
 
+    let model_output_set: HashSet<&str> =
+        analysis.output_names.iter().map(|s| s.as_str()).collect();
+
     let mut outputs: Vec<String> = output_map
         .keys()
-        .filter(|output| !inputs.contains(output))
+        .filter(|output| {
+            if inputs.contains(output) {
+                return false;
+            }
+            // Exclude tensors consumed by a later node in the same segment
+            // unless they are also model-level final outputs. The materializer
+            // only promotes internally-consumed tensors to graph outputs when
+            // a downstream segment needs them; the metadata list must match.
+            if consumed_in_segment.contains(output.as_str())
+                && !model_output_set.contains(output.as_str())
+            {
+                return false;
+            }
+            true
+        })
         .cloned()
         .collect();
     outputs.sort();

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -1843,6 +1843,69 @@ fn create_matmul_dim_template(
     Ok(tmpl_path)
 }
 
+fn check_axis_separable(graph: &GraphProto, split_dim: usize, slice_idx: usize) -> Result<()> {
+    for node in &graph.node {
+        match node.op_type.as_str() {
+            "Reshape" | "Flatten" => {
+                return Err(crate::error::DsperseError::Slicer(format!(
+                    "create_generic_dim_template: slice {slice_idx} contains {} which embeds \
+                     tensor layout and is not axis-separable at dim {split_dim}",
+                    node.op_type
+                )));
+            }
+            "Softmax" | "LogSoftmax" => {
+                let axis = onnx_proto::get_attribute_int(node, "axis").unwrap_or(-1);
+                let ndim = graph
+                    .input
+                    .first()
+                    .and_then(onnx_proto::shape_from_value_info)
+                    .map(|s| s.len() as i64)
+                    .unwrap_or(4);
+                let resolved = if axis < 0 {
+                    (ndim + axis) as usize
+                } else {
+                    axis as usize
+                };
+                if resolved == split_dim {
+                    return Err(crate::error::DsperseError::Slicer(format!(
+                        "create_generic_dim_template: slice {slice_idx} {} axis {resolved} \
+                         equals split_dim {split_dim}; normalization spans the split dimension",
+                        node.op_type
+                    )));
+                }
+            }
+            "LayerNormalization" => {
+                let axis = onnx_proto::get_attribute_int(node, "axis").unwrap_or(-1);
+                let ndim = graph
+                    .input
+                    .first()
+                    .and_then(onnx_proto::shape_from_value_info)
+                    .map(|s| s.len() as i64)
+                    .unwrap_or(4);
+                let resolved = if axis < 0 {
+                    (ndim + axis) as usize
+                } else {
+                    axis as usize
+                };
+                if resolved <= split_dim {
+                    return Err(crate::error::DsperseError::Slicer(format!(
+                        "create_generic_dim_template: slice {slice_idx} LayerNormalization axis \
+                         {resolved} <= split_dim {split_dim}; normalization spans the split dimension",
+                    )));
+                }
+            }
+            "BatchNormalization" if split_dim == 0 => {
+                return Err(crate::error::DsperseError::Slicer(format!(
+                    "create_generic_dim_template: slice {slice_idx} BatchNormalization requires \
+                     full batch statistics; cannot split at dim 0"
+                )));
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
 fn create_generic_dim_template(
     model: &ModelProto,
     graph: &GraphProto,
@@ -1857,6 +1920,8 @@ fn create_generic_dim_template(
             info.slice_idx
         )));
     }
+
+    check_axis_separable(graph, split_dim, info.slice_idx)?;
 
     let init_names: std::collections::HashSet<&str> =
         graph.initializer.iter().map(|i| i.name.as_str()).collect();

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -1862,10 +1862,10 @@ fn check_axis_separable(graph: &GraphProto, split_dim: usize, slice_idx: usize) 
         match node.op_type.as_str() {
             "Flatten" => {
                 let axis = resolve_axis(onnx_proto::get_attribute_int(node, "axis").unwrap_or(1));
-                if axis <= split_dim {
+                if split_dim < axis {
                     return Err(crate::error::DsperseError::Slicer(format!(
                         "create_generic_dim_template: slice {slice_idx} Flatten axis \
-                         {axis} <= split_dim {split_dim}; flattening merges the split dimension"
+                         {axis} > split_dim {split_dim}; split dimension falls in the merged leading group"
                     )));
                 }
             }
@@ -1944,6 +1944,17 @@ fn create_generic_dim_template(
             rewrite(vi);
         }
     }
+    // If output_name is declared in value_info but not graph.output,
+    // promote it so ORT actually produces the tensor at runtime.
+    if !tmpl_graph.output.iter().any(|o| o.name == info.output_name)
+        && let Some(vi) = tmpl_graph
+            .value_info
+            .iter()
+            .find(|v| v.name == info.output_name)
+            .cloned()
+    {
+        tmpl_graph.output.push(vi);
+    }
     for vi in tmpl_graph.output.iter_mut() {
         rewrite(vi);
     }
@@ -1951,31 +1962,61 @@ fn create_generic_dim_template(
         rewrite(vi);
     }
 
-    // Rewrite Reshape shape constants that embed dim_size. The second input
-    // to Reshape is the target shape tensor — when it's an initializer we
-    // can replace dim_size with epg so the Reshape stays consistent with
-    // the rewritten I/O shapes.
+    // Rewrite Reshape shape constants at exactly the position corresponding
+    // to split_dim. For each Reshape node whose shape input is an
+    // initializer, find the index in the shape constant where the value
+    // equals dim_size AND whose position corresponds to split_dim in the
+    // Reshape's input tensor. This avoids corrupting other dimensions that
+    // coincidentally equal dim_size.
     let dim_size_i64 = info.dim_size as i64;
     let epg_i64 = epg as i64;
-    let reshape_shape_names: Vec<String> = tmpl_graph
+    let reshape_nodes: Vec<(String, usize)> = tmpl_graph
         .node
         .iter()
         .filter(|n| n.op_type == "Reshape")
-        .filter_map(|n| n.input.get(1).cloned())
-        .collect();
-    for init in tmpl_graph.initializer.iter_mut() {
-        if !reshape_shape_names.contains(&init.name) {
-            continue;
-        }
-        let shape_data = onnx_proto::tensor_to_i64(init);
-        if shape_data.contains(&dim_size_i64) {
-            let rewritten: Vec<i64> = shape_data
+        .filter_map(|n| {
+            let shape_name = n.input.get(1)?.clone();
+            // Resolve the input tensor's shape to find where split_dim maps
+            // in the output shape constant. Walk value_info, graph input, and
+            // traced shapes for the Reshape's first input.
+            let inp_name = n.input.first()?;
+            let inp_shape = tmpl_graph
+                .value_info
                 .iter()
-                .map(|&d| if d == dim_size_i64 { epg_i64 } else { d })
-                .collect();
-            init.int64_data = rewritten;
-            init.raw_data.clear();
-            init.data_type = TensorProto::INT64;
+                .chain(tmpl_graph.input.iter())
+                .find(|v| v.name == *inp_name)
+                .and_then(onnx_proto::shape_from_value_info);
+            // If we can resolve the input shape and split_dim is in range,
+            // the position to rewrite is split_dim itself (Reshape preserves
+            // dimension indices when the target shape has the same rank).
+            // For rank-changing Reshapes we still use split_dim as a best
+            // effort — the axis-separability check already rejected
+            // fundamentally non-separable layouts.
+            let pos = if let Some(ref s) = inp_shape {
+                if split_dim < s.len() {
+                    split_dim
+                } else {
+                    return None;
+                }
+            } else {
+                split_dim
+            };
+            Some((shape_name, pos))
+        })
+        .collect();
+    for (shape_name, pos) in &reshape_nodes {
+        if let Some(init) = tmpl_graph
+            .initializer
+            .iter_mut()
+            .find(|i| i.name == *shape_name)
+        {
+            let mut shape_data = onnx_proto::tensor_to_i64(init);
+            if *pos < shape_data.len() && shape_data[*pos] == dim_size_i64 {
+                shape_data[*pos] = epg_i64;
+                init.int64_data = shape_data;
+                init.raw_data.clear();
+                init.data_type = TensorProto::INT64;
+            }
         }
     }
 

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -1844,28 +1844,34 @@ fn create_matmul_dim_template(
 }
 
 fn check_axis_separable(graph: &GraphProto, split_dim: usize, slice_idx: usize) -> Result<()> {
+    let resolve_axis = |axis: i64| -> usize {
+        let ndim = graph
+            .input
+            .first()
+            .and_then(onnx_proto::shape_from_value_info)
+            .map(|s| s.len() as i64)
+            .unwrap_or(4);
+        if axis < 0 {
+            (ndim + axis) as usize
+        } else {
+            axis as usize
+        }
+    };
+
     for node in &graph.node {
         match node.op_type.as_str() {
-            "Reshape" | "Flatten" => {
-                return Err(crate::error::DsperseError::Slicer(format!(
-                    "create_generic_dim_template: slice {slice_idx} contains {} which embeds \
-                     tensor layout and is not axis-separable at dim {split_dim}",
-                    node.op_type
-                )));
+            "Flatten" => {
+                let axis = resolve_axis(onnx_proto::get_attribute_int(node, "axis").unwrap_or(1));
+                if axis <= split_dim {
+                    return Err(crate::error::DsperseError::Slicer(format!(
+                        "create_generic_dim_template: slice {slice_idx} Flatten axis \
+                         {axis} <= split_dim {split_dim}; flattening merges the split dimension"
+                    )));
+                }
             }
             "Softmax" | "LogSoftmax" => {
-                let axis = onnx_proto::get_attribute_int(node, "axis").unwrap_or(-1);
-                let ndim = graph
-                    .input
-                    .first()
-                    .and_then(onnx_proto::shape_from_value_info)
-                    .map(|s| s.len() as i64)
-                    .unwrap_or(4);
-                let resolved = if axis < 0 {
-                    (ndim + axis) as usize
-                } else {
-                    axis as usize
-                };
+                let resolved =
+                    resolve_axis(onnx_proto::get_attribute_int(node, "axis").unwrap_or(-1));
                 if resolved == split_dim {
                     return Err(crate::error::DsperseError::Slicer(format!(
                         "create_generic_dim_template: slice {slice_idx} {} axis {resolved} \
@@ -1875,18 +1881,8 @@ fn check_axis_separable(graph: &GraphProto, split_dim: usize, slice_idx: usize) 
                 }
             }
             "LayerNormalization" => {
-                let axis = onnx_proto::get_attribute_int(node, "axis").unwrap_or(-1);
-                let ndim = graph
-                    .input
-                    .first()
-                    .and_then(onnx_proto::shape_from_value_info)
-                    .map(|s| s.len() as i64)
-                    .unwrap_or(4);
-                let resolved = if axis < 0 {
-                    (ndim + axis) as usize
-                } else {
-                    axis as usize
-                };
+                let resolved =
+                    resolve_axis(onnx_proto::get_attribute_int(node, "axis").unwrap_or(-1));
                 if resolved <= split_dim {
                     return Err(crate::error::DsperseError::Slicer(format!(
                         "create_generic_dim_template: slice {slice_idx} LayerNormalization axis \
@@ -1953,6 +1949,34 @@ fn create_generic_dim_template(
     }
     for vi in tmpl_graph.value_info.iter_mut() {
         rewrite(vi);
+    }
+
+    // Rewrite Reshape shape constants that embed dim_size. The second input
+    // to Reshape is the target shape tensor — when it's an initializer we
+    // can replace dim_size with epg so the Reshape stays consistent with
+    // the rewritten I/O shapes.
+    let dim_size_i64 = info.dim_size as i64;
+    let epg_i64 = epg as i64;
+    let reshape_shape_names: Vec<String> = tmpl_graph
+        .node
+        .iter()
+        .filter(|n| n.op_type == "Reshape")
+        .filter_map(|n| n.input.get(1).cloned())
+        .collect();
+    for init in tmpl_graph.initializer.iter_mut() {
+        if !reshape_shape_names.contains(&init.name) {
+            continue;
+        }
+        let shape_data = onnx_proto::tensor_to_i64(init);
+        if shape_data.contains(&dim_size_i64) {
+            let rewritten: Vec<i64> = shape_data
+                .iter()
+                .map(|&d| if d == dim_size_i64 { epg_i64 } else { d })
+                .collect();
+            init.int64_data = rewritten;
+            init.raw_data.clear();
+            init.data_type = TensorProto::INT64;
+        }
     }
 
     let tmpl_path = output_dir.join("dim_template.onnx");

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
-use super::onnx_proto::{self, GraphProto, ModelProto, NodeProto, TensorProto};
+use super::onnx_proto::{self, GraphProto, ModelProto, NodeProto, TensorProto, ValueInfoProto};
 use crate::error::Result;
 use crate::schema::tiling::{ChannelGroupInfo, ChannelSplitInfo, DimSplitKind};
 
@@ -1699,10 +1699,7 @@ pub fn create_dim_split_template(
         }
         crate::schema::tiling::DimSplitKind::HeadDim
         | crate::schema::tiling::DimSplitKind::BatchDim => {
-            Err(crate::error::DsperseError::Slicer(format!(
-                "create_dim_split_template: {:?} split requires shape rewriting not yet supported for slice {}",
-                info.split_kind, info.slice_idx
-            )))
+            create_generic_dim_template(model, graph, info, output_dir)
         }
     }
 }
@@ -1840,6 +1837,58 @@ fn create_matmul_dim_template(
         initializers,
     );
     let tmpl_model = onnx_proto::make_model(graph_proto, model_opset(model));
+
+    let tmpl_path = output_dir.join("dim_template.onnx");
+    onnx_proto::save_model(&tmpl_model, &tmpl_path)?;
+    Ok(tmpl_path)
+}
+
+fn create_generic_dim_template(
+    model: &ModelProto,
+    graph: &GraphProto,
+    info: &crate::schema::tiling::DimSplitInfo,
+    output_dir: &Path,
+) -> Result<std::path::PathBuf> {
+    let split_dim = info.split_dim;
+    let epg = info.elements_per_group;
+    if epg == 0 {
+        return Err(crate::error::DsperseError::Slicer(format!(
+            "create_generic_dim_template: slice {} elements_per_group is 0",
+            info.slice_idx
+        )));
+    }
+
+    let init_names: std::collections::HashSet<&str> =
+        graph.initializer.iter().map(|i| i.name.as_str()).collect();
+
+    let mut tmpl_model = model.clone();
+    let tmpl_graph = tmpl_model.graph.as_mut().ok_or_else(|| {
+        crate::error::DsperseError::Slicer(
+            "create_generic_dim_template: cloned model has no graph".into(),
+        )
+    })?;
+
+    let rewrite = |vi: &mut ValueInfoProto| {
+        if let Some(mut shape) = onnx_proto::shape_from_value_info(vi)
+            && split_dim < shape.len()
+            && shape[split_dim] == info.dim_size as i64
+        {
+            shape[split_dim] = epg as i64;
+            onnx_proto::set_vi_shape(vi, &shape);
+        }
+    };
+
+    for vi in tmpl_graph.input.iter_mut() {
+        if !init_names.contains(vi.name.as_str()) {
+            rewrite(vi);
+        }
+    }
+    for vi in tmpl_graph.output.iter_mut() {
+        rewrite(vi);
+    }
+    for vi in tmpl_graph.value_info.iter_mut() {
+        rewrite(vi);
+    }
 
     let tmpl_path = output_dir.join("dim_template.onnx");
     onnx_proto::save_model(&tmpl_model, &tmpl_path)?;

--- a/crates/dsperse/src/slicer/onnx_slicer.rs
+++ b/crates/dsperse/src/slicer/onnx_slicer.rs
@@ -151,10 +151,11 @@ pub fn slice_model(
                         dim_split_info.insert(seg_idx, (detection, tmpl_rel));
                     }
                     Err(e) => {
-                        tracing::info!(
+                        tracing::warn!(
                             slice = seg_idx,
                             error = %e,
-                            "dim-split detected but template creation failed, skipping"
+                            "dim-split detected but template creation failed; \
+                             slice will compile and run as monolithic circuit"
                         );
                     }
                 }

--- a/crates/dsperse/src/slicer/onnx_slicer.rs
+++ b/crates/dsperse/src/slicer/onnx_slicer.rs
@@ -121,24 +121,7 @@ pub fn slice_model(
                 // Only record the detection if the template materializes
                 // successfully, so the metadata never carries dim_split
                 // entries that can't be fulfilled at runtime.
-                let tentative_info = crate::schema::tiling::DimSplitInfo {
-                    slice_idx: seg_idx,
-                    split_kind: detection.split_kind.clone(),
-                    split_dim: detection.split_dim,
-                    dim_size: detection.dim_size,
-                    num_groups: detection.num_groups,
-                    elements_per_group: detection.elements_per_group,
-                    input_name: detection.input_name.clone(),
-                    output_name: detection.output_name.clone(),
-                    concat_axis: detection.concat_axis,
-                    estimated_group_constraints: 0,
-                    weight_name: detection.weight_name.clone(),
-                    k_dim: detection.k_dim,
-                    n_dim: detection.n_dim,
-                    k_chunks: detection.k_chunks,
-                    template_path: None,
-                    jstprove_circuit_path: None,
-                };
+                let tentative_info = DimSplitInfo::from_detection(&detection, seg_idx, None);
                 let slice_dir = output_dir.join(format!("slice_{seg_idx}")).join("payload");
                 std::fs::create_dir_all(&slice_dir).map_err(|e| DsperseError::io(e, &slice_dir))?;
                 match autotiler::create_dim_split_template(
@@ -350,30 +333,7 @@ fn build_slice_metadata(
 
         let dim_split = dim_split_info
             .get(&seg_idx)
-            .map(|(d, tmpl_rel)| DimSplitInfo {
-                slice_idx: seg_idx,
-                split_kind: d.split_kind.clone(),
-                split_dim: d.split_dim,
-                dim_size: d.dim_size,
-                num_groups: d.num_groups,
-                elements_per_group: d.elements_per_group,
-                input_name: d.input_name.clone(),
-                output_name: d.output_name.clone(),
-                concat_axis: d.concat_axis,
-                estimated_group_constraints: if d.k_chunks > 1 {
-                    (d.k_dim.div_ceil(d.k_chunks) * d.n_dim * 2) as u64
-                } else if d.num_groups > 0 {
-                    d.estimated_constraints / d.num_groups as u64
-                } else {
-                    d.estimated_constraints
-                },
-                weight_name: d.weight_name.clone(),
-                k_dim: d.k_dim,
-                n_dim: d.n_dim,
-                k_chunks: d.k_chunks,
-                template_path: Some(tmpl_rel.clone()),
-                jstprove_circuit_path: None,
-            });
+            .map(|(d, tmpl_rel)| DimSplitInfo::from_detection(d, seg_idx, Some(tmpl_rel.clone())));
 
         slices.push(SliceMetadata {
             index: seg_idx,

--- a/crates/dsperse/src/slicer/onnx_slicer.rs
+++ b/crates/dsperse/src/slicer/onnx_slicer.rs
@@ -81,7 +81,7 @@ pub fn slice_model(
     let trimmed_points = &slice_points[..slice_points.len().saturating_sub(1)];
 
     let mut tiled_info = HashMap::new();
-    let mut dim_split_info: HashMap<usize, autotiler::DimSplitDetection> = HashMap::new();
+    let mut dim_split_info: HashMap<usize, (autotiler::DimSplitDetection, String)> = HashMap::new();
     for (seg_idx, _) in segment_ranges.iter().enumerate() {
         let slice_model =
             materializer::materialize_slice_model(&model, trimmed_points, &traced_shapes, seg_idx)?;
@@ -146,7 +146,12 @@ pub fn slice_model(
                     &tentative_info,
                     &slice_dir,
                 ) {
-                    Ok(_) => {
+                    Ok(tmpl_path) => {
+                        let tmpl_rel = tmpl_path
+                            .strip_prefix(&output_dir)
+                            .unwrap_or(&tmpl_path)
+                            .to_string_lossy()
+                            .into_owned();
                         tracing::info!(
                             slice = seg_idx,
                             estimated = detection.estimated_constraints,
@@ -154,7 +159,7 @@ pub fn slice_model(
                             split_kind = ?detection.split_kind,
                             "dim-split detected and template created"
                         );
-                        dim_split_info.insert(seg_idx, detection);
+                        dim_split_info.insert(seg_idx, (detection, tmpl_rel));
                     }
                     Err(e) => {
                         tracing::info!(
@@ -211,7 +216,7 @@ fn build_slice_metadata(
     segment_ranges: &[(usize, usize)],
     traced_shapes: &HashMap<String, Vec<i64>>,
     tiled_info: &HashMap<usize, autotiler::TilingDetection>,
-    dim_split_info: &HashMap<usize, autotiler::DimSplitDetection>,
+    dim_split_info: &HashMap<usize, (autotiler::DimSplitDetection, String)>,
 ) -> Vec<SliceMetadata> {
     let mut slices = Vec::new();
 
@@ -337,30 +342,32 @@ fn build_slice_metadata(
             }
         }
 
-        let dim_split = dim_split_info.get(&seg_idx).map(|d| DimSplitInfo {
-            slice_idx: seg_idx,
-            split_kind: d.split_kind.clone(),
-            split_dim: d.split_dim,
-            dim_size: d.dim_size,
-            num_groups: d.num_groups,
-            elements_per_group: d.elements_per_group,
-            input_name: d.input_name.clone(),
-            output_name: d.output_name.clone(),
-            concat_axis: d.concat_axis,
-            estimated_group_constraints: if d.k_chunks > 1 {
-                (d.k_dim.div_ceil(d.k_chunks) * d.n_dim * 2) as u64
-            } else if d.num_groups > 0 {
-                d.estimated_constraints / d.num_groups as u64
-            } else {
-                d.estimated_constraints
-            },
-            weight_name: d.weight_name.clone(),
-            k_dim: d.k_dim,
-            n_dim: d.n_dim,
-            k_chunks: d.k_chunks,
-            template_path: Some(format!("slice_{seg_idx}/payload/dim_template.onnx")),
-            jstprove_circuit_path: None,
-        });
+        let dim_split = dim_split_info
+            .get(&seg_idx)
+            .map(|(d, tmpl_rel)| DimSplitInfo {
+                slice_idx: seg_idx,
+                split_kind: d.split_kind.clone(),
+                split_dim: d.split_dim,
+                dim_size: d.dim_size,
+                num_groups: d.num_groups,
+                elements_per_group: d.elements_per_group,
+                input_name: d.input_name.clone(),
+                output_name: d.output_name.clone(),
+                concat_axis: d.concat_axis,
+                estimated_group_constraints: if d.k_chunks > 1 {
+                    (d.k_dim.div_ceil(d.k_chunks) * d.n_dim * 2) as u64
+                } else if d.num_groups > 0 {
+                    d.estimated_constraints / d.num_groups as u64
+                } else {
+                    d.estimated_constraints
+                },
+                weight_name: d.weight_name.clone(),
+                k_dim: d.k_dim,
+                n_dim: d.n_dim,
+                k_chunks: d.k_chunks,
+                template_path: Some(tmpl_rel.clone()),
+                jstprove_circuit_path: None,
+            });
 
         slices.push(SliceMetadata {
             index: seg_idx,

--- a/crates/dsperse/src/slicer/onnx_slicer.rs
+++ b/crates/dsperse/src/slicer/onnx_slicer.rs
@@ -149,7 +149,13 @@ pub fn slice_model(
                     Ok(tmpl_path) => {
                         let tmpl_rel = tmpl_path
                             .strip_prefix(&output_dir)
-                            .unwrap_or(&tmpl_path)
+                            .map_err(|_| {
+                                DsperseError::Slicer(format!(
+                                    "dim-split template path {} is not under output dir {}",
+                                    tmpl_path.display(),
+                                    output_dir.display()
+                                ))
+                            })?
                             .to_string_lossy()
                             .into_owned();
                         tracing::info!(

--- a/crates/dsperse/src/slicer/onnx_slicer.rs
+++ b/crates/dsperse/src/slicer/onnx_slicer.rs
@@ -117,14 +117,53 @@ pub fn slice_model(
             if let Some(detection) =
                 autotiler::detect_dim_split(&graph.node, &slice_shapes, &init_names)
             {
-                tracing::info!(
-                    slice = seg_idx,
-                    estimated = detection.estimated_constraints,
-                    num_groups = detection.num_groups,
-                    split_kind = ?detection.split_kind,
-                    "dim-split detected"
-                );
-                dim_split_info.insert(seg_idx, detection);
+                // Build a tentative DimSplitInfo to attempt template creation.
+                // Only record the detection if the template materializes
+                // successfully, so the metadata never carries dim_split
+                // entries that can't be fulfilled at runtime.
+                let tentative_info = crate::schema::tiling::DimSplitInfo {
+                    slice_idx: seg_idx,
+                    split_kind: detection.split_kind.clone(),
+                    split_dim: detection.split_dim,
+                    dim_size: detection.dim_size,
+                    num_groups: detection.num_groups,
+                    elements_per_group: detection.elements_per_group,
+                    input_name: detection.input_name.clone(),
+                    output_name: detection.output_name.clone(),
+                    concat_axis: detection.concat_axis,
+                    estimated_group_constraints: 0,
+                    weight_name: detection.weight_name.clone(),
+                    k_dim: detection.k_dim,
+                    n_dim: detection.n_dim,
+                    k_chunks: detection.k_chunks,
+                    template_path: None,
+                    jstprove_circuit_path: None,
+                };
+                let slice_dir = output_dir.join(format!("slice_{seg_idx}")).join("payload");
+                std::fs::create_dir_all(&slice_dir).map_err(|e| DsperseError::io(e, &slice_dir))?;
+                match autotiler::create_dim_split_template(
+                    &slice_model,
+                    &tentative_info,
+                    &slice_dir,
+                ) {
+                    Ok(_) => {
+                        tracing::info!(
+                            slice = seg_idx,
+                            estimated = detection.estimated_constraints,
+                            num_groups = detection.num_groups,
+                            split_kind = ?detection.split_kind,
+                            "dim-split detected and template created"
+                        );
+                        dim_split_info.insert(seg_idx, detection);
+                    }
+                    Err(e) => {
+                        tracing::info!(
+                            slice = seg_idx,
+                            error = %e,
+                            "dim-split detected but template creation failed, skipping"
+                        );
+                    }
+                }
             }
         }
     }
@@ -319,7 +358,7 @@ fn build_slice_metadata(
             k_dim: d.k_dim,
             n_dim: d.n_dim,
             k_chunks: d.k_chunks,
-            template_path: None,
+            template_path: Some(format!("slice_{seg_idx}/payload/dim_template.onnx")),
             jstprove_circuit_path: None,
         });
 


### PR DESCRIPTION
## Summary

- Implement create_generic_dim_template for HeadDim and BatchDim split kinds. Clones the slice model and rewrites I/O shape declarations at split_dim from dim_size to elements_per_group. Replaces the error that previously rejected these split kinds.
- Branch execute_dim_split on split_kind: MatMulOutputDim uses sequence-tiled K-chunked path, HeadDim/BatchDim use a generic slice-along-dim path (iterate groups, slice input, run template, pad/trim, concatenate).
- Resolve get_segment_dependencies overcounting segment-internal intermediates as outputs. The materializer correctly excluded these from ONNX graph outputs, creating a mismatch that caused missing declared output at runtime.

## Test plan

- [x] cargo clippy / cargo fmt / cargo test (213 passing)
- [ ] Re-slice + run rf-detr-nano to verify combined and per-slice paths
- [ ] Numerical fidelity comparison

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support HeadDim/BatchDim dim-splits with generic template generation, axis-separability checks, and Reshape-target rewriting.
  * New constructor to build dim-split metadata (including template path) with improved group-constraint estimation.

* **Refactor**
  * Dim-split execution split into an optimized matmul path and a generic path with shared output-shape resolution and clearer tracing.

* **Bug Fixes**
  * Exclude tensors consumed later in a segment from segment outputs.
  * Record dim-split detections only when a template is materialized.

* **Chores**
  * Strip unmaterialized dim-split metadata and fall back to single execution when no template exists.
  * Updated pinned revision of a build dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->