### PR TITLE
Replace heuristic constraint estimation with jstprove formulas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "arith"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
 dependencies = [
  "ark-std",
  "criterion",
@@ -354,7 +354,7 @@ dependencies = [
 [[package]]
 name = "babybear"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
 dependencies = [
  "arith",
  "ark-std",
@@ -398,7 +398,7 @@ dependencies = [
 [[package]]
 name = "bin"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
 dependencies = [
  "arith",
  "babybear",
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "circuit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
 dependencies = [
  "arith",
  "ark-std",
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "circuit-std-rs"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
 dependencies = [
  "arith",
  "ark-bls12-381",
@@ -689,7 +689,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "config_macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
 dependencies = [
  "gkr_engine",
  "gkr_hashers",
@@ -857,7 +857,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 [[package]]
 name = "crosslayer_prototype"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
 dependencies = [
  "arith",
  "env_logger",
@@ -1093,7 +1093,7 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 [[package]]
 name = "expander_compiler"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
 dependencies = [
  "arith",
  "ark-std",
@@ -1324,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "gf2"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
 dependencies = [
  "arith",
  "ark-std",
@@ -1341,7 +1341,7 @@ dependencies = [
 [[package]]
 name = "gf2_128"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
 dependencies = [
  "arith",
  "ark-std",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "gkr"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
 dependencies = [
  "arith",
  "ark-std",
@@ -1387,7 +1387,7 @@ dependencies = [
 [[package]]
 name = "gkr_engine"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
 dependencies = [
  "arith",
  "babybear",
@@ -1405,7 +1405,7 @@ dependencies = [
 [[package]]
 name = "gkr_hashers"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
 dependencies = [
  "arith",
  "halo2curves",
@@ -1417,7 +1417,7 @@ dependencies = [
 [[package]]
 name = "goldilocks"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
 dependencies = [
  "arith",
  "ark-std",
@@ -2015,7 +2015,7 @@ dependencies = [
 [[package]]
 name = "jstprove-io"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
 dependencies = [
  "anyhow",
  "crc32c",
@@ -2027,7 +2027,7 @@ dependencies = [
 [[package]]
 name = "jstprove-onnx"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
 dependencies = [
  "anyhow",
  "prost 0.13.5",
@@ -2038,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "jstprove_circuits"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
 dependencies = [
  "anyhow",
  "arith",
@@ -2223,7 +2223,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2297,7 +2297,7 @@ dependencies = [
 [[package]]
 name = "mersenne31"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
 dependencies = [
  "arith",
  "ark-std",
@@ -2791,7 +2791,7 @@ dependencies = [
 [[package]]
 name = "poly_commit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
 dependencies = [
  "arith",
  "ark-std",
@@ -2817,7 +2817,7 @@ dependencies = [
 [[package]]
 name = "polynomials"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
 dependencies = [
  "arith",
  "ark-std",
@@ -3661,7 +3661,7 @@ dependencies = [
 [[package]]
 name = "serdes"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
 dependencies = [
  "ethnum",
  "halo2curves",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "serdes_derive"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3844,7 +3844,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
 dependencies = [
  "arith",
  "circuit",
@@ -4455,7 +4455,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
 dependencies = [
  "arith",
  "gkr_engine",
@@ -4478,7 +4478,7 @@ dependencies = [
 [[package]]
 name = "tree"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
 dependencies = [
  "arith",
  "ark-std",
@@ -4638,7 +4638,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "arith"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
 dependencies = [
  "ark-std",
  "criterion",
@@ -354,7 +354,7 @@ dependencies = [
 [[package]]
 name = "babybear"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
 dependencies = [
  "arith",
  "ark-std",
@@ -398,7 +398,7 @@ dependencies = [
 [[package]]
 name = "bin"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
 dependencies = [
  "arith",
  "babybear",
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "circuit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
 dependencies = [
  "arith",
  "ark-std",
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "circuit-std-rs"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
 dependencies = [
  "arith",
  "ark-bls12-381",
@@ -689,7 +689,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "config_macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
 dependencies = [
  "gkr_engine",
  "gkr_hashers",
@@ -857,7 +857,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 [[package]]
 name = "crosslayer_prototype"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
 dependencies = [
  "arith",
  "env_logger",
@@ -1093,7 +1093,7 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 [[package]]
 name = "expander_compiler"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
 dependencies = [
  "arith",
  "ark-std",
@@ -1324,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "gf2"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
 dependencies = [
  "arith",
  "ark-std",
@@ -1341,7 +1341,7 @@ dependencies = [
 [[package]]
 name = "gf2_128"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
 dependencies = [
  "arith",
  "ark-std",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "gkr"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
 dependencies = [
  "arith",
  "ark-std",
@@ -1380,13 +1380,14 @@ dependencies = [
  "sumcheck",
  "thiserror 2.0.18",
  "transcript",
+ "tree",
  "utils",
 ]
 
 [[package]]
 name = "gkr_engine"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
 dependencies = [
  "arith",
  "babybear",
@@ -1404,7 +1405,7 @@ dependencies = [
 [[package]]
 name = "gkr_hashers"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
 dependencies = [
  "arith",
  "halo2curves",
@@ -1416,7 +1417,7 @@ dependencies = [
 [[package]]
 name = "goldilocks"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
 dependencies = [
  "arith",
  "ark-std",
@@ -2014,7 +2015,7 @@ dependencies = [
 [[package]]
 name = "jstprove-io"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
 dependencies = [
  "anyhow",
  "crc32c",
@@ -2026,7 +2027,7 @@ dependencies = [
 [[package]]
 name = "jstprove-onnx"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
 dependencies = [
  "anyhow",
  "prost 0.13.5",
@@ -2037,17 +2038,21 @@ dependencies = [
 [[package]]
 name = "jstprove_circuits"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
 dependencies = [
  "anyhow",
  "arith",
  "ark-std",
  "chrono",
+ "circuit",
  "circuit-std-rs",
  "clap",
  "console 0.15.11",
  "ethnum",
  "expander_compiler",
+ "gkr",
+ "gkr_engine",
+ "goldilocks",
  "halo2curves",
  "indicatif",
  "jstprove-io",
@@ -2058,6 +2063,8 @@ dependencies = [
  "num-traits",
  "once_cell",
  "openssl",
+ "poly_commit",
+ "polynomials",
  "rand 0.8.5",
  "rayon",
  "rmp-serde",
@@ -2065,12 +2072,15 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "serdes",
  "strum",
  "strum_macros",
+ "sumcheck",
  "tempfile",
  "thiserror 2.0.18",
  "tiny-keccak",
  "tracing",
+ "transcript",
  "zstd",
 ]
 
@@ -2213,7 +2223,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2287,7 +2297,7 @@ dependencies = [
 [[package]]
 name = "mersenne31"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
 dependencies = [
  "arith",
  "ark-std",
@@ -2781,7 +2791,7 @@ dependencies = [
 [[package]]
 name = "poly_commit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
 dependencies = [
  "arith",
  "ark-std",
@@ -2807,7 +2817,7 @@ dependencies = [
 [[package]]
 name = "polynomials"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
 dependencies = [
  "arith",
  "ark-std",
@@ -3651,7 +3661,7 @@ dependencies = [
 [[package]]
 name = "serdes"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
 dependencies = [
  "ethnum",
  "halo2curves",
@@ -3662,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "serdes_derive"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3834,7 +3844,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
 dependencies = [
  "arith",
  "circuit",
@@ -4445,7 +4455,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
 dependencies = [
  "arith",
  "gkr_engine",
@@ -4468,7 +4478,7 @@ dependencies = [
 [[package]]
 name = "tree"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
 dependencies = [
  "arith",
  "ark-std",
@@ -4628,7 +4638,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=02032293#02032293baa9cfe2e5a96346330c442c336ccc4d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "arith"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
 dependencies = [
  "ark-std",
  "criterion",
@@ -354,7 +354,7 @@ dependencies = [
 [[package]]
 name = "babybear"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
 dependencies = [
  "arith",
  "ark-std",
@@ -398,7 +398,7 @@ dependencies = [
 [[package]]
 name = "bin"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
 dependencies = [
  "arith",
  "babybear",
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "circuit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
 dependencies = [
  "arith",
  "ark-std",
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "circuit-std-rs"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
 dependencies = [
  "arith",
  "ark-bls12-381",
@@ -689,7 +689,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "config_macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
 dependencies = [
  "gkr_engine",
  "gkr_hashers",
@@ -857,7 +857,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 [[package]]
 name = "crosslayer_prototype"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
 dependencies = [
  "arith",
  "env_logger",
@@ -1093,7 +1093,7 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 [[package]]
 name = "expander_compiler"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
 dependencies = [
  "arith",
  "ark-std",
@@ -1324,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "gf2"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
 dependencies = [
  "arith",
  "ark-std",
@@ -1341,7 +1341,7 @@ dependencies = [
 [[package]]
 name = "gf2_128"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
 dependencies = [
  "arith",
  "ark-std",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "gkr"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
 dependencies = [
  "arith",
  "ark-std",
@@ -1387,7 +1387,7 @@ dependencies = [
 [[package]]
 name = "gkr_engine"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
 dependencies = [
  "arith",
  "babybear",
@@ -1405,7 +1405,7 @@ dependencies = [
 [[package]]
 name = "gkr_hashers"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
 dependencies = [
  "arith",
  "halo2curves",
@@ -1417,7 +1417,7 @@ dependencies = [
 [[package]]
 name = "goldilocks"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
 dependencies = [
  "arith",
  "ark-std",
@@ -2015,7 +2015,7 @@ dependencies = [
 [[package]]
 name = "jstprove-io"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
 dependencies = [
  "anyhow",
  "crc32c",
@@ -2027,7 +2027,7 @@ dependencies = [
 [[package]]
 name = "jstprove-onnx"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
 dependencies = [
  "anyhow",
  "prost 0.13.5",
@@ -2038,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "jstprove_circuits"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
 dependencies = [
  "anyhow",
  "arith",
@@ -2223,7 +2223,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2297,7 +2297,7 @@ dependencies = [
 [[package]]
 name = "mersenne31"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
 dependencies = [
  "arith",
  "ark-std",
@@ -2791,7 +2791,7 @@ dependencies = [
 [[package]]
 name = "poly_commit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
 dependencies = [
  "arith",
  "ark-std",
@@ -2817,7 +2817,7 @@ dependencies = [
 [[package]]
 name = "polynomials"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
 dependencies = [
  "arith",
  "ark-std",
@@ -3661,7 +3661,7 @@ dependencies = [
 [[package]]
 name = "serdes"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
 dependencies = [
  "ethnum",
  "halo2curves",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "serdes_derive"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3844,7 +3844,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
 dependencies = [
  "arith",
  "circuit",
@@ -4455,7 +4455,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
 dependencies = [
  "arith",
  "gkr_engine",
@@ -4478,7 +4478,7 @@ dependencies = [
 [[package]]
 name = "tree"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
 dependencies = [
  "arith",
  "ark-std",
@@ -4638,7 +4638,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e9bdd246#e9bdd2461017dd9c5c6f288dc84720a0d8cfec7d"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=e0c6aa5d#e0c6aa5d9617933013235cf375ea633f7e4ad243"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ sha2 = "0.10"
 tempfile = "3"
 prost = "0.13"
 pyo3 = { version = "0.24" }
-jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "e0c6aa5d" }
+jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "8f1d0a2f" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ sha2 = "0.10"
 tempfile = "3"
 prost = "0.13"
 pyo3 = { version = "0.24" }
-jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "02032293" }
+jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "7e250688" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ sha2 = "0.10"
 tempfile = "3"
 prost = "0.13"
 pyo3 = { version = "0.24" }
-jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "e9bdd246" }
+jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "e0c6aa5d" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ sha2 = "0.10"
 tempfile = "3"
 prost = "0.13"
 pyo3 = { version = "0.24" }
-jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "7e250688" }
+jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "e9bdd246" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -688,32 +688,26 @@ pub struct DimSplitDetection {
 }
 
 pub fn estimate_slice_constraints(nodes: &[NodeProto], shapes: &HashMap<String, Vec<i64>>) -> u64 {
+    let config = jstprove_circuits::api::EstimationConfig::bn254_defaults();
     let mut total: u64 = 0;
-    for node in nodes {
-        let output_elements: u64 = node
-            .output
-            .first()
-            .and_then(|name| shapes.get(name))
-            .map(|s| s.iter().filter(|&&d| d > 0).map(|&d| d as u64).product())
-            .unwrap_or(0);
 
-        let cost = match node.op_type.as_str() {
-            "MatMul" | "Gemm" => {
-                let input_last_dim: u64 = node
-                    .input
-                    .first()
-                    .and_then(|name| shapes.get(name))
-                    .and_then(|s| s.last())
-                    .map(|&d| d.max(0) as u64)
-                    .unwrap_or(1);
-                output_elements
-                    .saturating_mul(input_last_dim)
-                    .saturating_mul(2)
-            }
-            "Softmax" => output_elements.saturating_mul(4),
-            "Conv" => output_elements.saturating_mul(3),
-            _ => output_elements.saturating_mul(2),
+    for node in nodes {
+        let to_usize_shape = |name: &String| -> Vec<usize> {
+            shapes
+                .get(name)
+                .map(|s| s.iter().map(|&d| d.max(0) as usize).collect())
+                .unwrap_or_default()
         };
+
+        let input_shapes: Vec<Vec<usize>> = node.input.iter().map(&to_usize_shape).collect();
+        let output_shapes: Vec<Vec<usize>> = node.output.iter().map(&to_usize_shape).collect();
+
+        let cost = jstprove_circuits::api::estimate_op_constraints(
+            &node.op_type,
+            &input_shapes,
+            &output_shapes,
+            &config,
+        );
         total = total.saturating_add(cost);
     }
     total

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -691,14 +691,14 @@ pub fn estimate_slice_constraints(nodes: &[NodeProto], shapes: &HashMap<String, 
     let config = jstprove_circuits::api::EstimationConfig::bn254_defaults();
     let mut total: u64 = 0;
 
-    for node in nodes {
-        let to_usize_shape = |name: &String| -> Vec<usize> {
-            shapes
-                .get(name)
-                .map(|s| s.iter().map(|&d| d.max(1) as usize).collect())
-                .unwrap_or_default()
-        };
+    let to_usize_shape = |name: &String| -> Vec<usize> {
+        shapes
+            .get(name)
+            .map(|s| s.iter().map(|&d| d.max(1) as usize).collect())
+            .unwrap_or_default()
+    };
 
+    for node in nodes {
         let input_shapes: Vec<Vec<usize>> = node.input.iter().map(&to_usize_shape).collect();
         let output_shapes: Vec<Vec<usize>> = node.output.iter().map(&to_usize_shape).collect();
 

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -3060,4 +3060,40 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         assert!(create_pool_tile_slice(&model, 16, 0, tmp.path()).is_err());
     }
+
+    #[test]
+    fn estimate_slice_constraints_clamps_symbolic_dimensions() {
+        // ONNX serializes dynamic axes as -1 and placeholder axes as 0.
+        // Both must be clamped to 1 before forwarding to the jstprove
+        // estimator, otherwise product(shape) multiplies by zero and
+        // collapses the op's cost contribution to 0.
+        let node = NodeProto {
+            op_type: "MatMul".to_string(),
+            input: vec!["input".to_string(), "weight".to_string()],
+            output: vec!["output".to_string()],
+            ..Default::default()
+        };
+
+        let mut symbolic_shapes = HashMap::new();
+        symbolic_shapes.insert("input".to_string(), vec![-1, 64]);
+        symbolic_shapes.insert("weight".to_string(), vec![64, 128]);
+        symbolic_shapes.insert("output".to_string(), vec![0, 128]);
+
+        let mut concrete_shapes = HashMap::new();
+        concrete_shapes.insert("input".to_string(), vec![1, 64]);
+        concrete_shapes.insert("weight".to_string(), vec![64, 128]);
+        concrete_shapes.insert("output".to_string(), vec![1, 128]);
+
+        let symbolic_cost = estimate_slice_constraints(&[node.clone()], &symbolic_shapes);
+        let concrete_cost = estimate_slice_constraints(&[node], &concrete_shapes);
+
+        assert!(
+            symbolic_cost > 0,
+            "symbolic dims must not collapse cost to zero"
+        );
+        assert_eq!(
+            symbolic_cost, concrete_cost,
+            "batch -1 and batch 0 must clamp to 1 and match concrete batch 1"
+        );
+    }
 }

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -668,7 +668,7 @@ fn detect_elementwise_fixed_segments(graph: &GraphProto) -> Option<TilingDetecti
     })
 }
 
-pub const MAX_ESTIMATED_CONSTRAINTS: u64 = 500_000;
+pub const MAX_ESTIMATED_CONSTRAINTS: u64 = 2_000_000;
 
 #[derive(Debug, Clone)]
 pub struct DimSplitDetection {

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -2518,9 +2518,10 @@ mod tests {
 
     #[test]
     fn detect_dim_split_k_chunks_saturate_budget() {
-        // k_dim=10, n_dim=100_000: row_cost=2M, naive k_chunks=4 yields
-        // chunk_size=3 -> per-chunk=600K > 500K. Loop should bump k_chunks
-        // until per-chunk <= MAX_ESTIMATED_CONSTRAINTS.
+        // k_dim=10, n_dim=300_000: row_cost=6M. Naive k_chunks=ceil(6M/2M)=3
+        // yields chunk_size=ceil(10/3)=4 -> per-chunk=4*300_000*2=2.4M > 2M
+        // (MAX_ESTIMATED_CONSTRAINTS). Loop bumps k_chunks to 4 giving
+        // chunk_size=3 -> per-chunk=1.8M which fits.
         let node = NodeProto {
             op_type: "MatMul".to_string(),
             input: vec!["input".to_string(), "weight".to_string()],
@@ -2529,14 +2530,14 @@ mod tests {
         };
         let mut shapes = HashMap::new();
         shapes.insert("input".to_string(), vec![4, 10]);
-        shapes.insert("weight".to_string(), vec![10, 100_000]);
-        shapes.insert("output".to_string(), vec![4, 100_000]);
+        shapes.insert("weight".to_string(), vec![10, 300_000]);
+        shapes.insert("output".to_string(), vec![4, 300_000]);
         let mut init_names = HashSet::new();
         init_names.insert("weight".to_string());
 
         let d = detect_dim_split(&[node], &shapes, &init_names).unwrap();
         assert_eq!(d.k_dim, 10);
-        assert_eq!(d.n_dim, 100_000);
+        assert_eq!(d.n_dim, 300_000);
         let chunk_size = d.k_dim.div_ceil(d.k_chunks);
         assert!(
             chunk_size * d.n_dim * 2 <= MAX_ESTIMATED_CONSTRAINTS as usize,
@@ -2614,10 +2615,10 @@ mod tests {
             ..Default::default()
         };
         let mut shapes = HashMap::new();
-        // n_dim = 400_000 -> n*2 = 800_000 > MAX (500_000)
+        // n_dim = 1_500_000 -> n*2 = 3_000_000 > MAX (2_000_000)
         shapes.insert("input".to_string(), vec![1, 4]);
-        shapes.insert("weight".to_string(), vec![4, 400_000]);
-        shapes.insert("output".to_string(), vec![1, 400_000]);
+        shapes.insert("weight".to_string(), vec![4, 1_500_000]);
+        shapes.insert("output".to_string(), vec![1, 1_500_000]);
         let mut init_names = HashSet::new();
         init_names.insert("weight".to_string());
 

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -3084,8 +3084,9 @@ mod tests {
         concrete_shapes.insert("weight".to_string(), vec![64, 128]);
         concrete_shapes.insert("output".to_string(), vec![1, 128]);
 
-        let symbolic_cost = estimate_slice_constraints(&[node.clone()], &symbolic_shapes);
-        let concrete_cost = estimate_slice_constraints(&[node], &concrete_shapes);
+        let nodes = [node];
+        let symbolic_cost = estimate_slice_constraints(&nodes, &symbolic_shapes);
+        let concrete_cost = estimate_slice_constraints(&nodes, &concrete_shapes);
 
         assert!(
             symbolic_cost > 0,

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -695,7 +695,7 @@ pub fn estimate_slice_constraints(nodes: &[NodeProto], shapes: &HashMap<String, 
         let to_usize_shape = |name: &String| -> Vec<usize> {
             shapes
                 .get(name)
-                .map(|s| s.iter().map(|&d| d.max(0) as usize).collect())
+                .map(|s| s.iter().map(|&d| d.max(1) as usize).collect())
                 .unwrap_or_default()
         };
 


### PR DESCRIPTION
## Summary

- Replaces the hardcoded multiplier-based `estimate_slice_constraints` with delegation to `jstprove_circuits::api::estimate_op_constraints` which replicates the actual circuit constraint formulas (Freivalds vs direct matmul cost decision, LogUp range-check query counts, per-op costs)
- Updates `jstprove_circuits` dependency rev to include the new estimation API (inference-labs-inc/JSTprove#272)

## Test plan

- [x] All 12 existing dsperse tests pass
- [x] `cargo clippy -p dsperse -- -D warnings` clean
- [ ] Validate dim-split detection thresholds on representative sliced models — the more accurate estimates may shift which slices trigger splitting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate constraint estimation for complex operations, reducing mispredicted costs.

* **Improvements**
  * Increased global constraint budget to better handle larger model slices.
  * Estimation now uses full input/output shapes and a centralized estimator for more reliable split and chunk decisions.
  * Symbolic/dynamic dimensions are clamped so they no longer collapse estimated cost to zero.

* **Tests**
  * Added unit test verifying clamping of symbolic/dynamic dimensions.

* **Chores**
  * Updated a pinned workspace dependency to a newer commit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->