### PR TITLE
Introduce slice analysis command and verbose compilation diagnostics

### DIFF
--- a/crates/dsperse/src/cli/mod.rs
+++ b/crates/dsperse/src/cli/mod.rs
@@ -637,12 +637,18 @@ impl std::fmt::Display for AnalyzeFormat {
 fn cmd_analyze(args: AnalyzeArgs) -> Result<()> {
     let slices_dir = resolve_slices_dir(args.slices_dir, &args.model_dir);
     let ops = resolve_circuit_ops(&args.proof_system, args.circuit_ops.as_deref())?;
+    // Validate proof_config through the same parser cmd_compile and
+    // cmd_full_run use so a typo in --proof-config fails fast with a
+    // "unknown proof config 'foo'" message rather than silently
+    // producing signatures under an unintended curve.
+    let proof_config = parse_proof_config(&args.proof_config)?;
+    let proof_config_name = proof_config.to_string();
 
     let reports = pipeline::analyze_slices(
         &slices_dir,
         &ops.as_refs(),
         args.skip_compile_over_size,
-        Some(args.proof_config.as_str()),
+        Some(proof_config_name.as_str()),
     )?;
 
     if matches!(args.format, AnalyzeFormat::Json) {

--- a/crates/dsperse/src/cli/mod.rs
+++ b/crates/dsperse/src/cli/mod.rs
@@ -38,6 +38,7 @@ pub enum Commands {
     Publish(PublishArgs),
     #[command(name = "full-run")]
     FullRun(FullRunArgs),
+    Analyze(AnalyzeArgs),
 }
 
 pub fn dispatch(command: Commands) -> Result<()> {
@@ -51,6 +52,7 @@ pub fn dispatch(command: Commands) -> Result<()> {
         Commands::Package(args) => cmd_package(args),
         Commands::Publish(args) => cmd_publish(args),
         Commands::FullRun(args) => cmd_full_run(args),
+        Commands::Analyze(args) => cmd_analyze(args),
     }
 }
 
@@ -129,6 +131,13 @@ pub struct CompileArgs {
         help = "Skip compilation of slices whose estimated constraint count exceeds this threshold"
     )]
     pub skip_compile_over_size: Option<u64>,
+    #[arg(
+        long,
+        default_value_t = false,
+        action = clap::ArgAction::Set,
+        help = "Allow the command to exit 0 when individual slices fail to compile.  Failed slices fall back to ONNX execution at run / prove time, producing a partial-coverage proof.  Off by default so CI surfaces real compile regressions."
+    )]
+    pub allow_onnx_fallback: bool,
 }
 
 #[derive(Args)]
@@ -286,6 +295,13 @@ pub struct FullRunArgs {
         help = "Skip compilation of slices whose estimated constraint count exceeds this threshold"
     )]
     pub skip_compile_over_size: Option<u64>,
+    #[arg(
+        long,
+        default_value_t = false,
+        action = clap::ArgAction::Set,
+        help = "Allow full-run to proceed when individual slices fail to compile.  Failed slices fall back to ONNX execution, producing a partial-coverage proof.  Off by default so CI surfaces real compile regressions."
+    )]
+    pub allow_onnx_fallback: bool,
 }
 
 struct CircuitOps(Vec<String>);
