### PR TITLE
Resolve Loop subgraph shape and type propagation

### DIFF
--- a/crates/dsperse/benches/serialization.rs
+++ b/crates/dsperse/benches/serialization.rs
@@ -53,6 +53,7 @@ fn make_model_metadata(num_slices: usize) -> ModelMetadata {
         jstprove_version: Some("0.1.0".into()),
         jstprove_rev: Some("def5678".into()),
         traced_shapes: None,
+        traced_types: None,
         original_model_path: None,
         folded_constant_names: vec![],
     }

--- a/crates/dsperse/src/pipeline/packager.rs
+++ b/crates/dsperse/src/pipeline/packager.rs
@@ -639,6 +639,7 @@ mod tests {
             jstprove_version: Some("0.1.0-test".to_string()),
             jstprove_rev: None,
             traced_shapes: None,
+            traced_types: None,
             original_model_path: None,
             folded_constant_names: vec![],
         };
@@ -1000,6 +1001,7 @@ mod tests {
             jstprove_version: None,
             jstprove_rev: None,
             traced_shapes: None,
+            traced_types: None,
             original_model_path: None,
             folded_constant_names: vec![],
         };
@@ -1201,6 +1203,7 @@ mod tests {
             jstprove_version: None,
             jstprove_rev: None,
             traced_shapes: None,
+            traced_types: None,
             original_model_path: None,
             folded_constant_names: vec![],
         };
@@ -1278,6 +1281,7 @@ mod tests {
             jstprove_version: None,
             jstprove_rev: None,
             traced_shapes: None,
+            traced_types: None,
             original_model_path: None,
             folded_constant_names: vec![],
         };
@@ -1355,6 +1359,7 @@ mod tests {
             jstprove_version: None,
             jstprove_rev: None,
             traced_shapes: None,
+            traced_types: None,
             original_model_path: None,
             folded_constant_names: vec![],
         };
@@ -1425,6 +1430,7 @@ mod tests {
             jstprove_version: None,
             jstprove_rev: None,
             traced_shapes: None,
+            traced_types: None,
             original_model_path: None,
             folded_constant_names: vec![],
         };
@@ -1521,6 +1527,7 @@ mod tests {
             jstprove_version: None,
             jstprove_rev: None,
             traced_shapes: None,
+            traced_types: None,
             original_model_path: None,
             folded_constant_names: vec![],
         };
@@ -1608,6 +1615,7 @@ mod tests {
             jstprove_version: None,
             jstprove_rev: None,
             traced_shapes: None,
+            traced_types: None,
             original_model_path: None,
             folded_constant_names: vec![],
         };

