### PR TITLE
Resolve dim-split template compilation with pad-to-dim_size and value_info propagation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "arith"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
 dependencies = [
  "ark-std",
  "criterion",
@@ -354,7 +354,7 @@ dependencies = [
 [[package]]
 name = "babybear"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
 dependencies = [
  "arith",
  "ark-std",
@@ -398,7 +398,7 @@ dependencies = [
 [[package]]
 name = "bin"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
 dependencies = [
  "arith",
  "babybear",
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "circuit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
 dependencies = [
  "arith",
  "ark-std",
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "circuit-std-rs"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
 dependencies = [
  "arith",
  "ark-bls12-381",
@@ -689,7 +689,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "config_macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
 dependencies = [
  "gkr_engine",
  "gkr_hashers",
@@ -857,7 +857,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 [[package]]
 name = "crosslayer_prototype"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
 dependencies = [
  "arith",
  "env_logger",
@@ -1093,7 +1093,7 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 [[package]]
 name = "expander_compiler"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
 dependencies = [
  "arith",
  "ark-std",
@@ -1324,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "gf2"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
 dependencies = [
  "arith",
  "ark-std",
@@ -1341,7 +1341,7 @@ dependencies = [
 [[package]]
 name = "gf2_128"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
 dependencies = [
  "arith",
  "ark-std",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "gkr"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
 dependencies = [
  "arith",
  "ark-std",
@@ -1386,7 +1386,7 @@ dependencies = [
 [[package]]
 name = "gkr_engine"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
 dependencies = [
  "arith",
  "babybear",
@@ -1404,7 +1404,7 @@ dependencies = [
 [[package]]
 name = "gkr_hashers"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
 dependencies = [
  "arith",
  "halo2curves",
@@ -1416,7 +1416,7 @@ dependencies = [
 [[package]]
 name = "goldilocks"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
 dependencies = [
  "arith",
  "ark-std",
@@ -2014,7 +2014,7 @@ dependencies = [
 [[package]]
 name = "jstprove-io"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
 dependencies = [
  "anyhow",
  "crc32c",
@@ -2026,7 +2026,7 @@ dependencies = [
 [[package]]
 name = "jstprove-onnx"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
 dependencies = [
  "anyhow",
  "prost 0.13.5",
@@ -2037,7 +2037,7 @@ dependencies = [
 [[package]]
 name = "jstprove_circuits"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
 dependencies = [
  "anyhow",
  "arith",
@@ -2213,7 +2213,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2287,7 +2287,7 @@ dependencies = [
 [[package]]
 name = "mersenne31"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
 dependencies = [
  "arith",
  "ark-std",
@@ -2781,7 +2781,7 @@ dependencies = [
 [[package]]
 name = "poly_commit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
 dependencies = [
  "arith",
  "ark-std",
@@ -2807,7 +2807,7 @@ dependencies = [
 [[package]]
 name = "polynomials"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
 dependencies = [
  "arith",
  "ark-std",
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "serdes"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
 dependencies = [
  "ethnum",
  "halo2curves",
@@ -3662,7 +3662,7 @@ dependencies = [
 [[package]]
 name = "serdes_derive"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3834,7 +3834,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
 dependencies = [
  "arith",
  "circuit",
@@ -4445,7 +4445,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
 dependencies = [
  "arith",
  "gkr_engine",
@@ -4468,7 +4468,7 @@ dependencies = [
 [[package]]
 name = "tree"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
 dependencies = [
  "arith",
  "ark-std",
@@ -4628,7 +4628,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ec0172f5#ec0172f55b065f784aabb940f8d93b09c9568936"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ sha2 = "0.10"
 tempfile = "3"
 prost = "0.13"
 pyo3 = { version = "0.24" }
-jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "ec0172f5" }
+jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "02032293" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/crates/dsperse/src/pipeline/compiler.rs
+++ b/crates/dsperse/src/pipeline/compiler.rs
@@ -705,7 +705,7 @@ fn compile_dim_split_template(
     exclude_from_wai: &std::collections::HashSet<String>,
     skip_compile_over_size: Option<u64>,
     circuit_cache: &CircuitCache,
-    traced_shapes: Option<&std::collections::HashMap<String, Vec<i64>>>,
+    _traced_shapes: Option<&std::collections::HashMap<String, Vec<i64>>>,
 ) -> Result<CompileOutcome> {
     let slice_dir = slice_dir_path(slices_dir, slice.index);
     let jst_dir = slice_dir.join("jstprove");
@@ -780,12 +780,13 @@ fn compile_dim_split_template(
         "compiling dim-split template (weights-as-inputs)"
     );
 
-    let (params, architecture, wandb) = converter::prepare_jstprove_artifacts_filtered(
-        tmpl_path,
-        true,
-        exclude_from_wai,
-        traced_shapes,
-    )?;
+    // Do NOT pass the original traced_shapes when compiling dim-split
+    // templates. The template has rewritten shapes (dim_size → epg) that
+    // differ from the original model's traced shapes. If traced_shapes
+    // is passed, jstprove uses the original (larger) shapes and the
+    // Transpose/Reshape validation fails on the mismatch.
+    let (params, architecture, wandb) =
+        converter::prepare_jstprove_artifacts_filtered(tmpl_path, true, exclude_from_wai, None)?;
 
     std::panic::catch_unwind(|| {
         backend.compile(&circuit_path, proof_config, params, architecture, wandb)

--- a/crates/dsperse/src/pipeline/dim_split.rs
+++ b/crates/dsperse/src/pipeline/dim_split.rs
@@ -336,6 +336,9 @@ fn execute_generic_dim_split(
         let dim_end = ((g + 1) * epg).min(ds.dim_size);
         let actual_size = dim_end - dim_start;
 
+        // Pad every group's input to dim_size so the template runs with
+        // the original model's shapes unchanged. This keeps the compiled
+        // circuit signature identical for every group and across slices.
         let mut group_cache = TensorStore::new();
         for vi_name in &input_names {
             let arr = tensor_cache.try_get(vi_name).ok_or_else(|| {
@@ -348,20 +351,16 @@ fn execute_generic_dim_split(
                 let sliced = arr
                     .slice_axis(Axis(split_dim), ndarray::Slice::from(dim_start..dim_end))
                     .to_owned();
-                if actual_size < epg {
-                    let mut padded_shape = sliced.shape().to_vec();
-                    padded_shape[split_dim] = epg;
-                    let mut padded = ndarray::ArrayD::zeros(padded_shape);
-                    for (mut dst, src) in padded
-                        .axis_iter_mut(Axis(split_dim))
-                        .zip(sliced.axis_iter(Axis(split_dim)))
-                    {
-                        dst.assign(&src);
-                    }
-                    group_cache.put(vi_name.clone(), padded);
-                } else {
-                    group_cache.put(vi_name.clone(), sliced);
+                let mut padded_shape = sliced.shape().to_vec();
+                padded_shape[split_dim] = ds.dim_size;
+                let mut padded = ndarray::ArrayD::zeros(padded_shape);
+                for (mut dst, src) in padded
+                    .axis_iter_mut(Axis(split_dim))
+                    .zip(sliced.axis_iter(Axis(split_dim)))
+                {
+                    dst.assign(&src);
                 }
+                group_cache.put(vi_name.clone(), padded);
             } else {
                 group_cache.put(vi_name.clone(), arr.clone());
             }
@@ -378,7 +377,8 @@ fn execute_generic_dim_split(
         let group_output = ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&shape), data)
             .map_err(|e| DsperseError::Pipeline(format!("{slice_id}: group {g} reshape: {e}")))?;
 
-        let trimmed = if actual_size < epg && concat_axis < group_output.ndim() {
+        // Trim the padded region from the output along concat_axis.
+        let trimmed = if actual_size < ds.dim_size && concat_axis < group_output.ndim() {
             group_output
                 .slice_axis(Axis(concat_axis), ndarray::Slice::from(0..actual_size))
                 .to_owned()

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
-use super::onnx_proto::{self, GraphProto, ModelProto, NodeProto, TensorProto, ValueInfoProto};
+use super::onnx_proto::{self, GraphProto, ModelProto, NodeProto, TensorProto};
 use crate::error::Result;
 use crate::schema::tiling::{ChannelGroupInfo, ChannelSplitInfo, DimSplitKind};
 
@@ -1688,6 +1688,7 @@ pub fn create_dim_split_template(
     model: &ModelProto,
     info: &crate::schema::tiling::DimSplitInfo,
     output_dir: &Path,
+    traced_shapes: Option<&HashMap<String, Vec<i64>>>,
 ) -> Result<std::path::PathBuf> {
     let graph = model.graph.as_ref().ok_or_else(|| {
         crate::error::DsperseError::Slicer("create_dim_split_template: model has no graph".into())
@@ -1699,7 +1700,7 @@ pub fn create_dim_split_template(
         }
         crate::schema::tiling::DimSplitKind::HeadDim
         | crate::schema::tiling::DimSplitKind::BatchDim => {
-            create_generic_dim_template(model, graph, info, output_dir)
+            create_generic_dim_template(model, graph, info, output_dir, traced_shapes)
         }
     }
 }
@@ -1907,21 +1908,22 @@ fn create_generic_dim_template(
     graph: &GraphProto,
     info: &crate::schema::tiling::DimSplitInfo,
     output_dir: &Path,
+    traced_shapes: Option<&HashMap<String, Vec<i64>>>,
 ) -> Result<std::path::PathBuf> {
-    let split_dim = info.split_dim;
-    let epg = info.elements_per_group;
-    if epg == 0 {
+    if info.elements_per_group == 0 {
         return Err(crate::error::DsperseError::Slicer(format!(
             "create_generic_dim_template: slice {} elements_per_group is 0",
             info.slice_idx
         )));
     }
 
-    check_axis_separable(graph, split_dim, info.slice_idx)?;
+    check_axis_separable(graph, info.split_dim, info.slice_idx)?;
 
-    let init_names: std::collections::HashSet<&str> =
-        graph.initializer.iter().map(|i| i.name.as_str()).collect();
-
+    // The template is the original slice model with no shape rewriting.
+    // The runner pads each group's input to dim_size before inference and
+    // trims the output afterward. Keeping the original shapes means the
+    // compiled circuit signature is identical regardless of group size,
+    // maximizing cross-slice and cross-model circuit catalog reuse.
     let mut tmpl_model = model.clone();
     let tmpl_graph = tmpl_model.graph.as_mut().ok_or_else(|| {
         crate::error::DsperseError::Slicer(
@@ -1929,23 +1931,51 @@ fn create_generic_dim_template(
         )
     })?;
 
-    let rewrite = |vi: &mut ValueInfoProto| {
-        if let Some(mut shape) = onnx_proto::shape_from_value_info(vi)
-            && split_dim < shape.len()
-            && shape[split_dim] == info.dim_size as i64
-        {
-            shape[split_dim] = epg as i64;
-            onnx_proto::set_vi_shape(vi, &shape);
-        }
-    };
-
-    for vi in tmpl_graph.input.iter_mut() {
-        if !init_names.contains(vi.name.as_str()) {
-            rewrite(vi);
+    // Populate value_info for intermediate node outputs that lack shape
+    // declarations. jstprove needs these to resolve weight shapes during
+    // WAI circuit compilation (e.g. Gemm expected_weight_shape derives N
+    // from the output shape). Without traced_shapes the circuit compiler
+    // cannot infer these and falls back to incorrect dimensions.
+    if let Some(shapes) = traced_shapes {
+        let existing: HashSet<String> = tmpl_graph
+            .input
+            .iter()
+            .chain(tmpl_graph.output.iter())
+            .chain(tmpl_graph.value_info.iter())
+            .map(|vi| vi.name.clone())
+            .collect();
+        let init_names: HashSet<&str> = tmpl_graph
+            .initializer
+            .iter()
+            .map(|i| i.name.as_str())
+            .collect();
+        let node_output_types = super::materializer::build_node_output_types(tmpl_graph);
+        for node in &tmpl_graph.node {
+            for out_name in &node.output {
+                if out_name.is_empty()
+                    || existing.contains(out_name)
+                    || init_names.contains(out_name.as_str())
+                {
+                    continue;
+                }
+                if let Some(shape) = shapes.get(out_name) {
+                    let elem_type = node_output_types
+                        .get(out_name)
+                        .copied()
+                        .unwrap_or(TensorProto::FLOAT);
+                    tmpl_graph
+                        .value_info
+                        .push(onnx_proto::make_tensor_value_info(
+                            out_name, elem_type, shape,
+                        ));
+                }
+            }
         }
     }
-    // If output_name is declared in value_info but not graph.output,
-    // promote it so ORT actually produces the tensor at runtime.
+
+    // Promote output_name to graph output if it only exists in value_info.
+    // Runs after the traced_shapes synthesis above so that newly created
+    // value_info entries are eligible for promotion.
     if !tmpl_graph.output.iter().any(|o| o.name == info.output_name)
         && let Some(vi) = tmpl_graph
             .value_info
@@ -1954,70 +1984,6 @@ fn create_generic_dim_template(
             .cloned()
     {
         tmpl_graph.output.push(vi);
-    }
-    for vi in tmpl_graph.output.iter_mut() {
-        rewrite(vi);
-    }
-    for vi in tmpl_graph.value_info.iter_mut() {
-        rewrite(vi);
-    }
-
-    // Rewrite Reshape shape constants at exactly the position corresponding
-    // to split_dim. For each Reshape node whose shape input is an
-    // initializer, find the index in the shape constant where the value
-    // equals dim_size AND whose position corresponds to split_dim in the
-    // Reshape's input tensor. This avoids corrupting other dimensions that
-    // coincidentally equal dim_size.
-    let dim_size_i64 = info.dim_size as i64;
-    let epg_i64 = epg as i64;
-    let reshape_nodes: Vec<(String, usize)> = tmpl_graph
-        .node
-        .iter()
-        .filter(|n| n.op_type == "Reshape")
-        .filter_map(|n| {
-            let shape_name = n.input.get(1)?.clone();
-            // Resolve the input tensor's shape to find where split_dim maps
-            // in the output shape constant. Walk value_info, graph input, and
-            // traced shapes for the Reshape's first input.
-            let inp_name = n.input.first()?;
-            let inp_shape = tmpl_graph
-                .value_info
-                .iter()
-                .chain(tmpl_graph.input.iter())
-                .find(|v| v.name == *inp_name)
-                .and_then(onnx_proto::shape_from_value_info);
-            // If we can resolve the input shape and split_dim is in range,
-            // the position to rewrite is split_dim itself (Reshape preserves
-            // dimension indices when the target shape has the same rank).
-            // For rank-changing Reshapes we still use split_dim as a best
-            // effort — the axis-separability check already rejected
-            // fundamentally non-separable layouts.
-            let pos = if let Some(ref s) = inp_shape {
-                if split_dim < s.len() {
-                    split_dim
-                } else {
-                    return None;
-                }
-            } else {
-                split_dim
-            };
-            Some((shape_name, pos))
-        })
-        .collect();
-    for (shape_name, pos) in &reshape_nodes {
-        if let Some(init) = tmpl_graph
-            .initializer
-            .iter_mut()
-            .find(|i| i.name == *shape_name)
-        {
-            let mut shape_data = onnx_proto::tensor_to_i64(init);
-            if *pos < shape_data.len() && shape_data[*pos] == dim_size_i64 {
-                shape_data[*pos] = epg_i64;
-                init.int64_data = shape_data;
-                init.raw_data.clear();
-                init.data_type = TensorProto::INT64;
-            }
-        }
     }
 
     let tmpl_path = output_dir.join("dim_template.onnx");
@@ -2856,7 +2822,7 @@ mod tests {
         };
 
         let tmp = tempfile::tempdir().unwrap();
-        let tmpl_path = create_dim_split_template(&model, &info, tmp.path()).unwrap();
+        let tmpl_path = create_dim_split_template(&model, &info, tmp.path(), None).unwrap();
         let tmpl_model = onnx_proto::load_model(&tmpl_path).unwrap();
         let g = tmpl_model.graph.as_ref().unwrap();
         let w = g.initializer.iter().find(|i| i.name == "W").unwrap();
@@ -2922,7 +2888,7 @@ mod tests {
         // Builder should succeed by binding the second op (the one whose
         // IO matches info), even though the first op also references the
         // same weight initializer.
-        let tmpl_path = create_dim_split_template(&model, &info, tmp.path()).unwrap();
+        let tmpl_path = create_dim_split_template(&model, &info, tmp.path(), None).unwrap();
         let tmpl_model = onnx_proto::load_model(&tmpl_path).unwrap();
         let g = tmpl_model.graph.as_ref().unwrap();
         let w = g.initializer.iter().find(|i| i.name == "W").unwrap();

--- a/crates/dsperse/src/slicer/materializer.rs
+++ b/crates/dsperse/src/slicer/materializer.rs
@@ -264,7 +264,7 @@ pub fn ensure_slice_materialized(
 
 fn materialize_tiling_artifacts(
     slices_dir: &Path,
-    _metadata: &ModelMetadata,
+    metadata: &ModelMetadata,
     slice_meta: &crate::schema::metadata::SliceMetadata,
     slice_idx: usize,
 ) -> Result<()> {
@@ -359,7 +359,12 @@ fn materialize_tiling_artifacts(
         if !tmpl_path.exists() {
             let onnx_path = payload_dir.join(format!("slice_{slice_idx}.onnx"));
             let slice_model = onnx_proto::load_model(&onnx_path)?;
-            match autotiler::create_dim_split_template(&slice_model, ds, &payload_dir) {
+            match autotiler::create_dim_split_template(
+                &slice_model,
+                ds,
+                &payload_dir,
+                metadata.traced_shapes.as_ref(),
+            ) {
                 Ok(_) => {
                     tracing::info!(slice = slice_idx, "materialized dim-split template");
                 }

--- a/crates/dsperse/src/slicer/onnx_slicer.rs
+++ b/crates/dsperse/src/slicer/onnx_slicer.rs
@@ -83,7 +83,8 @@ pub fn slice_model(
     let trimmed_points = &slice_points[..slice_points.len().saturating_sub(1)];
 
     let mut tiled_info = HashMap::new();
-    let mut dim_split_info: HashMap<usize, (autotiler::DimSplitDetection, String)> = HashMap::new();
+    let mut dim_split_info: HashMap<usize, (autotiler::DimSplitDetection, Option<String>)> =
+        HashMap::new();
     for (seg_idx, _) in segment_ranges.iter().enumerate() {
         let slice_model =
             materializer::materialize_slice_model(&model, trimmed_points, &traced_shapes, seg_idx)?;
@@ -130,6 +131,7 @@ pub fn slice_model(
                     &slice_model,
                     &tentative_info,
                     &slice_dir,
+                    Some(&traced_shapes),
                 ) {
                     Ok(tmpl_path) => {
                         let tmpl_rel = tmpl_path
@@ -150,15 +152,21 @@ pub fn slice_model(
                             split_kind = ?detection.split_kind,
                             "dim-split detected and template created"
                         );
-                        dim_split_info.insert(seg_idx, (detection, tmpl_rel));
+                        dim_split_info.insert(seg_idx, (detection, Some(tmpl_rel)));
                     }
                     Err(e) => {
                         tracing::warn!(
                             slice = seg_idx,
+                            estimated = detection.estimated_constraints,
                             error = %e,
                             "dim-split detected but template creation failed; \
-                             slice will compile and run as monolithic circuit"
+                             slice will be skipped during compilation"
                         );
+                        // Record detection with no template path so the
+                        // compiler knows this slice was over-budget and
+                        // should be skipped rather than falling through
+                        // to monolithic compilation.
+                        dim_split_info.insert(seg_idx, (detection, None));
                     }
                 }
             }
@@ -209,7 +217,7 @@ fn build_slice_metadata(
     segment_ranges: &[(usize, usize)],
     traced_shapes: &HashMap<String, Vec<i64>>,
     tiled_info: &HashMap<usize, autotiler::TilingDetection>,
-    dim_split_info: &HashMap<usize, (autotiler::DimSplitDetection, String)>,
+    dim_split_info: &HashMap<usize, (autotiler::DimSplitDetection, Option<String>)>,
 ) -> Vec<SliceMetadata> {
     let mut slices = Vec::new();
 
@@ -337,7 +345,7 @@ fn build_slice_metadata(
 
         let dim_split = dim_split_info
             .get(&seg_idx)
-            .map(|(d, tmpl_rel)| DimSplitInfo::from_detection(d, seg_idx, Some(tmpl_rel.clone())));
+            .map(|(d, tmpl_rel)| DimSplitInfo::from_detection(d, seg_idx, tmpl_rel.clone()));
 
         slices.push(SliceMetadata {
             index: seg_idx,


### PR DESCRIPTION
## Summary

Replace shape-rewriting approach with pad-to-dim_size execution for HeadDim/BatchDim dim-split templates. Template is the original slice model unchanged — runner pads inputs to dim_size, runs ORT, trims outputs. Eliminates Reshape/Transpose/Gemm shape rewriting failures.

- Populate intermediate value_info from traced_shapes so jstprove can resolve WAI weight shapes
- Pass None for traced_shapes to circuit compiler to prevent original shapes overriding template shapes
- Strip dim_split metadata from slices where template creation failed; strategy.rs falls back for legacy bundles
- Analyzer filters segment-internal intermediates from dependency outputs
- Extract DimSplitInfo::from_detection helper
- Pin jstprove to 02032293 (Transpose bounds validation)

## Test plan

- [x] cargo test (213), clippy, fmt
- [x] rf-detr-nano compile: 310+ bundles, 0 shape errors, 0 deadlocks
- [x] Combined run fidelity: dets max_diff=8.88e-05, labels max_diff=6.48e-05

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated jstprove_circuits dependency to a newer revision.

* **Bug Fixes**
  * Dim-split template failures now skip compilation rather than falling back to monolithic circuit generation; failures record the skip and emit enriched warnings.

* **Improvements**
  * Dim-split templates and artifact preparation use template-specific traced shape info when available.
  * Dim-split execution always pads group inputs to a uniform size and trims outputs only for smaller segments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->