@@ -377,7 +393,7 @@ pub fn cmd_compile(args: CompileArgs) -> Result<()> {
 
     let ops = resolve_circuit_ops(&args.proof_system, args.circuit_ops.as_deref())?;
 
-    pipeline::compile_slices(
+    let report = pipeline::compile_slices(
         &slices_dir,
         &backend,
         proof_config,
@@ -386,7 +402,12 @@ pub fn cmd_compile(args: CompileArgs) -> Result<()> {
         layers.as_deref(),
         &ops.as_refs(),
         args.skip_compile_over_size,
-    )
+    )?;
+    if args.allow_onnx_fallback {
+        Ok(())
+    } else {
+        report.ok_if_no_failures().map(|_| ())
+    }
 }
 
 pub fn cmd_run(args: RunArgs) -> Result<()> {
@@ -524,7 +545,7 @@ pub fn cmd_full_run(args: FullRunArgs) -> Result<()> {
     let ops = resolve_circuit_ops(&args.proof_system, args.circuit_ops.as_deref())?;
 
     tracing::info!("compiling slices");
-    pipeline::compile_slices(
+    let report = pipeline::compile_slices(
         &slices_dir,
         &backend,
         proof_config,
@@ -534,6 +555,9 @@ pub fn cmd_full_run(args: FullRunArgs) -> Result<()> {
         &ops.as_refs(),
         args.skip_compile_over_size,
     )?;
+    if !args.allow_onnx_fallback {
+        report.ok_if_no_failures()?;
+    }
 
     let run_dir = args.model_dir.join("run").join(format!("run_{}", run_id()));
 
@@ -554,6 +578,127 @@ pub fn cmd_full_run(args: FullRunArgs) -> Result<()> {
     pipeline::verify_run(&run_dir, &slices_dir, &backend, args.parallel.get())?;
 
     tracing::info!(run_dir = %run_dir.display(), "full run complete");
+    Ok(())
+}
+
+#[derive(Args)]
+pub struct AnalyzeArgs {
+    #[arg(long)]
+    pub model_dir: PathBuf,
+    #[arg(long)]
+    pub slices_dir: Option<PathBuf>,
+    #[arg(
+        long,
+        default_value = "expander",
+        help = "Proof system backend (expander or remainder)"
+    )]
+    pub proof_system: String,
+    #[arg(
+        long,
+        help = "Comma-separated ONNX op names to compile via the proof backend"
+    )]
+    pub circuit_ops: Option<String>,
+    #[arg(
+        long,
+        help = "Skip slices whose estimated constraint count exceeds this"
+    )]
+    pub skip_compile_over_size: Option<u64>,
+    #[arg(
+        long,
+        default_value = "bn254_raw",
+        help = "Proof config for circuit signature computation",
+        aliases = ["--curve"]
+    )]
+    pub proof_config: String,
+    #[arg(long, default_value = "table", help = "Output format: table or json")]
+    pub format: String,
+}
+
+fn cmd_analyze(args: AnalyzeArgs) -> Result<()> {
+    let slices_dir = resolve_slices_dir(args.slices_dir, &args.model_dir);
+    let ops = resolve_circuit_ops(&args.proof_system, args.circuit_ops.as_deref())?;
+
+    let reports = pipeline::analyze_slices(
+        &slices_dir,
+        &ops.as_refs(),
+        args.skip_compile_over_size,
+        Some(args.proof_config.as_str()),
+    )?;
+
+    if args.format == "json" {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&reports)
+                .map_err(|e| DsperseError::Other(e.to_string()))?
+        );
+    } else {
+        let hdr_ops = "OPS";
+        println!(
+            "{:<8} {:<10} {:<28} {:<14} {:<6} {:<6} {:<6} {:<12} {hdr_ops}",
+            "SLICE", "BACKEND", "REASON", "EST.CONSTR", "TILED", "CHSPL", "DMSPL", "SIGNATURE"
+        );
+        println!("{}", "-".repeat(120));
+
+        let mut jstprove_count = 0usize;
+        let mut onnx_count = 0usize;
+        let mut missing_count = 0usize;
+        let mut total_constraints: u64 = 0;
+        let mut unique_sigs: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+        for r in &reports {
+            let est = r
+                .estimated_constraints
+                .map(|c| format!("{c}"))
+                .unwrap_or_default();
+            let sig = r
+                .circuit_signature
+                .as_deref()
+                .map(|s| &s[..12.min(s.len())])
+                .unwrap_or("");
+            println!(
+                "{:<8} {:<10} {:<28} {:<14} {:<6} {:<6} {:<6} {:<12} {}",
+                r.index,
+                r.backend,
+                r.reason,
+                est,
+                r.tiled,
+                r.channel_split,
+                r.dim_split,
+                sig,
+                r.ops,
+            );
+            match r.backend.as_str() {
+                "jstprove" => jstprove_count += 1,
+                "onnx" => onnx_count += 1,
+                "missing" => missing_count += 1,
+                other => {
+                    tracing::warn!(
+                        slice = r.index,
+                        backend = other,
+                        "analyze: unknown backend classification; not counted"
+                    );
+                }
+            }
+            if let Some(c) = r.estimated_constraints {
+                total_constraints += c;
+            }
+            if let Some(ref s) = r.circuit_signature {
+                unique_sigs.insert(s.clone());
+            }
+        }
+
+        println!("{}", "-".repeat(120));
+        println!(
+            "total: {} slices | jstprove: {} | onnx: {} | missing: {} | unique circuits: {} | total constraints: {}",
+            reports.len(),
+            jstprove_count,
+            onnx_count,
+            missing_count,
+            unique_sigs.len(),
+            total_constraints,
+        );
+    }
+
     Ok(())
 }
 

--- a/crates/dsperse/src/cli/mod.rs
+++ b/crates/dsperse/src/cli/mod.rs
@@ -604,14 +604,34 @@ pub struct AnalyzeArgs {
     )]
     pub skip_compile_over_size: Option<u64>,
     #[arg(
-        long,
+        long = "proof-config",
+        visible_alias = "curve",
         default_value = "bn254_raw",
-        help = "Proof config for circuit signature computation",
-        aliases = ["--curve"]
+        help = "Proof config for circuit signature computation"
     )]
     pub proof_config: String,