--- a/crates/dsperse/src/schema/metadata.rs
+++ b/crates/dsperse/src/schema/metadata.rs
@@ -79,7 +79,7 @@ pub struct SliceShapeWrapper {
     pub tensor_shape: TensorShape,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SliceMetadata {
     #[serde(default)]
     pub index: usize,
@@ -202,6 +202,8 @@ pub struct ModelMetadata {
     pub jstprove_rev: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub traced_shapes: Option<HashMap<String, Vec<i64>>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub traced_types: Option<HashMap<String, i32>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub original_model_path: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/crates/dsperse/src/slicer/combiner.rs
+++ b/crates/dsperse/src/slicer/combiner.rs
@@ -1,7 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
-use super::materializer::build_node_output_types;
 use super::onnx_proto::{self, ModelProto, TensorProto, ValueInfoProto};
 use crate::error::{DsperseError, Result};
 use crate::schema::metadata::ModelMetadata;
@@ -10,6 +9,7 @@ pub fn materialize_combined_model(
     model: &ModelProto,
     metadata: &ModelMetadata,
     traced_shapes: &HashMap<String, Vec<i64>>,
+    traced_types: Option<&HashMap<String, i32>>,
 ) -> Result<ModelProto> {
     let mut combined = model.clone();
     let graph = combined
@@ -30,12 +30,6 @@ pub fn materialize_combined_model(
 
     {
         let vi_map = onnx_proto::build_value_info_map(graph);
-        let init_types: HashMap<&str, i32> = graph
-            .initializer
-            .iter()
-            .map(|i| (i.name.as_str(), i.data_type))
-            .collect();
-        let node_output_types = build_node_output_types(graph);
 
         for slice in &metadata.slices {
             for output_name in &slice.dependencies.output {
@@ -51,13 +45,9 @@ pub fn materialize_combined_model(
                     continue;
                 }
 
-                if let Some(vi) = resolve_value_info(
-                    output_name,
-                    &vi_map,
-                    traced_shapes,
-                    &init_types,
-                    &node_output_types,
-                )? {
+                if let Some(vi) =
+                    resolve_value_info(output_name, &vi_map, traced_shapes, traced_types)?
+                {
                     new_outputs.push(vi);
                     added.insert(output_name.clone());
                 }
@@ -76,13 +66,9 @@ pub fn materialize_combined_model(
                     continue;
                 }
 
-                if let Some(vi) = resolve_value_info(
-                    input_name,
-                    &vi_map,
-                    traced_shapes,
-                    &init_types,
-                    &node_output_types,
-                )? {
+                if let Some(vi) =
+                    resolve_value_info(input_name, &vi_map, traced_shapes, traced_types)?
+                {
                     new_outputs.push(vi);
                     added.insert(input_name.clone());
                 }
@@ -108,8 +94,7 @@ fn resolve_value_info(
     name: &str,
     vi_map: &HashMap<String, &ValueInfoProto>,
     traced_shapes: &HashMap<String, Vec<i64>>,
-    init_types: &HashMap<&str, i32>,
-    node_output_types: &HashMap<String, i32>,
+    traced_types: Option<&HashMap<String, i32>>,
 ) -> Result<Option<ValueInfoProto>> {
     if let Some(vi) = vi_map.get(name) {
         let elem_type = onnx_proto::elem_type_from_value_info(vi).unwrap_or(TensorProto::FLOAT);
@@ -125,10 +110,8 @@ fn resolve_value_info(
         ))
     })?;
 
-    let elem_type = init_types
-        .get(name)
-        .copied()
-        .or_else(|| node_output_types.get(name).copied())
+    let elem_type = traced_types
+        .and_then(|t| t.get(name).copied())
         .unwrap_or(TensorProto::FLOAT);
 
     if NON_NUMERIC_TENSOR_TYPES.contains(&elem_type) {
@@ -138,35 +121,6 @@ fn resolve_value_info(
     Ok(Some(onnx_proto::make_tensor_value_info(
         name, elem_type, shape,
     )))
-}
-
-pub fn materialize_combined_to_disk(
-    slices_dir: &Path,
-    metadata: &ModelMetadata,
-) -> Result<PathBuf> {
-    let traced_shapes = metadata.traced_shapes.as_ref().ok_or_else(|| {
-        DsperseError::Slicer("metadata missing traced_shapes for combined model".into())
-    })?;
-    let original_path = metadata.original_model_path.as_ref().ok_or_else(|| {
-        DsperseError::Slicer("metadata missing original_model_path for combined model".into())
-    })?;
-
-    let model_path = if Path::new(original_path).is_absolute() {
-        PathBuf::from(original_path)
-    } else {
-        slices_dir.join(original_path)
-    };
-
-    let mut model = onnx_proto::load_model(&model_path)?;
-    onnx_proto::normalize_opset(&mut model);
-    let combined = materialize_combined_model(&model, metadata, traced_shapes)?;
-
-    let output_path = slices_dir.join("combined.onnx");
-    onnx_proto::save_model(&combined, &output_path)?;
-
-    tracing::info!(path = %output_path.display(), "materialized combined ONNX");
-
-    Ok(output_path)
 }
 
 pub fn ensure_combined_materialized(
@@ -180,116 +134,107 @@ pub fn ensure_combined_materialized(
     materialize_combined_to_disk(slices_dir, metadata)
 }
 
+pub fn materialize_combined_to_disk(
+    slices_dir: &Path,
+    metadata: &ModelMetadata,
+) -> Result<PathBuf> {
+    let traced_shapes = metadata.traced_shapes.as_ref().ok_or_else(|| {
+        DsperseError::Slicer("metadata missing traced_shapes for combined model".into())
+    })?;
+    let traced_types = metadata.traced_types.as_ref();
+    let original_path = metadata.original_model_path.as_ref().ok_or_else(|| {
+        DsperseError::Slicer("metadata missing original_model_path for combined model".into())
+    })?;
+
+    let model_path = if Path::new(original_path).is_absolute() {
+        std::path::PathBuf::from(original_path)
+    } else {
+        slices_dir.join(original_path)
+    };
+
+    let mut model = onnx_proto::load_model(&model_path)?;
+    onnx_proto::normalize_opset(&mut model);
+
+    let combined = materialize_combined_model(&model, metadata, traced_shapes, traced_types)?;
+
+    let dest = slices_dir.join("combined.onnx");
+    onnx_proto::save_model(&combined, &dest)?;
+    tracing::info!(path = %dest.display(), "materialized combined ONNX");
+
+    Ok(dest)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::schema::metadata::{
+        Dependencies, ModelMetadata, SliceMetadata, SliceShapeWrapper, TensorShape,
+    };
 
-    const TEST_OPS: &[&str] = &["Conv", "Gemm", "MatMul"];
+    fn make_test_model(
+        node_output_types: HashMap<String, i32>,
+        traced_shapes: HashMap<String, Vec<i64>>,
+    ) -> (ModelProto, ModelMetadata) {
+        let graph = onnx_proto::GraphProto {
+            node: vec![onnx_proto::NodeProto {
+                op_type: "Identity".to_string(),
+                input: vec!["input".to_string()],
+                output: vec![
+                    "float_tensor".to_string(),
+                    "bool_tensor".to_string(),
+                    "string_tensor".to_string(),
+                    "int_tensor".to_string(),
+                ],
+                ..Default::default()
+            }],
+            input: vec![onnx_proto::make_tensor_value_info(
+                "input",
+                TensorProto::FLOAT,
+                &[1, 3, 8, 8],
+            )],
+            output: vec![onnx_proto::make_tensor_value_info(
+                "model_output",
+                TensorProto::FLOAT,
+                &[1, 3, 8, 8],
+            )],
+            ..Default::default()
+        };
+        let model = onnx_proto::make_model(graph, 13);
 
-    #[test]
-    fn combined_model_has_intermediate_outputs() {
-        let models_dir = std::path::PathBuf::from(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../tests/models/net"
-        ));
-        let model_path = models_dir.join("model.onnx");
-        if !model_path.exists() {
-            return;
-        }
-        let tmp = tempfile::tempdir().unwrap();
-        let meta = crate::slicer::slice_model(&model_path, Some(tmp.path()), None, TEST_OPS, None)
-            .unwrap();
+        let metadata = ModelMetadata {
+            slices: vec![SliceMetadata {
+                index: 0,
+                filename: "s0.onnx".to_string(),
+                path: "s0.onnx".to_string(),
+                relative_path: "s0.onnx".to_string(),
+                shape: SliceShapeWrapper {
+                    tensor_shape: TensorShape {
+                        input: vec![],
+                        output: vec![],
+                    },
+                },
+                dependencies: Dependencies {
+                    input: vec![],
+                    filtered_inputs: vec![],
+                    output: vec![
+                        "float_tensor".to_string(),
+                        "bool_tensor".to_string(),
+                        "string_tensor".to_string(),
+                        "int_tensor".to_string(),
+                    ],
+                },
+                ..Default::default()
+            }],
+            traced_shapes: Some(traced_shapes.clone()),
+            traced_types: Some(node_output_types),
+            ..Default::default()
+        };
 
-        if meta.slices.len() <= 1 {
-            return;
-        }
-
-        let traced = meta.traced_shapes.as_ref().unwrap();
-        let model = onnx_proto::load_model(&tmp.path().join("model.onnx")).unwrap();
-        let original_output_count = model.graph.as_ref().unwrap().output.len();
-
-        let combined = materialize_combined_model(&model, &meta, traced).unwrap();
-        let combined_output_count = combined.graph.as_ref().unwrap().output.len();
-
-        assert!(
-            combined_output_count > original_output_count,
-            "combined model should have more outputs than original: {combined_output_count} vs {original_output_count}"
-        );
-
-        let output_names: HashSet<String> = combined
-            .graph
-            .as_ref()
-            .unwrap()
-            .output
-            .iter()
-            .map(|o| o.name.clone())
-            .collect();
-
-        for slice in &meta.slices {
-            for out in &slice.dependencies.output {
-                let node_produces = combined
-                    .graph
-                    .as_ref()
-                    .unwrap()
-                    .node
-                    .iter()
-                    .any(|n| n.output.contains(out));
-                if node_produces {
-                    assert!(
-                        output_names.contains(out),
-                        "slice {} output '{out}' should be in combined model outputs",
-                        slice.index
-                    );
-                }
-            }
-        }
-    }
-
-    #[test]
-    fn combined_model_to_disk_roundtrip() {
-        let models_dir = std::path::PathBuf::from(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../tests/models/net"
-        ));
-        let model_path = models_dir.join("model.onnx");
-        if !model_path.exists() {
-            return;
-        }
-        let tmp = tempfile::tempdir().unwrap();
-        let meta = crate::slicer::slice_model(&model_path, Some(tmp.path()), None, TEST_OPS, None)
-            .unwrap();
-
-        let combined_path = materialize_combined_to_disk(tmp.path(), &meta).unwrap();
-        assert!(combined_path.exists());
-
-        let reloaded = onnx_proto::load_model(&combined_path).unwrap();
-        assert!(reloaded.graph.is_some());
-    }
-
-    #[test]
-    fn ensure_combined_is_idempotent() {
-        let models_dir = std::path::PathBuf::from(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../tests/models/net"
-        ));
-        let model_path = models_dir.join("model.onnx");
-        if !model_path.exists() {
-            return;
-        }
-        let tmp = tempfile::tempdir().unwrap();
-        let meta = crate::slicer::slice_model(&model_path, Some(tmp.path()), None, TEST_OPS, None)
-            .unwrap();
-
-        let p1 = ensure_combined_materialized(tmp.path(), &meta).unwrap();
-        let p2 = ensure_combined_materialized(tmp.path(), &meta).unwrap();
-        assert_eq!(p1, p2);
+        (model, metadata)
     }
 
     #[test]
     fn bool_outputs_included_in_combined_model() {
-        let vi_map: HashMap<String, &ValueInfoProto> = HashMap::new();
-        let init_types: HashMap<&str, i32> = HashMap::new();
-
         let mut node_output_types = HashMap::new();
         node_output_types.insert("float_tensor".to_string(), TensorProto::FLOAT);
         node_output_types.insert("bool_tensor".to_string(), TensorProto::BOOL);
@@ -299,47 +244,119 @@ mod tests {
         let mut traced_shapes = HashMap::new();
         traced_shapes.insert("float_tensor".to_string(), vec![1, 3, 8, 8]);
         traced_shapes.insert("bool_tensor".to_string(), vec![1, 3, 8, 8]);
-        traced_shapes.insert("string_tensor".to_string(), vec![4]);
-        traced_shapes.insert("int_tensor".to_string(), vec![1, 300]);
+        traced_shapes.insert("string_tensor".to_string(), vec![1, 3, 8, 8]);
+        traced_shapes.insert("int_tensor".to_string(), vec![1, 3, 8, 8]);
 
-        let float_vi = resolve_value_info(
-            "float_tensor",
-            &vi_map,
-            &traced_shapes,
-            &init_types,
-            &node_output_types,
-        )
-        .unwrap();
+        let (model, metadata) = make_test_model(node_output_types, traced_shapes.clone());
+
+        let traced_types = metadata.traced_types.as_ref();
+        let combined =
+            materialize_combined_model(&model, &metadata, &traced_shapes, traced_types).unwrap();
+
+        let graph = combined.graph.as_ref().unwrap();
+
+        let float_vi = graph.output.iter().find(|o| o.name == "float_tensor");
         assert!(float_vi.is_some());
 
-        let bool_vi = resolve_value_info(
-            "bool_tensor",
-            &vi_map,
-            &traced_shapes,
-            &init_types,
-            &node_output_types,
-        )
-        .unwrap();
+        let bool_vi = graph.output.iter().find(|o| o.name == "bool_tensor");
         assert!(bool_vi.is_some());
 
-        let string_vi = resolve_value_info(
-            "string_tensor",
-            &vi_map,
-            &traced_shapes,
-            &init_types,
-            &node_output_types,
-        )
-        .unwrap();
-        assert!(string_vi.is_none());
+        let string_vi = graph.output.iter().find(|o| o.name == "string_tensor");
+        assert!(
+            string_vi.is_none(),
+            "string tensors should be excluded from combined outputs"
+        );
 
-        let int_vi = resolve_value_info(
-            "int_tensor",
-            &vi_map,
-            &traced_shapes,
-            &init_types,
-            &node_output_types,
-        )
-        .unwrap();
+        let int_vi = graph.output.iter().find(|o| o.name == "int_tensor");
         assert!(int_vi.is_some());
+    }
+
+    #[test]
+    fn combined_model_has_intermediate_outputs() {
+        let mut traced_shapes = HashMap::new();
+        traced_shapes.insert("float_tensor".to_string(), vec![1, 3, 8, 8]);
+        traced_shapes.insert("bool_tensor".to_string(), vec![1]);
+        traced_shapes.insert("string_tensor".to_string(), vec![1]);
+        traced_shapes.insert("int_tensor".to_string(), vec![2, 4]);
+
+        let mut types = HashMap::new();
+        types.insert("float_tensor".to_string(), TensorProto::FLOAT);
+        types.insert("bool_tensor".to_string(), TensorProto::BOOL);
+        types.insert("int_tensor".to_string(), TensorProto::INT64);
+
+        let (model, metadata) = make_test_model(types, traced_shapes.clone());
+        let traced_types = metadata.traced_types.as_ref();
+        let combined =
+            materialize_combined_model(&model, &metadata, &traced_shapes, traced_types).unwrap();
+
+        let graph = combined.graph.as_ref().unwrap();
+        assert!(
+            graph.output.len() > 1,
+            "combined model should have intermediate outputs"
+        );
+    }
+
+    #[test]
+    fn combined_model_to_disk_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let slices_dir = dir.path();
+
+        let mut traced_shapes = HashMap::new();
+        traced_shapes.insert("float_tensor".to_string(), vec![1, 3, 8, 8]);
+        traced_shapes.insert("bool_tensor".to_string(), vec![1]);
+        traced_shapes.insert("string_tensor".to_string(), vec![1]);
+        traced_shapes.insert("int_tensor".to_string(), vec![2, 4]);
+
+        let mut types = HashMap::new();
+        types.insert("float_tensor".to_string(), TensorProto::FLOAT);
+        types.insert("bool_tensor".to_string(), TensorProto::BOOL);
+        types.insert("int_tensor".to_string(), TensorProto::INT64);
+
+        let (model, mut metadata) = make_test_model(types, traced_shapes);
+        metadata.original_model_path = Some("model.onnx".to_string());
+
+        let model_path = slices_dir.join("model.onnx");
+        onnx_proto::save_model(&model, &model_path).unwrap();
+        let meta_path = slices_dir.join("metadata.msgpack");
+        metadata.save(&meta_path).unwrap();
+
+        let dest = materialize_combined_to_disk(slices_dir, &metadata).unwrap();
+        assert!(dest.exists());
+
+        let loaded = onnx_proto::load_model(&dest).unwrap();
+        let graph = loaded.graph.as_ref().unwrap();
+        assert!(
+            graph.output.len() > 1,
+            "reloaded combined model should have intermediate outputs"
+        );
+    }
+
+    #[test]
+    fn ensure_combined_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let slices_dir = dir.path();
+
+        let mut traced_shapes = HashMap::new();
+        traced_shapes.insert("float_tensor".to_string(), vec![1, 3, 8, 8]);
+        traced_shapes.insert("bool_tensor".to_string(), vec![1]);
+        traced_shapes.insert("string_tensor".to_string(), vec![1]);
+        traced_shapes.insert("int_tensor".to_string(), vec![2, 4]);
+
+        let mut types = HashMap::new();
+        types.insert("float_tensor".to_string(), TensorProto::FLOAT);
+        types.insert("bool_tensor".to_string(), TensorProto::BOOL);
+        types.insert("int_tensor".to_string(), TensorProto::INT64);
+
+        let (model, mut metadata) = make_test_model(types, traced_shapes);
+        metadata.original_model_path = Some("model.onnx".to_string());
+
+        let model_path = slices_dir.join("model.onnx");
+        onnx_proto::save_model(&model, &model_path).unwrap();
+        let meta_path = slices_dir.join("metadata.msgpack");
+        metadata.save(&meta_path).unwrap();
+
+        let dest1 = materialize_combined_to_disk(slices_dir, &metadata).unwrap();
+        let dest2 = materialize_combined_to_disk(slices_dir, &metadata).unwrap();
+        assert_eq!(dest1, dest2);
     }
 }

--- a/crates/dsperse/src/slicer/onnx_fold.rs
+++ b/crates/dsperse/src/slicer/onnx_fold.rs
@@ -170,13 +170,19 @@ pub(crate) fn propagate_constants(graph: &mut GraphProto) -> HashSet<String> {
         }
     }
 
-    let consumed_by_remaining: HashSet<String> = graph
+    let mut consumed_by_remaining: HashSet<String> = graph
         .node
         .iter()
         .enumerate()
         .filter(|(i, _)| !folded_node_indices.contains(i))
         .flat_map(|(_, n)| n.input.iter().cloned())
         .collect();
+    for node in &graph.node {
+        if super::is_control_flow(&node.op_type) {
+            let outer_refs = super::collect_subgraph_outer_refs(node, graph);
+            consumed_by_remaining.extend(outer_refs);
+        }
+    }
     let output_names: HashSet<String> = graph.output.iter().map(|o| o.name.clone()).collect();
 
     for name in &new_init_names {

--- a/crates/dsperse/src/slicer/onnx_slicer.rs
+++ b/crates/dsperse/src/slicer/onnx_slicer.rs
@@ -30,7 +30,9 @@ pub fn slice_model(
     onnx_proto::save_model(&model, &tract_path)?;
 
     tracing::info!("folding constants and tracing shapes via tract");
-    let traced_shapes = super::trace::fold_and_trace_via_tract(&tract_path, &model)?;
+    let trace_result = super::trace::fold_and_trace_via_tract(&tract_path, &model)?;
+    let traced_shapes = trace_result.shapes;
+    let traced_types = trace_result.types;
 
     if let Some(graph) = model.graph.as_mut() {
         let folded = super::onnx_fold::propagate_constants_with_shapes(graph, &traced_shapes);
@@ -151,6 +153,7 @@ pub fn slice_model(
         jstprove_version: None,
         jstprove_rev: None,
         traced_shapes: Some(traced_shapes),
+        traced_types: Some(traced_types),
         original_model_path: Some("model.onnx".to_string()),
         folded_constant_names: folded_constants.into_iter().collect(),
     };

--- a/crates/dsperse/src/slicer/trace.rs
+++ b/crates/dsperse/src/slicer/trace.rs
@@ -4,18 +4,27 @@ use std::path::Path;
 use super::onnx_proto::ModelProto;
 use crate::error::{DsperseError, Result};
 
+pub(crate) struct TraceResult {
+    pub shapes: HashMap<String, Vec<i64>>,
+    pub types: HashMap<String, i32>,
+}
+
 pub(crate) fn fold_and_trace_via_tract(
     onnx_path: &Path,
     model: &ModelProto,
-) -> Result<HashMap<String, Vec<i64>>> {
+) -> Result<TraceResult> {
     use tract_onnx::prelude::*;
     use tract_onnx::tract_hir::infer::InferenceSimplePlan;
 
+    let loop_bodies = collect_loop_bodies(model);
+
+    let tract_path = tag_all_outputs(onnx_path, model)?;
     let tract_model = std::sync::Arc::new(
         tract_onnx::onnx()
-            .model_for_path(onnx_path)
+            .model_for_path(&tract_path)
             .map_err(|e| DsperseError::Slicer(format!("tract load: {e}")))?,
     );
+    let _ = std::fs::remove_file(&tract_path);
 
     let plan = InferenceSimplePlan::new(tract_model.clone())
         .map_err(|e| DsperseError::Slicer(format!("plan creation: {e}")))?;
@@ -46,6 +55,7 @@ pub(crate) fn fold_and_trace_via_tract(
     }
 
     let shapes_cell = std::cell::RefCell::new(HashMap::<usize, Vec<Vec<i64>>>::new());
+    let dtypes_cell = std::cell::RefCell::new(HashMap::<usize, Vec<u8>>::new());
     let failed_nodes = std::cell::RefCell::new(HashSet::<usize>::new());
 
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -73,20 +83,31 @@ pub(crate) fn fold_and_trace_via_tract(
                 match eval_result {
                     Ok(o) => o,
                     Err(e) => {
-                        tracing::warn!(
-                            node = %node.name,
-                            op = %node.op.name(),
-                            error = %e,
-                            "op eval failed, using input[0] shape as fallback"
-                        );
-                        failed_nodes.borrow_mut().insert(node.id);
-                        let fallback = inputs.first().cloned().unwrap_or_else(|| {
-                            Tensor::zero::<f32>(&[1])
-                                .expect("scalar f32 allocation")
-                                .into_tvalue()
-                        });
-                        let n = node.outputs.len().max(1);
-                        (0..n).map(|_| fallback.clone()).collect()
+                        if let Some(synth) =
+                            synthesize_loop_outputs(&node.name, &inputs, &loop_bodies)
+                        {
+                            tracing::info!(
+                                node = %node.name,
+                                outputs = synth.len(),
+                                "synthesized Loop output tensors from body subgraph shapes"
+                            );
+                            synth
+                        } else {
+                            tracing::warn!(
+                                node = %node.name,
+                                op = %node.op.name(),
+                                error = %e,
+                                "op eval failed, using input[0] shape as fallback"
+                            );
+                            failed_nodes.borrow_mut().insert(node.id);
+                            let fallback = inputs.first().cloned().unwrap_or_else(|| {
+                                Tensor::zero::<f32>(&[1])
+                                    .expect("scalar f32 allocation")
+                                    .into_tvalue()
+                            });
+                            let n = node.outputs.len().max(1);
+                            (0..n).map(|_| fallback.clone()).collect()
+                        }
                     }
                 }
             };
@@ -94,7 +115,12 @@ pub(crate) fn fold_and_trace_via_tract(
                 .iter()
                 .map(|t| t.shape().iter().map(|&d| d as i64).collect())
                 .collect();
+            let node_dtypes: Vec<u8> = outputs
+                .iter()
+                .map(|t| datum_type_to_onnx(t.datum_type()))
+                .collect();
             shapes_cell.borrow_mut().insert(node.id, node_shapes);
+            dtypes_cell.borrow_mut().insert(node.id, node_dtypes);
             Ok::<_, TractError>(outputs)
         })
     }));
@@ -112,6 +138,7 @@ pub(crate) fn fold_and_trace_via_tract(
     }
 
     let run_shapes = shapes_cell.into_inner();
+    let run_dtypes = dtypes_cell.into_inner();
     let failed = failed_nodes.into_inner();
 
     tracing::info!(
@@ -120,29 +147,40 @@ pub(crate) fn fold_and_trace_via_tract(
     );
 
     let mut shapes: HashMap<String, Vec<i64>> = HashMap::new();
+    let mut types: HashMap<String, i32> = HashMap::new();
     for (node_id, node_shapes) in &run_shapes {
         if failed.contains(node_id) {
             continue;
         }
+        let node_dtypes = run_dtypes.get(node_id);
         for (slot, shape) in node_shapes.iter().enumerate() {
+            let dt = node_dtypes.and_then(|d| d.get(slot)).copied().unwrap_or(1) as i32; // 1 = FLOAT
             let outlet = OutletId::new(*node_id, slot);
             if let Some(label) = tract_model.outlet_label(outlet)
                 && !label.is_empty()
             {
                 shapes.insert(label.to_string(), shape.clone());
+                types.insert(label.to_string(), dt);
             }
             let node = tract_model.node(*node_id);
-            let name = if slot == 0 && !node.name.is_empty() {
-                node.name.clone()
-            } else {
-                format!("{}:{}", node.name, slot)
-            };
-            shapes.entry(name).or_insert_with(|| shape.clone());
+            if !node.name.is_empty() {
+                if slot == 0 {
+                    shapes
+                        .entry(node.name.clone())
+                        .or_insert_with(|| shape.clone());
+                    types.entry(node.name.clone()).or_insert(dt);
+                }
+                let qualified = format!("{}:{}", node.name, slot);
+                shapes
+                    .entry(qualified.clone())
+                    .or_insert_with(|| shape.clone());
+                types.entry(qualified).or_insert(dt);
+            }
         }
     }
 
     if let Some(graph) = &model.graph {
-        let mut extra: Vec<(String, Vec<i64>)> = Vec::new();
+        let mut extra: Vec<(String, Vec<i64>, Option<i32>)> = Vec::new();
         for n in &graph.node {
             for (slot, out) in n.output.iter().enumerate() {
                 if out.is_empty() || shapes.contains_key(out) {
@@ -154,12 +192,16 @@ pub(crate) fn fold_and_trace_via_tract(
                     format!("{}:{}", n.name, slot)
                 };
                 if let Some(shape) = shapes.get(&key) {
-                    extra.push((out.clone(), shape.clone()));
+                    let dt = types.get(&key).copied();
+                    extra.push((out.clone(), shape.clone(), dt));
                 }
             }
         }
-        for (name, shape) in extra {
-            shapes.insert(name, shape);
+        for (name, shape, dt) in extra {
+            shapes.insert(name.clone(), shape);
+            if let Some(dt) = dt {
+                types.insert(name, dt);
+            }
         }
         for init in &graph.initializer {
             if !init.dims.is_empty() {
@@ -167,9 +209,364 @@ pub(crate) fn fold_and_trace_via_tract(
                     .entry(init.name.clone())
                     .or_insert_with(|| init.dims.clone());
             }
+            if init.data_type != 0 {
+                types.entry(init.name.clone()).or_insert(init.data_type);
+            }
         }
+        for inp in &graph.input {
+            if let Some(shape) = super::onnx_shapes::shape_from_value_info(inp) {
+                shapes.entry(inp.name.clone()).or_insert(shape);
+            }
+            if let Some(dt) = super::onnx_shapes::elem_type_from_value_info(inp) {
+                types.entry(inp.name.clone()).or_insert(dt);
+            }
+        }
+        resolve_absorbed_nodes(graph, &mut shapes);
     }
 
     tracing::info!(tensors = shapes.len(), "shape trace complete");
-    Ok(shapes)
+    Ok(TraceResult { shapes, types })
+}
+
+/// Save a copy of the ONNX model with every node output declared as a graph
+/// output.  This forces tract to preserve outlet labels for all intermediate
+/// tensors, preventing them from being lost during op fusion.
+fn tag_all_outputs(onnx_path: &Path, model: &ModelProto) -> Result<std::path::PathBuf> {
+    let mut tagged = model.clone();
+    if let Some(ref mut graph) = tagged.graph {
+        let existing: HashSet<String> = graph.output.iter().map(|o| o.name.clone()).collect();
+        for node in &graph.node {
+            for out in &node.output {
+                if !out.is_empty() && !existing.contains(out) {
+                    graph.output.push(super::onnx_proto::ValueInfoProto {
+                        name: out.clone(),
+                        ..Default::default()
+                    });
+                }
+            }
+        }
+    }
+    let dir = onnx_path.parent().unwrap_or_else(|| Path::new("."));
+    let tagged_path = dir.join("_tract_tagged.onnx");
+    super::onnx_proto::save_model(&tagged, &tagged_path)?;
+    Ok(tagged_path)
+}
+
+fn onnx_elem_type_to_datum(onnx_type: i32) -> Option<tract_onnx::prelude::DatumType> {
+    use tract_onnx::prelude::DatumType;
+    match onnx_type {
+        1 => Some(DatumType::F32),
+        2 => Some(DatumType::U8),
+        3 => Some(DatumType::I8),
+        5 => Some(DatumType::I16),
+        6 => Some(DatumType::I32),
+        7 => Some(DatumType::I64),
+        9 => Some(DatumType::Bool),
+        10 => Some(DatumType::F16),
+        11 => Some(DatumType::F64),
+        12 => Some(DatumType::U32),
+        13 => Some(DatumType::U64),
+        _ => None,
+    }
+}
+
+fn datum_type_to_onnx(dt: tract_onnx::prelude::DatumType) -> u8 {
+    use tract_onnx::prelude::DatumType;
+    match dt {
+        DatumType::F32 => 1,
+        DatumType::U8 => 2,
+        DatumType::I8 => 3,
+        DatumType::U16 => 4,
+        DatumType::I16 => 5,
+        DatumType::I32 => 6,
+        DatumType::I64 => 7,
+        DatumType::Bool => 9,
+        DatumType::F16 => 10,
+        DatumType::F64 => 11,
+        DatumType::U32 => 12,
+        DatumType::U64 => 13,
+        _ => 1,
+    }
+}
+
+struct LoopBody {
+    num_loop_carried: usize,
+    num_scan: usize,
+    scan_body_output_shapes: Vec<Option<Vec<i64>>>,
+    scan_body_output_dtypes: Vec<Option<i32>>,
+}
+
+/// Collect Loop node body metadata from the ONNX graph.  For scan outputs
+/// whose shapes can be statically determined from the body subgraph, store
+/// the body-side shape (without the leading trip-count dimension).
+fn collect_loop_bodies(model: &ModelProto) -> HashMap<String, LoopBody> {
+    let graph = match model.graph.as_ref() {
+        Some(g) => g,
+        None => return HashMap::new(),
+    };
+
+    let mut known: HashMap<String, Vec<i64>> = HashMap::new();
+    for init in &graph.initializer {
+        if !init.dims.is_empty() {
+            known.insert(init.name.clone(), init.dims.clone());
+        }
+    }
+    for vi in graph
+        .input
+        .iter()
+        .chain(graph.value_info.iter())
+        .chain(graph.output.iter())
+    {
+        if let Some(shape) = super::onnx_shapes::shape_from_value_info(vi) {
+            known.insert(vi.name.clone(), shape);
+        }
+    }
+
+    let mut result = HashMap::new();
+    for node in &graph.node {
+        if node.op_type != "Loop" {
+            continue;
+        }
+        let body = match node
+            .attribute
+            .iter()
+            .find(|a| a.name == "body")
+            .and_then(|a| a.g.as_ref())
+        {
+            Some(b) => b,
+            None => continue,
+        };
+
+        let num_loop_carried = node.input.len().saturating_sub(2);
+        let num_body_out = body.output.len().saturating_sub(1);
+        let num_scan = num_body_out.saturating_sub(num_loop_carried);
+
+        let mut scan_shapes = Vec::with_capacity(num_scan);
+        let mut scan_dtypes = Vec::with_capacity(num_scan);
+        for j in 0..num_scan {
+            let body_out_idx = 1 + num_loop_carried + j;
+            let body_vi = body.output.get(body_out_idx);
+            let shape =
+                body_vi.and_then(|vi| resolve_body_tensor_shape(&vi.name, body, graph, &known));
+            let dtype = body_vi.and_then(super::onnx_shapes::elem_type_from_value_info);
+            scan_shapes.push(shape);
+            scan_dtypes.push(dtype);
+        }
+
+        result.insert(
+            node.name.clone(),
+            LoopBody {
+                num_loop_carried,
+                num_scan,
+                scan_body_output_shapes: scan_shapes,
+                scan_body_output_dtypes: scan_dtypes,
+            },
+        );
+    }
+    result
+}
+
+/// During tract evaluation, when a Loop node fails, produce correctly-shaped
+/// zero tensors so downstream nodes receive valid inputs and are not tainted.
+///
+/// Loop-carried output shapes come directly from the actual input tensors
+/// (inputs\[2..\]).  Scan output shapes come from the pre-analyzed body
+/// subgraph with a leading dimension of 1 (single iteration assumption).
+fn synthesize_loop_outputs(
+    node_name: &str,
+    inputs: &[tract_onnx::prelude::TValue],
+    loop_bodies: &HashMap<String, LoopBody>,
+) -> Option<tract_onnx::prelude::TVec<tract_onnx::prelude::TValue>> {
+    use tract_onnx::prelude::*;
+
+    let body = loop_bodies.get(node_name)?;
+    let mut tvs: TVec<TValue> = tvec![];
+
+    for i in 0..body.num_loop_carried {
+        let init_tensor = inputs.get(i + 2)?;
+        let shape: Vec<usize> = init_tensor.shape().to_vec();
+        let tensor = Tensor::zero_dt(init_tensor.datum_type(), &shape).ok()?;
+        tvs.push(tensor.into_tvalue());
+    }
+
+    for j in 0..body.num_scan {
+        let body_shape = body.scan_body_output_shapes.get(j)?;
+        let shape: Vec<usize> = match body_shape {
+            Some(bs) => {
+                let mut s = vec![1usize];
+                s.extend(bs.iter().map(|&d| d.max(1) as usize));
+                s
+            }
+            None => {
+                tracing::warn!(
+                    node = node_name,
+                    scan_idx = j,
+                    "scan output shape unknown, using [1,1] placeholder"
+                );
+                vec![1, 1]
+            }
+        };
+        let dt = body
+            .scan_body_output_dtypes
+            .get(j)
+            .and_then(|d| *d)
+            .and_then(onnx_elem_type_to_datum)
+            .unwrap_or(DatumType::F32);
+        let tensor = Tensor::zero_dt(dt, &shape).ok()?;
+        tvs.push(tensor.into_tvalue());
+    }
+
+    Some(tvs)
+}
+
+/// Resolve shapes for ONNX graph nodes that tract absorbed or renamed,
+/// making them invisible in the tract shape output.  Iterates until no
+/// more progress, using only rules already defined in the slicer module
+/// (shape-preserving ops, binary broadcast).
+fn resolve_absorbed_nodes(
+    graph: &super::onnx_proto::GraphProto,
+    shapes: &mut HashMap<String, Vec<i64>>,
+) {
+    let max_passes = 10;
+    for _ in 0..max_passes {
+        let mut progress = false;
+        for node in &graph.node {
+            for out in &node.output {
+                if out.is_empty() || shapes.contains_key(out) {
+                    continue;
+                }
+                let op = node.op_type.as_str();
+                let shape = if super::is_shape_preserving(op) || op == "Identity" {
+                    node.input.first().and_then(|inp| shapes.get(inp).cloned())
+                } else if super::is_binary_arithmetic(op) {
+                    let resolved: Vec<&Vec<i64>> =
+                        node.input.iter().filter_map(|i| shapes.get(i)).collect();
+                    let non_empty = node.input.iter().filter(|i| !i.is_empty()).count();
+                    if resolved.len() == non_empty {
+                        super::onnx_slicer::broadcast_shapes(&resolved)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+                if let Some(s) = shape {
+                    shapes.insert(out.clone(), s);
+                    progress = true;
+                }
+            }
+        }
+        if !progress {
+            break;
+        }
+    }
+}
+
+fn resolve_body_tensor_shape(
+    name: &str,
+    body: &super::onnx_proto::GraphProto,
+    outer_graph: &super::onnx_proto::GraphProto,
+    known_shapes: &HashMap<String, Vec<i64>>,
+) -> Option<Vec<i64>> {
+    resolve_body_tensor_shape_inner(name, body, outer_graph, known_shapes, 0)
+}
+
+fn resolve_body_tensor_shape_inner(
+    name: &str,
+    body: &super::onnx_proto::GraphProto,
+    outer_graph: &super::onnx_proto::GraphProto,
+    known_shapes: &HashMap<String, Vec<i64>>,
+    depth: usize,
+) -> Option<Vec<i64>> {
+    if depth > 32 {
+        return None;
+    }
+
+    for vi in body.output.iter().chain(body.value_info.iter()) {
+        if vi.name == name
+            && let Some(shape) = super::onnx_shapes::shape_from_value_info(vi)
+        {
+            return Some(shape);
+        }
+    }
+
+    for init in body
+        .initializer
+        .iter()
+        .chain(outer_graph.initializer.iter())
+    {
+        if init.name == name && !init.dims.is_empty() {
+            return Some(init.dims.to_vec());
+        }
+    }
+
+    if let Some(shape) = known_shapes.get(name) {
+        return Some(shape.clone());
+    }
+
+    let producer = body
+        .node
+        .iter()
+        .find(|n| n.output.contains(&name.to_string()))?;
+    let op = producer.op_type.as_str();
+
+    if super::is_shape_preserving(op) || op == "Identity" {
+        let inp = producer.input.first()?;
+        return resolve_body_tensor_shape_inner(inp, body, outer_graph, known_shapes, depth + 1);
+    }
+
+    if super::is_binary_arithmetic(op) {
+        let resolved: Vec<Vec<i64>> = producer
+            .input
+            .iter()
+            .filter_map(|inp| {
+                resolve_body_tensor_shape_inner(inp, body, outer_graph, known_shapes, depth + 1)
+            })
+            .collect();
+        let refs: Vec<&Vec<i64>> = resolved.iter().collect();
+        return super::onnx_slicer::broadcast_shapes(&refs);
+    }
+
+    if op == "Concat" {
+        let axis = super::onnx_proto::get_attribute_int(producer, "axis")?;
+        let input_shapes: Vec<Vec<i64>> = producer
+            .input
+            .iter()
+            .filter_map(|inp| {
+                resolve_body_tensor_shape_inner(inp, body, outer_graph, known_shapes, depth + 1)
+            })
+            .collect();
+        if input_shapes.len() != producer.input.len() || input_shapes.is_empty() {
+            return None;
+        }
+        let rank = input_shapes[0].len();
+        let axis_idx = if axis < 0 {
+            (rank as i64 + axis) as usize
+        } else {
+            axis as usize
+        };
+        let mut result = input_shapes[0].clone();
+        for shape in &input_shapes[1..] {
+            if let Some(d) = result.get_mut(axis_idx) {
+                *d += shape.get(axis_idx).copied().unwrap_or(0);
+            }
+        }
+        return Some(result);
+    }
+
+    if op == "Transpose" {
+        let inp = producer.input.first()?;
+        let in_shape =
+            resolve_body_tensor_shape_inner(inp, body, outer_graph, known_shapes, depth + 1)?;
+        let perm = &producer.attribute.iter().find(|a| a.name == "perm")?.ints;
+        let result: Vec<i64> = perm
+            .iter()
+            .filter_map(|&p| in_shape.get(p as usize).copied())
+            .collect();
+        if result.len() == in_shape.len() {
+            return Some(result);
+        }
+    }
+
+    None
 }

--- a/crates/dsperse/src/slicer/trace.rs
+++ b/crates/dsperse/src/slicer/trace.rs
@@ -24,7 +24,9 @@ pub(crate) fn fold_and_trace_via_tract(
             .model_for_path(&tract_path)
             .map_err(|e| DsperseError::Slicer(format!("tract load: {e}")))?,
     );
-    let _ = std::fs::remove_file(&tract_path);
+    if let Err(e) = std::fs::remove_file(&tract_path) {
+        tracing::debug!(path = %tract_path.display(), error = %e, "failed to remove tagged model");
+    }
 
     let plan = InferenceSimplePlan::new(tract_model.clone())
         .map_err(|e| DsperseError::Slicer(format!("plan creation: {e}")))?;
@@ -247,7 +249,7 @@ fn tag_all_outputs(onnx_path: &Path, model: &ModelProto) -> Result<std::path::Pa
         }
     }
     let dir = onnx_path.parent().unwrap_or_else(|| Path::new("."));
-    let tagged_path = dir.join("_tract_tagged.onnx");
+    let tagged_path = dir.join(format!("_tract_tagged_{}.onnx", std::process::id()));
     super::onnx_proto::save_model(&tagged, &tagged_path)?;
     Ok(tagged_path)
 }
@@ -539,9 +541,12 @@ fn resolve_body_tensor_shape_inner(
         if input_shapes.len() != producer.input.len() || input_shapes.is_empty() {
             return None;
         }
-        let rank = input_shapes[0].len();
+        let rank = input_shapes[0].len() as i64;
+        if axis < -rank || axis >= rank {
+            return None;
+        }
         let axis_idx = if axis < 0 {
-            (rank as i64 + axis) as usize
+            (rank + axis) as usize
         } else {
             axis as usize
         };


### PR DESCRIPTION
## Summary

- Investigate and resolve the inability to slice and combine ONNX models containing Loop operators (e.g. TF-exported models with map/TensorArray preprocessing and NMS post-processing)
- Introduce `traced_types` in ModelMetadata so the combiner uses ground-truth element types from the tract run instead of per-op heuristic inference
- Resolve constant folding discarding outer-scope tensor references needed by Loop body subgraphs

## Approach

Three systematic changes to the shape/type tracing pipeline:

1. **Loop output synthesis** (`trace.rs`): When tract fails to evaluate a Loop op, synthesize correctly-typed zero tensors using initial-value dtypes for loop-carried outputs and body subgraph value_info for scan outputs. This prevents downstream taint propagation.

2. **Outlet label preservation** (`trace.rs`): Tag all ONNX node outputs as graph-level outputs before the tract pass, preventing tract from dropping outlet labels during op fusion. Eliminates the need for a parallel shape inference engine.

3. **Traced types** (`metadata.rs`, `combiner.rs`, `trace.rs`): Capture tensor element types during the tract run and store in metadata. The combiner reads ground-truth types directly instead of deriving them from op-specific rules.

Also fixes `propagate_constants` in `onnx_fold.rs` to include Loop body subgraph outer-scope references in the consumed-by analysis.

## Test plan

- [x] All 242 existing tests pass
- [x] Clippy clean, fmt clean
- [x] End-to-end: slice → combine → onnxruntime load → inference on models with Loop operators
- [x] Combined model produces correct detection output shapes `(1, 100, 4)`, `(1, 100)`, `(1, 100)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model processing now captures tensor element types alongside shapes for more complete model metadata.

* **Improvements**
  * Constant propagation handles control-flow constructs more accurately.
  * Materialization and slicing use traced type information for more reliable type resolution and output consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->