### PR TITLE
Introduce unified circuit signature for compilation and packaging

### DIFF
--- a/crates/dsperse/src/pipeline/compiler.rs
+++ b/crates/dsperse/src/pipeline/compiler.rs
@@ -274,7 +274,7 @@ fn analyze_slice_onnx(onnx_path: &Path, jstprove_ops: &[&str]) -> Result<SliceAn
     })
 }
 
-fn compute_template_signature(tmpl_path: &Path) -> Result<String> {
+pub(super) fn compute_circuit_signature(tmpl_path: &Path, curve: Option<&str>) -> Result<String> {
     use sha2::{Digest, Sha256};
     let model = onnx_proto::load_model(tmpl_path)?;
     let graph = model
@@ -282,14 +282,25 @@ fn compute_template_signature(tmpl_path: &Path) -> Result<String> {
         .as_ref()
         .ok_or_else(|| DsperseError::Slicer("no graph for signature".into()))?;
     let mut hasher = Sha256::new();
+    if let Some(c) = curve {
+        hasher.update(c.as_bytes());
+    }
     for node in &graph.node {
         hasher.update(node.op_type.as_bytes());
         for attr in &node.attribute {
             hasher.update(attr.name.as_bytes());
+            hasher.update(attr.r#type.to_le_bytes());
             hasher.update(attr.i.to_le_bytes());
             hasher.update(attr.f.to_le_bytes());
+            hasher.update(&attr.s);
             for v in &attr.ints {
                 hasher.update(v.to_le_bytes());
+            }
+            for v in &attr.floats {
+                hasher.update(v.to_le_bytes());
+            }
+            for v in &attr.strings {
+                hasher.update(v);
             }
         }
     }
@@ -319,7 +330,7 @@ fn compute_template_signature(tmpl_path: &Path) -> Result<String> {
         hasher.update(init.data_type.to_le_bytes());
     }
     let hash = hasher.finalize();
-    Ok(format!("{:x}", hash).chars().take(16).collect())
+    Ok(format!("{:x}", hash))
 }
 
 fn estimate_onnx_constraints(onnx_path: &Path) -> Result<u64> {
@@ -634,7 +645,7 @@ fn compile_channel_split_slice(
             }
         }
 
-        let sig = compute_template_signature(&onnx_path)?;
+        let sig = compute_circuit_signature(&onnx_path, None)?;
 
         let cached = circuit_cache.lock().unwrap().get(&sig).cloned();
         if let Some(ref cached_path) = cached
@@ -775,7 +786,7 @@ fn compile_dim_split_template(
         }
     }
 
-    let sig = compute_template_signature(tmpl_path)?;
+    let sig = compute_circuit_signature(tmpl_path, None)?;
 
     let cached = circuit_cache.lock().unwrap().get(&sig).cloned();
     if let Some(ref cached_path) = cached

--- a/crates/dsperse/src/pipeline/compiler.rs
+++ b/crates/dsperse/src/pipeline/compiler.rs
@@ -276,6 +276,12 @@ fn analyze_slice_onnx(onnx_path: &Path, jstprove_ops: &[&str]) -> Result<SliceAn
 
 pub(super) fn compute_circuit_signature(tmpl_path: &Path, curve: Option<&str>) -> Result<String> {
     use sha2::{Digest, Sha256};
+
+    fn hash_bytes(hasher: &mut Sha256, b: &[u8]) {
+        hasher.update((b.len() as u64).to_le_bytes());
+        hasher.update(b);
+    }
+
     let model = onnx_proto::load_model(tmpl_path)?;
     let graph = model
         .graph
@@ -283,24 +289,37 @@ pub(super) fn compute_circuit_signature(tmpl_path: &Path, curve: Option<&str>) -
         .ok_or_else(|| DsperseError::Slicer("no graph for signature".into()))?;
     let mut hasher = Sha256::new();
     if let Some(c) = curve {
-        hasher.update(c.as_bytes());
+        hash_bytes(&mut hasher, c.as_bytes());
     }
+    hasher.update((graph.node.len() as u64).to_le_bytes());
     for node in &graph.node {
-        hasher.update(node.op_type.as_bytes());
+        hash_bytes(&mut hasher, node.op_type.as_bytes());
+        hasher.update((node.input.len() as u64).to_le_bytes());
+        for inp in &node.input {
+            hash_bytes(&mut hasher, inp.as_bytes());
+        }
+        hasher.update((node.output.len() as u64).to_le_bytes());
+        for out in &node.output {
+            hash_bytes(&mut hasher, out.as_bytes());
+        }
+        hasher.update((node.attribute.len() as u64).to_le_bytes());
         for attr in &node.attribute {
-            hasher.update(attr.name.as_bytes());
+            hash_bytes(&mut hasher, attr.name.as_bytes());
             hasher.update(attr.r#type.to_le_bytes());
             hasher.update(attr.i.to_le_bytes());
             hasher.update(attr.f.to_le_bytes());
-            hasher.update(&attr.s);
+            hash_bytes(&mut hasher, &attr.s);
+            hasher.update((attr.ints.len() as u64).to_le_bytes());
             for v in &attr.ints {
                 hasher.update(v.to_le_bytes());
             }
+            hasher.update((attr.floats.len() as u64).to_le_bytes());
             for v in &attr.floats {
                 hasher.update(v.to_le_bytes());
             }
+            hasher.update((attr.strings.len() as u64).to_le_bytes());
             for v in &attr.strings {
-                hasher.update(v);
+                hash_bytes(&mut hasher, v);
             }
         }
     }
@@ -311,6 +330,7 @@ pub(super) fn compute_circuit_signature(tmpl_path: &Path, curve: Option<&str>) -
             continue;
         }
         if let Some(shape) = onnx_proto::shape_from_value_info(vi) {
+            hasher.update((shape.len() as u64).to_le_bytes());
             for d in &shape {
                 hasher.update(d.to_le_bytes());
             }
@@ -318,12 +338,15 @@ pub(super) fn compute_circuit_signature(tmpl_path: &Path, curve: Option<&str>) -
     }
     for vi in &graph.output {
         if let Some(shape) = onnx_proto::shape_from_value_info(vi) {
+            hasher.update((shape.len() as u64).to_le_bytes());
             for d in &shape {
                 hasher.update(d.to_le_bytes());
             }
         }
     }
+    hasher.update((graph.initializer.len() as u64).to_le_bytes());
     for init in &graph.initializer {
+        hasher.update((init.dims.len() as u64).to_le_bytes());
         for d in &init.dims {
             hasher.update(d.to_le_bytes());
         }

--- a/crates/dsperse/src/pipeline/compiler.rs
+++ b/crates/dsperse/src/pipeline/compiler.rs
@@ -335,6 +335,9 @@ pub(super) fn compute_circuit_signature(tmpl_path: &Path, curve: Option<&str>) -
                 hasher.update(d.to_le_bytes());
             }
         }
+        if let Some(dt) = onnx_proto::elem_type_from_value_info(vi) {
+            hasher.update(dt.to_le_bytes());
+        }
     }
     for vi in &graph.output {
         if let Some(shape) = onnx_proto::shape_from_value_info(vi) {
@@ -342,6 +345,9 @@ pub(super) fn compute_circuit_signature(tmpl_path: &Path, curve: Option<&str>) -
             for d in &shape {
                 hasher.update(d.to_le_bytes());
             }
+        }
+        if let Some(dt) = onnx_proto::elem_type_from_value_info(vi) {
+            hasher.update(dt.to_le_bytes());
         }
     }
     hasher.update((graph.initializer.len() as u64).to_le_bytes());

--- a/crates/dsperse/src/pipeline/packager.rs
+++ b/crates/dsperse/src/pipeline/packager.rs
@@ -8,6 +8,7 @@ use sha2::{Digest, Sha256};
 use walkdir::WalkDir;
 
 use crate::error::{DsperseError, Result};
+use crate::pipeline::compiler::compute_circuit_signature;
 use crate::pipeline::runner::load_model_metadata;
 use crate::schema::metadata::SliceMetadata;
 use crate::utils::paths::resolve_relative_path;
@@ -327,6 +328,60 @@ enum ComponentSource {
     OnnxFile(PathBuf),
 }
 
+fn resolve_source_onnx(slices_dir: &Path, slice: &SliceMetadata) -> Result<PathBuf> {
+    if let Some(ref cs) = slice.channel_split
+        && let Some(group) = cs.groups.first()
+    {
+        let p = resolve_relative_path(slices_dir, &group.path)?;
+        if p.is_file() {
+            return Ok(p);
+        }
+    }
+    if let Some(ref ds) = slice.dim_split
+        && let Some(ref tmpl) = ds.template_path
+    {
+        let p = resolve_relative_path(slices_dir, tmpl)?;
+        if p.is_file() {
+            return Ok(p);
+        }
+    }
+    if let Some(ref tiling) = slice.tiling
+        && let Some(ref tile) = tiling.tile
+    {
+        let p = resolve_relative_path(slices_dir, &tile.path)?;
+        if p.is_file() {
+            return Ok(p);
+        }
+    }
+    slice.resolve_onnx(slices_dir)
+}
+
+fn list_bundle_files(dir: &Path) -> Result<Vec<String>> {
+    let mut files = Vec::new();
+    for entry in WalkDir::new(dir) {
+        let entry = entry.map_err(|e| DsperseError::Other(e.to_string()))?;
+        reject_symlink(&entry)?;
+        if entry.file_type().is_file() {
+            let relative = entry
+                .path()
+                .strip_prefix(dir)
+                .map_err(|e| DsperseError::Other(e.to_string()))?
+                .components()
+                .map(|c| match c {
+                    std::path::Component::Normal(part) => Ok(part.to_string_lossy().into_owned()),
+                    _ => Err(DsperseError::Other(
+                        "unexpected non-normal path component in bundle".into(),
+                    )),
+                })
+                .collect::<Result<Vec<_>>>()?
+                .join("/");
+            files.push(relative);
+        }
+    }
+    files.sort();
+    Ok(files)
+}
+
 fn extract_component(
     slices_dir: &Path,
     slice: &SliceMetadata,
@@ -334,9 +389,11 @@ fn extract_component(
     curve: Option<&str>,
 ) -> Result<(String, Vec<String>, Option<String>, ComponentSource)> {
     if let Some(dir) = resolve_circuit_dir(slices_dir, slice)? {
-        let (hash, files) = hash_directory(&dir, curve)?;
+        let onnx_path = resolve_source_onnx(slices_dir, slice)?;
+        let sig = compute_circuit_signature(&onnx_path, curve)?;
+        let files = list_bundle_files(&dir)?;
         return Ok((
-            hash,
+            sig,
             files,
             Some("jstprove".to_string()),
             ComponentSource::CircuitBundle(dir),
@@ -466,63 +523,6 @@ fn hash_named_file(path: &Path, filename: &str, curve: Option<&str>) -> Result<S
     Ok(encode_hex(&hasher.finalize()))
 }
 
-fn hash_directory(dir: &Path, curve: Option<&str>) -> Result<(String, Vec<String>)> {
-    let mut entries: Vec<(String, PathBuf)> = Vec::new();
-    for entry in WalkDir::new(dir) {
-        let entry = entry.map_err(|e| DsperseError::Other(e.to_string()))?;
-        reject_symlink(&entry)?;
-        if entry.file_type().is_file() {
-            let relative = entry
-                .path()
-                .strip_prefix(dir)
-                .map_err(|e| DsperseError::Other(e.to_string()))?
-                .components()
-                .map(|c| match c {
-                    std::path::Component::Normal(part) => Ok(part.to_string_lossy().into_owned()),
-                    _ => Err(DsperseError::Other(
-                        "unexpected non-normal path component in bundle".into(),
-                    )),
-                })
-                .collect::<Result<Vec<_>>>()?
-                .join("/");
-            entries.push((relative, entry.path().to_path_buf()));
-        }
-    }
-    entries.sort_by(|a, b| a.0.cmp(&b.0));
-
-    let mut hasher = Sha256::new();
-    if let Some(c) = curve {
-        let c_bytes = c.as_bytes();
-        hasher.update((c_bytes.len() as u64).to_le_bytes());
-        hasher.update(c_bytes);
-    }
-    let file_names: Vec<String> = entries.iter().map(|(name, _)| name.clone()).collect();
-
-    for (name, path) in &entries {
-        let name_bytes = name.as_bytes();
-        hasher.update((name_bytes.len() as u64).to_le_bytes());
-        hasher.update(name_bytes);
-
-        let mut file = fs::File::open(path).map_err(|e| DsperseError::io(e, path))?;
-        let file_len = file
-            .metadata()
-            .map_err(|e| DsperseError::io(e, path))?
-            .len();
-        hasher.update(file_len.to_le_bytes());
-        let mut buf = [0u8; 8192];
-        loop {
-            let n = file.read(&mut buf).map_err(|e| DsperseError::io(e, path))?;
-            if n == 0 {
-                break;
-            }
-            hasher.update(&buf[..n]);
-        }
-    }
-
-    let hash = encode_hex(&hasher.finalize());
-    Ok((hash, file_names))
-}
-
 fn sha256_bytes(data: &[u8]) -> String {
     let mut hasher = Sha256::new();
     hasher.update(data);
@@ -572,6 +572,25 @@ mod tests {
     use crate::schema::metadata::{
         Compilation, Dependencies, ModelMetadata, SliceShapeWrapper, TensorShape,
     };
+    use crate::slicer::onnx_proto;
+
+    fn write_minimal_onnx(path: &Path, input_dim: i64) {
+        let node = onnx_proto::NodeProto {
+            op_type: "Relu".to_string(),
+            input: vec!["x".to_string()],
+            output: vec!["y".to_string()],
+            ..Default::default()
+        };
+        let graph = onnx_proto::make_graph(
+            "g",
+            vec![node],
+            vec![onnx_proto::make_tensor_value_info("x", 1, &[1, input_dim])],
+            vec![onnx_proto::make_tensor_value_info("y", 1, &[1, input_dim])],
+            vec![],
+        );
+        let model = onnx_proto::make_model(graph, 13);
+        onnx_proto::save_model(&model, path).unwrap();
+    }
 
     fn create_test_model_metadata(slices_dir: &Path, count: usize) {
         let mut slices = Vec::new();
@@ -579,11 +598,10 @@ mod tests {
             let slice_dir = slices_dir.join(format!("slice_{}", i));
             let payload_dir = slice_dir.join("payload");
             fs::create_dir_all(&payload_dir).unwrap();
-            fs::write(
-                payload_dir.join(format!("slice_{}.onnx", i)),
-                format!("onnx_data_{}", i),
-            )
-            .unwrap();
+            write_minimal_onnx(
+                &payload_dir.join(format!("slice_{}.onnx", i)),
+                (64 + i) as i64,
+            );
 
             let circuit_dir = slice_dir.join("jstprove").join("circuit.bundle");
             fs::create_dir_all(&circuit_dir).unwrap();
@@ -1156,11 +1174,7 @@ mod tests {
             let slice_dir = slices_dir.join(format!("slice_{}", i));
             let payload_dir = slice_dir.join("payload");
             fs::create_dir_all(&payload_dir).unwrap();
-            fs::write(
-                payload_dir.join(format!("slice_{}.onnx", i)),
-                format!("onnx_data_{}", i),
-            )
-            .unwrap();
+            write_minimal_onnx(&payload_dir.join(format!("slice_{}.onnx", i)), 64);
             let circuit_dir = slice_dir.join("jstprove").join("circuit.bundle");
             fs::create_dir_all(&circuit_dir).unwrap();
             fs::write(circuit_dir.join("circuit.bin"), "shared_circuit_data").unwrap();
@@ -1223,7 +1237,7 @@ mod tests {
         let result = package_content_addressed(&slices_dir, &config).unwrap();
 
         assert_eq!(result.component_count, 1);
-        assert_eq!(result.wb_count, 5);
+        assert_eq!(result.wb_count, 3);
 
         let manifest: serde_json::Value =
             rmp_serde::from_slice(&fs::read(output_dir.join("manifest.msgpack")).unwrap()).unwrap();

--- a/crates/dsperse/src/pipeline/packager.rs
+++ b/crates/dsperse/src/pipeline/packager.rs
@@ -379,7 +379,9 @@ fn resolve_source_onnx(slices_dir: &Path, slice: &SliceMetadata) -> Result<PathB
         }
         return Ok(p);
     }
-    slice.resolve_onnx(slices_dir)
+    let p = slice.resolve_onnx(slices_dir)?;
+    reject_symlink_path(&p)?;
+    Ok(p)
 }
 
 fn list_bundle_files(dir: &Path) -> Result<Vec<String>> {

--- a/crates/dsperse/src/pipeline/packager.rs
+++ b/crates/dsperse/src/pipeline/packager.rs
@@ -341,25 +341,43 @@ fn resolve_source_onnx(slices_dir: &Path, slice: &SliceMetadata) -> Result<PathB
         && let Some(group) = cs.groups.first()
     {
         let p = resolve_relative_path(slices_dir, &group.path)?;
-        if p.is_file() {
-            return Ok(p);
+        reject_symlink_path(&p)?;
+        if !p.is_file() {
+            return Err(DsperseError::Other(format!(
+                "slice {} channel group ONNX configured but missing: {}",
+                slice.index,
+                p.display()
+            )));
         }
+        return Ok(p);
     }
     if let Some(ref ds) = slice.dim_split
         && let Some(ref tmpl) = ds.template_path
     {
         let p = resolve_relative_path(slices_dir, tmpl)?;
-        if p.is_file() {
-            return Ok(p);
+        reject_symlink_path(&p)?;
+        if !p.is_file() {
+            return Err(DsperseError::Other(format!(
+                "slice {} dim-split template configured but missing: {}",
+                slice.index,
+                p.display()
+            )));
         }
+        return Ok(p);
     }
     if let Some(ref tiling) = slice.tiling
         && let Some(ref tile) = tiling.tile
     {
         let p = resolve_relative_path(slices_dir, &tile.path)?;
-        if p.is_file() {
-            return Ok(p);
+        reject_symlink_path(&p)?;
+        if !p.is_file() {
+            return Err(DsperseError::Other(format!(
+                "slice {} tile ONNX configured but missing: {}",
+                slice.index,
+                p.display()
+            )));
         }
+        return Ok(p);
     }
     slice.resolve_onnx(slices_dir)
 }

--- a/crates/dsperse/src/pipeline/packager.rs
+++ b/crates/dsperse/src/pipeline/packager.rs
@@ -320,6 +320,14 @@ fn resolve_circuit_dir(slices_dir: &Path, slice: &SliceMetadata) -> Result<Optio
             return Ok(Some(abs));
         }
     }
+    if let Some(ref ds) = slice.dim_split
+        && let Some(ref circuit_path) = ds.jstprove_circuit_path
+    {
+        let abs = resolve_relative_path(slices_dir, circuit_path)?;
+        if abs.is_dir() {
+            return Ok(Some(abs));
+        }
+    }
     Ok(None)
 }
 


### PR DESCRIPTION
## Summary

- Replaces content-addressed bundle hashing (`hash_directory`) in the packager with graph-topology-based signatures derived from the source ONNX
- Renames `compute_template_signature` → `compute_circuit_signature`, makes it `pub(super)` for cross-module use, adds `curve` parameter
- Signature now covers all attribute fields (`s`, `floats`, `strings`, `type`) in addition to existing `i`, `f`, `ints` — previously missing fields like `auto_pad` string attributes were not included
- Uses full 64-char SHA256 hex instead of truncated 16-char prefix
- Removes `hash_directory` (dead code after migration)

The signature hashes only what defines the constraint system: operator types, all ONNX attributes, non-initializer input shapes, output shapes, initializer dimensions, data types, and curve. Weight values are excluded — only their wire shapes matter.

## Test plan

- [ ] Verify `cargo test --locked` passes (213 tests)
- [ ] Verify `cargo clippy -- -D warnings` clean
- [ ] Package a model and confirm manifest `sha256` fields are 64-char hex derived from ONNX topology
- [ ] Package the same model with different curves and confirm different component hashes
- [ ] Package a model with structurally identical slices and confirm component deduplication

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Circuit signatures now include richer model metadata (node counts, inputs/outputs, attributes, shapes, element types) and optional curve info, and use full digests for improved cache accuracy and deduplication.
  * Bundle/component identity now derives from deterministic ONNX-based signatures and deterministic, sorted file listings.

* **Bug Fixes**
  * Improved handling of missing/invalid configured files and rejection of symlinks for bundle inputs.

* **Tests**
  * Tests now use minimal real model files and reflect adjusted deduplication expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->