-    #[arg(long, default_value = "table", help = "Output format: table or json")]
-    pub format: String,
+    #[arg(
+        long,
+        default_value_t = AnalyzeFormat::Table,
+        value_enum,
+        help = "Output format"
+    )]
+    pub format: AnalyzeFormat,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub enum AnalyzeFormat {
+    Table,
+    Json,
+}
+
+impl std::fmt::Display for AnalyzeFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Table => f.write_str("table"),
+            Self::Json => f.write_str("json"),
+        }
+    }
 }
 
 fn cmd_analyze(args: AnalyzeArgs) -> Result<()> {
@@ -625,7 +645,7 @@ fn cmd_analyze(args: AnalyzeArgs) -> Result<()> {
         Some(args.proof_config.as_str()),
     )?;
 
-    if args.format == "json" {
+    if matches!(args.format, AnalyzeFormat::Json) {
         println!(
             "{}",
             serde_json::to_string_pretty(&reports)

--- a/crates/dsperse/src/pipeline/compiler.rs
+++ b/crates/dsperse/src/pipeline/compiler.rs
@@ -260,11 +260,13 @@ pub fn compile_slices(
     let errors = errors.into_inner().unwrap();
     let (metadata, cs_dirty) = meta_mutex.into_inner().unwrap();
     if cs_dirty {
-        if let Err(e) = metadata.save(&meta_path) {
-            tracing::error!(error = %e, "failed to persist split circuit paths");
-        } else {
-            tracing::info!("persisted split circuit paths to metadata");
-        }
+        // Swallowing the save failure would let downstream
+        // analyze / run / package observe an in-memory set of
+        // materialised channel / dim-split circuit paths that the
+        // on-disk metadata doesn't know about -- the very problem
+        // normalize_split_metadata exists to prevent.  Propagate.
+        metadata.save(&meta_path)?;
+        tracing::info!("persisted split circuit paths to metadata");
     }
     let compiled_count = compiled_count.load(std::sync::atomic::Ordering::Relaxed);
 
@@ -571,9 +573,14 @@ pub fn analyze_slices(
         let onnx_path = match resolve_compile_onnx(slices_dir, slice) {
             Ok(p) => p,
             Err(_) => {
+                // resolve_compile_onnx failing means the slice has
+                // no ONNX artefact on disk at all.  That is a
+                // genuine "missing" state (the analyse footer
+                // already has a dedicated missing count), not an
+                // "onnx-backend-compatible" slice.
                 reports.push(SliceAnalysisReport {
                     index: slice.index,
-                    backend: "onnx".into(),
+                    backend: "missing".into(),
                     reason: "onnx not found".into(),
                     estimated_constraints: None,
                     ops: String::new(),
@@ -587,9 +594,13 @@ pub fn analyze_slices(
         };
 
         if !onnx_path.exists() {
+            // Same reasoning as the resolve_compile_onnx Err branch
+            // above: path was resolvable by metadata but the file
+            // is absent, so the slice is missing rather than ONNX-
+            // compatible.
             reports.push(SliceAnalysisReport {
                 index: slice.index,
-                backend: "onnx".into(),
+                backend: "missing".into(),
                 reason: "onnx not found".into(),
                 estimated_constraints: None,
                 ops: String::new(),
@@ -950,7 +961,37 @@ fn compile_channel_split_slice(
     let shared_circuit_rel = format!("slice_{}/jstprove/shared/circuit.bundle", slice.index);
     let shared_circuit_path = jst_dir.join("shared").join("circuit.bundle");
 
-    if !shared_circuit_path.is_dir() {
+    // Treat an existing shared bundle the same way the standard-
+    // slice path does: try to load it; if load_params rejects it
+    // (version drift, partial write, corruption), drop the stale
+    // directory and fall through to the compile-fresh branch so a
+    // single bad bundle doesn't permanently wedge every slice in
+    // the channel-split group.  The fresh-build code below is
+    // unchanged and will re-populate from the circuit cache or
+    // via backend.compile as appropriate.
+    let mut needs_build = !shared_circuit_path.is_dir();
+    if !needs_build {
+        match backend.load_params(&shared_circuit_path) {
+            Ok(_) => {
+                tracing::info!(
+                    slice = slice.index,
+                    "shared circuit already compiled, reusing"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    slice = slice.index,
+                    error = %e,
+                    "cached shared circuit invalid, recompiling"
+                );
+                std::fs::remove_dir_all(&shared_circuit_path)
+                    .map_err(|e| DsperseError::io(e, &shared_circuit_path))?;
+                needs_build = true;
+            }
+        }
+    }
+
+    if needs_build {
         let first_group = cs.groups.first().ok_or_else(|| {
             DsperseError::Pipeline(format!("slice {} channel_split has no groups", slice.index))
         })?;
@@ -1043,17 +1084,18 @@ fn compile_channel_split_slice(
                 .insert(sig.clone(), shared_circuit_path.clone());
             tracing::info!(slice = slice.index, sig = %sig, "shared circuit compiled");
         }
-    } else {
+
+        // One final load to match the cached-bundle branch's
+        // invariant: the function returns only after we have seen
+        // a viable shared circuit at shared_circuit_path.  If the
+        // freshly-built bundle still fails to load, a retry would
+        // recurse indefinitely, so surface the error.
         backend.load_params(&shared_circuit_path).map_err(|e| {
             DsperseError::Pipeline(format!(
-                "slice {} cached shared circuit invalid: {e}",
+                "slice {} freshly-built shared circuit failed to load: {e}",
                 slice.index
             ))
         })?;
-        tracing::info!(
-            slice = slice.index,
-            "shared circuit already compiled, reusing"
-        );
     }
 
     let group_circuits: Vec<(usize, String)> = cs

--- a/crates/dsperse/src/pipeline/compiler.rs
+++ b/crates/dsperse/src/pipeline/compiler.rs
@@ -26,6 +26,32 @@ enum CompileOutcome {
     },
 }
 
+/// Summary of a compile_slices invocation.  The pass returns Ok
+/// even when individual slice compilations fail, so callers must
+/// inspect `failed` to decide whether to proceed (e.g. allow
+/// partial-coverage ONNX fallback) or abort.  Keeping the
+/// compiled count explicit lets the CLI / analyze command
+/// report a structured summary instead of inferring success from
+/// log lines.
+#[derive(Debug, Default)]
+pub struct CompileReport {
+    pub compiled: usize,
+    pub failed: Vec<(usize, DsperseError)>,
+}
+
+impl CompileReport {
+    pub fn ok_if_no_failures(self) -> Result<Self> {
+        if self.failed.is_empty() {
+            Ok(self)
+        } else {
+            Err(DsperseError::Pipeline(format!(
+                "compile_slices: {} slice(s) failed to compile; set --allow-onnx-fallback to proceed with partial coverage",
+                self.failed.len()
+            )))
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn compile_slices(
     slices_dir: &Path,
@@ -36,7 +62,7 @@ pub fn compile_slices(
     layers: Option<&[usize]>,
     jstprove_ops: &[&str],
     skip_compile_over_size: Option<u64>,
-) -> Result<()> {
+) -> Result<CompileReport> {
     let meta_path = find_metadata_path(slices_dir).ok_or_else(|| {
         DsperseError::Metadata(format!(
             "no {} found in slices directory",
@@ -213,23 +239,20 @@ pub fn compile_slices(
 
     if errors.is_empty() {
         tracing::info!(count = compiled_count, "all slices compiled");
-        Ok(())
     } else {
         tracing::warn!(
             compiled = compiled_count,
             failed = errors.len(),
-            "compilation completed with errors"
+            "compilation completed with errors; failed slices fall back to ONNX execution if the caller allows partial coverage"
         );
-        let msg = errors
-            .iter()
-            .map(|(idx, e)| format!("slice {idx}: {e}"))
-            .collect::<Vec<_>>()
-            .join("; ");
-        Err(DsperseError::Pipeline(format!(
-            "{} slices failed: {msg}",
-            errors.len()
-        )))
+        for (idx, e) in &errors {
+            tracing::warn!(slice = idx, error = %e, "slice compilation failed");
+        }
     }
+    Ok(CompileReport {
+        compiled: compiled_count,
+        failed: errors,
+    })
 }
 
 struct SliceAnalysis {
@@ -360,6 +383,184 @@ pub(super) fn compute_circuit_signature(tmpl_path: &Path, curve: Option<&str>) -
     }
     let hash = hasher.finalize();
     Ok(format!("{:x}", hash))
+}
+
+fn summarize_onnx_ops(onnx_path: &Path) -> String {
+    let model = match onnx_proto::load_model(onnx_path) {
+        Ok(m) => m,
+        Err(_) => return String::from("?"),
+    };
+    let graph = match model.graph.as_ref() {
+        Some(g) => g,
+        None => return String::from("?"),
+    };
+    let mut counts: std::collections::BTreeMap<&str, usize> = std::collections::BTreeMap::new();
+    for node in &graph.node {
+        *counts.entry(node.op_type.as_str()).or_default() += 1;
+    }
+    counts
+        .iter()
+        .map(|(op, n)| {
+            if *n > 1 {
+                format!("{op}x{n}")
+            } else {
+                op.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct SliceAnalysisReport {
+    pub index: usize,
+    pub backend: String,
+    pub reason: String,
+    pub estimated_constraints: Option<u64>,
+    pub ops: String,
+    pub tiled: bool,
+    pub channel_split: bool,
+    pub dim_split: bool,
+    pub circuit_signature: Option<String>,
+}
+
+pub fn analyze_slices(
+    slices_dir: &Path,
+    jstprove_ops: &[&str],
+    skip_compile_over_size: Option<u64>,
+    proof_config: Option<&str>,
+) -> Result<Vec<SliceAnalysisReport>> {
+    let meta_path = find_metadata_path(slices_dir).ok_or_else(|| {
+        DsperseError::Metadata(format!(
+            "no {} found in slices directory",
+            crate::utils::paths::METADATA_FILE
+        ))
+    })?;
+    let metadata = ModelMetadata::load(&meta_path)?;
+    let mut reports = Vec::with_capacity(metadata.slices.len());
+
+    for slice in &metadata.slices {
+        let slice_dir = slice_dir_path(slices_dir, slice.index);
+        if !slice_dir.exists() {
+            reports.push(SliceAnalysisReport {
+                index: slice.index,
+                backend: "missing".into(),
+                reason: "slice directory not found".into(),
+                estimated_constraints: None,
+                ops: String::new(),
+                tiled: slice.tiling.is_some(),
+                channel_split: slice.channel_split.is_some(),
+                dim_split: slice.dim_split.is_some(),
+                circuit_signature: None,
+            });
+            continue;
+        }
+
+        if slice
+            .channel_split
+            .as_ref()
+            .is_some_and(|cs| !cs.groups.is_empty())
+        {
+            reports.push(SliceAnalysisReport {
+                index: slice.index,
+                backend: "jstprove".into(),
+                reason: "channel-split".into(),
+                estimated_constraints: None,
+                ops: String::new(),
+                tiled: slice.tiling.is_some(),
+                channel_split: true,
+                dim_split: false,
+                circuit_signature: None,
+            });
+            continue;
+        }
+
+        if let Some(ref ds) = slice.dim_split
+            && ds.template_path.is_some()
+        {
+            reports.push(SliceAnalysisReport {
+                index: slice.index,
+                backend: "jstprove".into(),
+                reason: "dim-split".into(),
+                estimated_constraints: None,
+                ops: String::new(),
+                tiled: slice.tiling.is_some(),
+                channel_split: false,
+                dim_split: true,
+                circuit_signature: None,
+            });
+            continue;
+        }
+
+        let onnx_path = match resolve_compile_onnx(slices_dir, slice) {
+            Ok(p) => p,
+            Err(_) => {
+                reports.push(SliceAnalysisReport {
+                    index: slice.index,
+                    backend: "onnx".into(),
+                    reason: "onnx not found".into(),
+                    estimated_constraints: None,
+                    ops: String::new(),
+                    tiled: slice.tiling.is_some(),
+                    channel_split: false,
+                    dim_split: false,
+                    circuit_signature: None,
+                });
+                continue;
+            }
+        };
+
+        if !onnx_path.exists() {
+            reports.push(SliceAnalysisReport {
+                index: slice.index,
+                backend: "onnx".into(),
+                reason: "onnx not found".into(),
+                estimated_constraints: None,
+                ops: String::new(),
+                tiled: slice.tiling.is_some(),
+                channel_split: false,
+                dim_split: false,
+                circuit_signature: None,
+            });
+            continue;
+        }
+
+        let ops = summarize_onnx_ops(&onnx_path);
+        let analysis = analyze_slice_onnx(&onnx_path, jstprove_ops);
+        let estimated = estimate_onnx_constraints(&onnx_path).ok();
+        let sig = compute_circuit_signature(&onnx_path, proof_config).ok();
+
+        let (backend, reason) = match analysis {
+            Ok(a) if !a.compatible => ("onnx", "unsupported ops"),
+            Ok(a) if a.data_movement_only => ("onnx", "data movement only"),
+            Ok(_) => {
+                if let (Some(est), Some(thresh)) = (estimated, skip_compile_over_size) {
+                    if est > thresh {
+                        ("onnx", "exceeds size threshold")
+                    } else {
+                        ("jstprove", "compilable")
+                    }
+                } else {
+                    ("jstprove", "compilable")
+                }
+            }
+            Err(_) => ("onnx", "analysis failed"),
+        };
+
+        reports.push(SliceAnalysisReport {
+            index: slice.index,
+            backend: backend.into(),
+            reason: reason.into(),
+            estimated_constraints: estimated,
+            ops,
+            tiled: slice.tiling.is_some(),
+            channel_split: false,
+            dim_split: slice.dim_split.is_some(),
+            circuit_signature: sig,
+        });
+    }
+
+    Ok(reports)
 }
 
 fn estimate_onnx_constraints(onnx_path: &Path) -> Result<u64> {
@@ -540,6 +741,21 @@ fn compile_single_slice(
     }
 
     let effective_wai = weights_as_inputs;
+
+    let estimated = estimate_onnx_constraints(&onnx_path).ok();
+    let op_summary = summarize_onnx_ops(&onnx_path);
+
+    tracing::debug!(
+        slice = slice.index,
+        onnx = %onnx_path.display(),
+        estimated_constraints = ?estimated,
+        weights_as_inputs = effective_wai,
+        ops = %op_summary,
+        tiled = slice.tiling.is_some(),
+        channel_split = slice.channel_split.is_some(),
+        dim_split = slice.dim_split.is_some(),
+        "compiling slice"
+    );
 
     let compile_onnx = normalize_slice_for_backend(&onnx_path)?;
 
@@ -806,8 +1022,25 @@ fn compile_dim_split_template(
             .as_ref()
             .map(|ds| ds.estimated_group_constraints)
             .filter(|&e| e > 0)
-            .unwrap_or_else(|| estimate_onnx_constraints(tmpl_path).unwrap_or(0));
-        if estimated > threshold {
+            .or_else(|| match estimate_onnx_constraints(tmpl_path) {
+                Ok(e) => Some(e),
+                Err(err) => {
+                    // We can't turn an unknown cost into a safe
+                    // gating decision, so fall through and let the
+                    // compile attempt surface the real error rather
+                    // than silently treating the slice as tiny.
+                    tracing::warn!(
+                        slice = slice.index,
+                        onnx = %tmpl_path.display(),
+                        error = %err,
+                        "skip_compile_over_size: constraint estimate failed; proceeding to compile"
+                    );
+                    None
+                }
+            });
+        if let Some(estimated) = estimated
+            && estimated > threshold
+        {
             return Ok(CompileOutcome::SkippedOverSize {
                 estimated,
                 threshold,

--- a/crates/dsperse/src/pipeline/compiler.rs
+++ b/crates/dsperse/src/pipeline/compiler.rs
@@ -52,27 +52,21 @@ impl CompileReport {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-pub fn compile_slices(
+/// Backfill split metadata fields that only become resolvable after
+/// slicing (channel_split.groups populated from disk,
+/// dim_split.template_path inferred from the materialized template
+/// ONNX), and strip dim_split entries whose template could not be
+/// materialized.  Called from both compile_slices and analyze_slices
+/// so the two classifications agree on what actually counts as a
+/// channel- or dim-split slice.  Persists the normalised metadata
+/// back to disk when any field changes.
+fn normalize_split_metadata(
     slices_dir: &Path,
-    backend: &JstproveBackend,
-    proof_config: jstprove_circuits::api::ProofConfigType,
-    parallel: usize,
-    weights_as_inputs: bool,
-    layers: Option<&[usize]>,
-    jstprove_ops: &[&str],
-    skip_compile_over_size: Option<u64>,
-) -> Result<CompileReport> {
-    let meta_path = find_metadata_path(slices_dir).ok_or_else(|| {
-        DsperseError::Metadata(format!(
-            "no {} found in slices directory",
-            crate::utils::paths::METADATA_FILE
-        ))
-    })?;
-    let mut metadata = ModelMetadata::load(&meta_path)?;
-
+    meta_path: &Path,
+    metadata: &mut ModelMetadata,
+) -> Result<()> {
     if metadata.original_model_path.is_some() {
-        crate::slicer::materializer::ensure_all_slices_materialized(slices_dir, &metadata)?;
+        crate::slicer::materializer::ensure_all_slices_materialized(slices_dir, metadata)?;
     }
 
     let mut metadata_dirty = false;
@@ -95,11 +89,12 @@ pub fn compile_slices(
             }
         }
     }
-    // Strip dim_split metadata from slices where template creation failed
-    // (axis-separability rejection, unsupported split kind). Leaving stale
-    // dim_split entries in the metadata causes downstream runners and the
-    // packager to emit bundles that fail at the strategy validation stage
-    // ("dim_split present but template_path is missing").
+    // Strip dim_split metadata from slices where template creation
+    // failed (axis-separability rejection, unsupported split kind).
+    // Leaving stale dim_split entries in the metadata causes
+    // downstream runners and the packager to emit bundles that fail
+    // at the strategy validation stage ("dim_split present but
+    // template_path is missing").
     for slice in &mut metadata.slices {
         if slice
             .dim_split
@@ -115,9 +110,31 @@ pub fn compile_slices(
         }
     }
     if metadata_dirty {
-        metadata.save(&meta_path)?;
+        metadata.save(meta_path)?;
         tracing::info!("persisted materialized split groups to metadata");
     }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn compile_slices(
+    slices_dir: &Path,
+    backend: &JstproveBackend,
+    proof_config: jstprove_circuits::api::ProofConfigType,
+    parallel: usize,
+    weights_as_inputs: bool,
+    layers: Option<&[usize]>,
+    jstprove_ops: &[&str],
+    skip_compile_over_size: Option<u64>,
+) -> Result<CompileReport> {
+    let meta_path = find_metadata_path(slices_dir).ok_or_else(|| {
+        DsperseError::Metadata(format!(
+            "no {} found in slices directory",
+            crate::utils::paths::METADATA_FILE
+        ))
+    })?;
+    let mut metadata = ModelMetadata::load(&meta_path)?;
+    normalize_split_metadata(slices_dir, &meta_path, &mut metadata)?;
 
     let slices: Vec<_> = metadata
         .slices
@@ -436,7 +453,14 @@ pub fn analyze_slices(
             crate::utils::paths::METADATA_FILE
         ))
     })?;
-    let metadata = ModelMetadata::load(&meta_path)?;
+    let mut metadata = ModelMetadata::load(&meta_path)?;
+    // Apply the same split-metadata normalisation compile_slices
+    // performs so the backend / reason classifications below see
+    // populated channel_split.groups, inferred dim_split template
+    // paths, and stripped dim_split entries whose template never
+    // materialised.  Without this step analyze_slices misreports
+    // slices whose split state is implicit in on-disk artefacts.
+    normalize_split_metadata(slices_dir, &meta_path, &mut metadata)?;
     let mut reports = Vec::with_capacity(metadata.slices.len());
 
     for slice in &metadata.slices {
@@ -711,11 +735,16 @@ fn compile_single_slice(
         return Ok(CompileOutcome::Skipped);
     }
 
+    // The threshold gate needs a concrete estimate; the debug
+    // block below can reuse it so we only re-parse the slice ONNX
+    // for constraint counting once per slice.
+    let mut estimated: Option<u64> = None;
     if let Some(threshold) = skip_compile_over_size {
-        let estimated = estimate_onnx_constraints(&onnx_path)?;
-        if estimated > threshold {
+        let est = estimate_onnx_constraints(&onnx_path)?;
+        estimated = Some(est);
+        if est > threshold {
             return Ok(CompileOutcome::SkippedOverSize {
-                estimated,
+                estimated: est,
                 threshold,
             });
         }
@@ -742,20 +771,29 @@ fn compile_single_slice(
 
     let effective_wai = weights_as_inputs;
 
-    let estimated = estimate_onnx_constraints(&onnx_path).ok();
-    let op_summary = summarize_onnx_ops(&onnx_path);
+    // The diagnostic bundle re-parses the slice ONNX (once for the
+    // op summary, once for the constraint estimate if we didn't
+    // already gate through it above).  Skip that work when debug
+    // tracing is disabled -- in a release build across hundreds of
+    // slices it adds up.
+    if tracing::enabled!(tracing::Level::DEBUG) {
+        if estimated.is_none() {
+            estimated = estimate_onnx_constraints(&onnx_path).ok();
+        }
+        let op_summary = summarize_onnx_ops(&onnx_path);
 
-    tracing::debug!(
-        slice = slice.index,
-        onnx = %onnx_path.display(),
-        estimated_constraints = ?estimated,
-        weights_as_inputs = effective_wai,
-        ops = %op_summary,
-        tiled = slice.tiling.is_some(),
-        channel_split = slice.channel_split.is_some(),
-        dim_split = slice.dim_split.is_some(),
-        "compiling slice"
-    );
+        tracing::debug!(
+            slice = slice.index,
+            onnx = %onnx_path.display(),
+            estimated_constraints = ?estimated,
+            weights_as_inputs = effective_wai,
+            ops = %op_summary,
+            tiled = slice.tiling.is_some(),
+            channel_split = slice.channel_split.is_some(),
+            dim_split = slice.dim_split.is_some(),
+            "compiling slice"
+        );
+    }
 
     let compile_onnx = normalize_slice_for_backend(&onnx_path)?;
 

--- a/crates/dsperse/src/pipeline/compiler.rs
+++ b/crates/dsperse/src/pipeline/compiler.rs
@@ -40,12 +40,19 @@ pub struct CompileReport {
 }
 
 impl CompileReport {
+    /// Return Ok(self) when every slice compiled cleanly.  Otherwise
+    /// return a generic Pipeline error; callers layer their own
+    /// actionable guidance on top (the CLI mentions its
+    /// --allow-onnx-fallback flag, the Python binding mentions the
+    /// `allow_onnx_fallback` keyword).  Keeping the library message
+    /// surface-agnostic avoids leaking CLI conventions into the
+    /// Python / Rust API error stream.
     pub fn ok_if_no_failures(self) -> Result<Self> {
         if self.failed.is_empty() {
             Ok(self)
         } else {
             Err(DsperseError::Pipeline(format!(
-                "compile_slices: {} slice(s) failed to compile; set --allow-onnx-fallback to proceed with partial coverage",
+                "compile_slices: {} slice(s) failed to compile; the caller must opt in to partial coverage before proceeding",
                 self.failed.len()
             )))
         }
@@ -236,7 +243,14 @@ pub fn compile_slices(
                     )
                 }
                 Err(e) => {
-                    tracing::error!(slice = slice.index, error = %e, "compilation failed");
+                    // Per-slice compile failure is recoverable: the
+                    // summary log at the end of compile_slices
+                    // already surfaces the aggregate via warn!, and
+                    // the caller decides whether to continue with
+                    // partial coverage.  Emitting error! here would
+                    // spam CI for an outcome that ok_if_no_failures
+                    // handles structurally.
+                    tracing::warn!(slice = slice.index, error = %e, "compilation failed");
                     errors.lock().unwrap().push((slice.index, e));
                 }
             }
@@ -441,6 +455,29 @@ pub struct SliceAnalysisReport {
     pub circuit_signature: Option<String>,
 }
 
+/// Derive the three metrics SliceAnalysisReport carries from an
+/// ONNX file: op-summary string, constraint estimate, and curve-
+/// stamped circuit signature.  Used from every analyze_slices
+/// branch that can point at a concrete representative ONNX (the
+/// slice's own .onnx for standard slices, the first channel
+/// group's .onnx for channel-split, the dim-split template
+/// ONNX for dim-split).  Failure on any single metric is
+/// non-fatal: we emit empty / None for the affected field and
+/// continue so analyze never aborts on a partially-materialised
+/// slice.
+fn derive_slice_report_metrics(
+    onnx_path: &Path,
+    proof_config: Option<&str>,
+) -> (String, Option<u64>, Option<String>) {
+    if !onnx_path.exists() {
+        return (String::new(), None, None);
+    }
+    let ops = summarize_onnx_ops(onnx_path);
+    let estimated = estimate_onnx_constraints(onnx_path).ok();
+    let signature = compute_circuit_signature(onnx_path, proof_config).ok();
+    (ops, estimated, signature)
+}
+
 pub fn analyze_slices(
     slices_dir: &Path,
     jstprove_ops: &[&str],
@@ -480,38 +517,53 @@ pub fn analyze_slices(
             continue;
         }
 
-        if slice
-            .channel_split
-            .as_ref()
-            .is_some_and(|cs| !cs.groups.is_empty())
+        if let Some(ref cs) = slice.channel_split
+            && !cs.groups.is_empty()
         {
+            // Use the first channel-group ONNX as representative
+            // for the reported metrics: every group in the split
+            // shares the same per-chunk topology, so op summary,
+            // constraint estimate, and circuit signature are
+            // group-invariant and the first group is authoritative
+            // for the backend's view of compilation cost.
+            let group_path = slices_dir.join(&cs.groups[0].path);
+            let (ops, estimated, circuit_signature) =
+                derive_slice_report_metrics(&group_path, proof_config);
             reports.push(SliceAnalysisReport {
                 index: slice.index,
                 backend: "jstprove".into(),
                 reason: "channel-split".into(),
-                estimated_constraints: None,
-                ops: String::new(),
+                estimated_constraints: estimated,
+                ops,
                 tiled: slice.tiling.is_some(),
                 channel_split: true,
                 dim_split: false,
-                circuit_signature: None,
+                circuit_signature,
             });
             continue;
         }
 
         if let Some(ref ds) = slice.dim_split
-            && ds.template_path.is_some()
+            && let Some(ref tmpl_rel) = ds.template_path
         {
+            // The dim-split template is the ONNX the backend
+            // actually compiles (one circuit shared across every
+            // group), so it is the correct source for the
+            // reported ops / constraint estimate / circuit
+            // signature.
+            let tmpl_path = slices_dir.join(tmpl_rel);
+            let (ops, estimated, circuit_signature) =
+                derive_slice_report_metrics(&tmpl_path, proof_config);
             reports.push(SliceAnalysisReport {
                 index: slice.index,
                 backend: "jstprove".into(),
                 reason: "dim-split".into(),
-                estimated_constraints: None,
-                ops: String::new(),
+                estimated_constraints: estimated,
+                ops,
                 tiled: slice.tiling.is_some(),
                 channel_split: false,
                 dim_split: true,
-                circuit_signature: None,
+                circuit_signature,
             });
             continue;
         }

--- a/crates/dsperse/src/pipeline/mod.rs
+++ b/crates/dsperse/src/pipeline/mod.rs
@@ -16,7 +16,7 @@ mod tiled;
 mod verifier;
 
 pub use combined::CombinedRun;
-pub use compiler::compile_slices;
+pub use compiler::{CompileReport, SliceAnalysisReport, analyze_slices, compile_slices};
 pub use incremental::{IncrementalRun, SliceExecutionResult, SliceWork};
 pub use prover::prove_run;
 pub use runner::{RunConfig, extract_onnx_initializers, run_inference};

--- a/crates/dsperse/src/python.rs
+++ b/crates/dsperse/src/python.rs
@@ -118,25 +118,32 @@ fn compile_slices(
     let dir = PathBuf::from(slices_dir);
     let ops = resolve_ops(proof_system, circuit_ops.as_deref())?;
     let ops_refs: Vec<&str> = ops.iter().map(String::as_str).collect();
-    py.allow_threads(|| {
-        // Propagate partial-compile failures to the Python caller
-        // so silent non-zero exit masks become impossible; callers
-        // that want permissive behaviour can catch the exception
-        // and continue with ONNX fallback explicitly, rather than
-        // the Rust wrapper deciding the policy on their behalf.
-        pipeline::compile_slices(
-            &dir,
-            &backend,
-            parsed_config,
-            parallel,
-            weights_as_inputs,
-            layers.as_deref(),
-            &ops_refs,
-            skip_compile_over_size,
-        )
-        .and_then(|report| report.ok_if_no_failures().map(|_| ()))
-    })
-    .map_err(to_py_err)
+    let report = py
+        .allow_threads(|| {
+            pipeline::compile_slices(
+                &dir,
+                &backend,
+                parsed_config,
+                parallel,
+                weights_as_inputs,
+                layers.as_deref(),
+                &ops_refs,
+                skip_compile_over_size,
+            )
+        })
+        .map_err(to_py_err)?;
+    // Propagate partial-compile failures to the Python caller so
+    // silent non-zero masks become impossible, but phrase the
+    // message in Python-binding terms rather than reusing the
+    // CLI's --allow-onnx-fallback hint (the Python API has its
+    // own opt-in path).
+    if !report.failed.is_empty() {
+        return Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
+            "partial compile failures: {} slice(s) failed to compile; catch this exception and continue to accept ONNX fallback for the failed slices, or inspect the Rust-side logs for the per-slice error payload",
+            report.failed.len()
+        )));
+    }
+    Ok(())
 }
 
 #[pyfunction]

--- a/crates/dsperse/src/python.rs
+++ b/crates/dsperse/src/python.rs
@@ -119,6 +119,11 @@ fn compile_slices(
     let ops = resolve_ops(proof_system, circuit_ops.as_deref())?;
     let ops_refs: Vec<&str> = ops.iter().map(String::as_str).collect();
     py.allow_threads(|| {
+        // Propagate partial-compile failures to the Python caller
+        // so silent non-zero exit masks become impossible; callers
+        // that want permissive behaviour can catch the exception
+        // and continue with ONNX fallback explicitly, rather than
+        // the Rust wrapper deciding the policy on their behalf.
         pipeline::compile_slices(
             &dir,
             &backend,
@@ -129,7 +134,7 @@ fn compile_slices(
             &ops_refs,
             skip_compile_over_size,
         )
-        .map(|_| ())
+        .and_then(|report| report.ok_if_no_failures().map(|_| ()))
     })
     .map_err(to_py_err)
 }

--- a/crates/dsperse/src/python.rs
+++ b/crates/dsperse/src/python.rs
@@ -129,6 +129,7 @@ fn compile_slices(
             &ops_refs,
             skip_compile_over_size,
         )
+        .map(|_| ())
     })
     .map_err(to_py_err)
 }


### PR DESCRIPTION
## Summary
- `compile_slices` no longer aborts the pipeline when individual slices fail compilation — failures are logged as warnings and those slices fall back to ONNX execution, allowing `full-run` to proceed through inference and prove phases
- Pre-compilation debug logging emits estimated constraints, op summary, WAI flag, and tiling/split properties before each slice compilation to diagnose slow or stuck compilation batches
- New `dsperse analyze` command produces a table or JSON report of all slices with backend assignment (jstprove vs onnx), estimated constraint count, circuit signature, and op breakdown

## Test plan
- [x] `dsperse analyze --model-dir <dir> --format table` produces expected output
- [x] `dsperse analyze --model-dir <dir> --format json` produces valid JSON
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [ ] `dsperse full-run` with slices that fail jstprove compilation completes gracefully instead of aborting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an analyze command to inspect circuit slices with table or JSON output and proof-system/proof-config options.
  * Added allow_onnx_fallback flag to compile and full-run to permit continuing despite partial compile failures.

* **Bug Fixes**
  * Compilation now reports per-slice successes/failures instead of aborting the whole run; detailed per-slice diagnostics are available.
  * Python bindings now surface partial compilation failures as runtime errors.

* **Refactor**
  * Normalized slice metadata and expanded slice analysis and reporting for clearer diagnostics and aggregated summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->