### PR TITLE
Introduce constant-folding evaluators and inline-LayerNorm fusion in slicer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "arith"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
 dependencies = [
  "ark-std",
  "criterion",
@@ -354,7 +354,7 @@ dependencies = [
 [[package]]
 name = "babybear"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
 dependencies = [
  "arith",
  "ark-std",
@@ -398,7 +398,7 @@ dependencies = [
 [[package]]
 name = "bin"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
 dependencies = [
  "arith",
  "babybear",
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "circuit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
 dependencies = [
  "arith",
  "ark-std",
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "circuit-std-rs"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
 dependencies = [
  "arith",
  "ark-bls12-381",
@@ -689,7 +689,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "config_macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
 dependencies = [
  "gkr_engine",
  "gkr_hashers",
@@ -857,7 +857,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 [[package]]
 name = "crosslayer_prototype"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
 dependencies = [
  "arith",
  "env_logger",
@@ -1093,7 +1093,7 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 [[package]]
 name = "expander_compiler"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
 dependencies = [
  "arith",
  "ark-std",
@@ -1324,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "gf2"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
 dependencies = [
  "arith",
  "ark-std",
@@ -1341,7 +1341,7 @@ dependencies = [
 [[package]]
 name = "gf2_128"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
 dependencies = [
  "arith",
  "ark-std",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "gkr"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
 dependencies = [
  "arith",
  "ark-std",
@@ -1387,7 +1387,7 @@ dependencies = [
 [[package]]
 name = "gkr_engine"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
 dependencies = [
  "arith",
  "babybear",
@@ -1405,7 +1405,7 @@ dependencies = [
 [[package]]
 name = "gkr_hashers"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
 dependencies = [
  "arith",
  "halo2curves",
@@ -1417,7 +1417,7 @@ dependencies = [
 [[package]]
 name = "goldilocks"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
 dependencies = [
  "arith",
  "ark-std",
@@ -2015,7 +2015,7 @@ dependencies = [
 [[package]]
 name = "jstprove-io"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
 dependencies = [
  "anyhow",
  "crc32c",
@@ -2027,7 +2027,7 @@ dependencies = [
 [[package]]
 name = "jstprove-onnx"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
 dependencies = [
  "anyhow",
  "prost 0.13.5",
@@ -2038,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "jstprove_circuits"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
 dependencies = [
  "anyhow",
  "arith",
@@ -2223,7 +2223,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2297,7 +2297,7 @@ dependencies = [
 [[package]]
 name = "mersenne31"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
 dependencies = [
  "arith",
  "ark-std",
@@ -2791,7 +2791,7 @@ dependencies = [
 [[package]]
 name = "poly_commit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
 dependencies = [
  "arith",
  "ark-std",
@@ -2817,7 +2817,7 @@ dependencies = [
 [[package]]
 name = "polynomials"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
 dependencies = [
  "arith",
  "ark-std",
@@ -3661,7 +3661,7 @@ dependencies = [
 [[package]]
 name = "serdes"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
 dependencies = [
  "ethnum",
  "halo2curves",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "serdes_derive"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3844,7 +3844,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
 dependencies = [
  "arith",
  "circuit",
@@ -4455,7 +4455,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
 dependencies = [
  "arith",
  "gkr_engine",
@@ -4478,7 +4478,7 @@ dependencies = [
 [[package]]
 name = "tree"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
 dependencies = [
  "arith",
  "ark-std",
@@ -4638,7 +4638,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -97,7 +97,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "arith"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
 dependencies = [
  "ark-std",
  "criterion",
@@ -354,7 +354,7 @@ dependencies = [
 [[package]]
 name = "babybear"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
 dependencies = [
  "arith",
  "ark-std",
@@ -398,7 +398,7 @@ dependencies = [
 [[package]]
 name = "bin"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
 dependencies = [
  "arith",
  "babybear",
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "circuit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
 dependencies = [
  "arith",
  "ark-std",
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "circuit-std-rs"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
 dependencies = [
  "arith",
  "ark-bls12-381",
@@ -689,7 +689,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "config_macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
 dependencies = [
  "gkr_engine",
  "gkr_hashers",
@@ -857,7 +857,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 [[package]]
 name = "crosslayer_prototype"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
 dependencies = [
  "arith",
  "env_logger",
@@ -1081,7 +1081,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1093,7 +1093,7 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 [[package]]
 name = "expander_compiler"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
 dependencies = [
  "arith",
  "ark-std",
@@ -1324,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "gf2"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
 dependencies = [
  "arith",
  "ark-std",
@@ -1341,7 +1341,7 @@ dependencies = [
 [[package]]
 name = "gf2_128"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
 dependencies = [
  "arith",
  "ark-std",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "gkr"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
 dependencies = [
  "arith",
  "ark-std",
@@ -1387,7 +1387,7 @@ dependencies = [
 [[package]]
 name = "gkr_engine"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
 dependencies = [
  "arith",
  "babybear",
@@ -1405,7 +1405,7 @@ dependencies = [
 [[package]]
 name = "gkr_hashers"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
 dependencies = [
  "arith",
  "halo2curves",
@@ -1417,7 +1417,7 @@ dependencies = [
 [[package]]
 name = "goldilocks"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
 dependencies = [
  "arith",
  "ark-std",
@@ -1924,7 +1924,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2015,7 +2015,7 @@ dependencies = [
 [[package]]
 name = "jstprove-io"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
 dependencies = [
  "anyhow",
  "crc32c",
@@ -2027,7 +2027,7 @@ dependencies = [
 [[package]]
 name = "jstprove-onnx"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
 dependencies = [
  "anyhow",
  "prost 0.13.5",
@@ -2038,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "jstprove_circuits"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
 dependencies = [
  "anyhow",
  "arith",
@@ -2223,7 +2223,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2297,7 +2297,7 @@ dependencies = [
 [[package]]
 name = "mersenne31"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
 dependencies = [
  "arith",
  "ark-std",
@@ -2475,7 +2475,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2791,7 +2791,7 @@ dependencies = [
 [[package]]
 name = "poly_commit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
 dependencies = [
  "arith",
  "ark-std",
@@ -2817,7 +2817,7 @@ dependencies = [
 [[package]]
 name = "polynomials"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
 dependencies = [
  "arith",
  "ark-std",
@@ -3444,7 +3444,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3661,7 +3661,7 @@ dependencies = [
 [[package]]
 name = "serdes"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
 dependencies = [
  "ethnum",
  "halo2curves",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "serdes_derive"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3774,7 +3774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3844,7 +3844,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
 dependencies = [
  "arith",
  "circuit",
@@ -3961,7 +3961,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4455,7 +4455,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
 dependencies = [
  "arith",
  "gkr_engine",
@@ -4478,7 +4478,7 @@ dependencies = [
 [[package]]
 name = "tree"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
 dependencies = [
  "arith",
  "ark-std",
@@ -4638,7 +4638,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
 
 [[package]]
 name = "uuid"
@@ -4874,7 +4874,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -97,7 +97,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "arith"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
 dependencies = [
  "ark-std",
  "criterion",
@@ -354,7 +354,7 @@ dependencies = [
 [[package]]
 name = "babybear"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
 dependencies = [
  "arith",
  "ark-std",
@@ -398,7 +398,7 @@ dependencies = [
 [[package]]
 name = "bin"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
 dependencies = [
  "arith",
  "babybear",
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "circuit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
 dependencies = [
  "arith",
  "ark-std",
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "circuit-std-rs"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
 dependencies = [
  "arith",
  "ark-bls12-381",
@@ -689,7 +689,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "config_macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
 dependencies = [
  "gkr_engine",
  "gkr_hashers",
@@ -857,7 +857,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 [[package]]
 name = "crosslayer_prototype"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
 dependencies = [
  "arith",
  "env_logger",
@@ -1081,7 +1081,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1093,7 +1093,7 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 [[package]]
 name = "expander_compiler"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
 dependencies = [
  "arith",
  "ark-std",
@@ -1324,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "gf2"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
 dependencies = [
  "arith",
  "ark-std",
@@ -1341,7 +1341,7 @@ dependencies = [
 [[package]]
 name = "gf2_128"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
 dependencies = [
  "arith",
  "ark-std",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "gkr"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
 dependencies = [
  "arith",
  "ark-std",
@@ -1387,7 +1387,7 @@ dependencies = [
 [[package]]
 name = "gkr_engine"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
 dependencies = [
  "arith",
  "babybear",
@@ -1405,7 +1405,7 @@ dependencies = [
 [[package]]
 name = "gkr_hashers"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
 dependencies = [
  "arith",
  "halo2curves",
@@ -1417,7 +1417,7 @@ dependencies = [
 [[package]]
 name = "goldilocks"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
 dependencies = [
  "arith",
  "ark-std",
@@ -1924,7 +1924,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2015,7 +2015,7 @@ dependencies = [
 [[package]]
 name = "jstprove-io"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
 dependencies = [
  "anyhow",
  "crc32c",
@@ -2027,7 +2027,7 @@ dependencies = [
 [[package]]
 name = "jstprove-onnx"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
 dependencies = [
  "anyhow",
  "prost 0.13.5",
@@ -2038,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "jstprove_circuits"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
 dependencies = [
  "anyhow",
  "arith",
@@ -2223,7 +2223,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2297,7 +2297,7 @@ dependencies = [
 [[package]]
 name = "mersenne31"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
 dependencies = [
  "arith",
  "ark-std",
@@ -2475,7 +2475,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2791,7 +2791,7 @@ dependencies = [
 [[package]]
 name = "poly_commit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
 dependencies = [
  "arith",
  "ark-std",
@@ -2817,7 +2817,7 @@ dependencies = [
 [[package]]
 name = "polynomials"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
 dependencies = [
  "arith",
  "ark-std",
@@ -3444,7 +3444,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3661,7 +3661,7 @@ dependencies = [
 [[package]]
 name = "serdes"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
 dependencies = [
  "ethnum",
  "halo2curves",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "serdes_derive"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3774,7 +3774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3844,7 +3844,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
 dependencies = [
  "arith",
  "circuit",
@@ -3961,7 +3961,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4455,7 +4455,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
 dependencies = [
  "arith",
  "gkr_engine",
@@ -4478,7 +4478,7 @@ dependencies = [
 [[package]]
 name = "tree"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
 dependencies = [
  "arith",
  "ark-std",
@@ -4638,7 +4638,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=1689e6c2#1689e6c2f7083b90a84349effc1bf394078c1ee9"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=838b7566#838b7566369f2c512cec035ffccea92a8b0a1188"
 
 [[package]]
 name = "uuid"
@@ -4874,7 +4874,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -97,7 +97,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "arith"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "ark-std",
  "criterion",
@@ -354,7 +354,7 @@ dependencies = [
 [[package]]
 name = "babybear"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "ark-std",
@@ -398,7 +398,7 @@ dependencies = [
 [[package]]
 name = "bin"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "babybear",
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "circuit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "ark-std",
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "circuit-std-rs"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "ark-bls12-381",
@@ -689,7 +689,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "config_macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "gkr_engine",
  "gkr_hashers",
@@ -857,7 +857,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 [[package]]
 name = "crosslayer_prototype"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "env_logger",
@@ -1081,7 +1081,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1093,7 +1093,7 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 [[package]]
 name = "expander_compiler"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "ark-std",
@@ -1324,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "gf2"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "ark-std",
@@ -1341,7 +1341,7 @@ dependencies = [
 [[package]]
 name = "gf2_128"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "ark-std",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "gkr"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "ark-std",
@@ -1387,7 +1387,7 @@ dependencies = [
 [[package]]
 name = "gkr_engine"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "babybear",
@@ -1405,7 +1405,7 @@ dependencies = [
 [[package]]
 name = "gkr_hashers"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "halo2curves",
@@ -1417,7 +1417,7 @@ dependencies = [
 [[package]]
 name = "goldilocks"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "ark-std",
@@ -1924,7 +1924,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2015,7 +2015,7 @@ dependencies = [
 [[package]]
 name = "jstprove-io"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "anyhow",
  "crc32c",
@@ -2027,7 +2027,7 @@ dependencies = [
 [[package]]
 name = "jstprove-onnx"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "anyhow",
  "prost 0.13.5",
@@ -2038,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "jstprove_circuits"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "anyhow",
  "arith",
@@ -2223,7 +2223,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2297,7 +2297,7 @@ dependencies = [
 [[package]]
 name = "mersenne31"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "ark-std",
@@ -2475,7 +2475,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2791,7 +2791,7 @@ dependencies = [
 [[package]]
 name = "poly_commit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "ark-std",
@@ -2817,7 +2817,7 @@ dependencies = [
 [[package]]
 name = "polynomials"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "ark-std",
@@ -3444,7 +3444,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3661,7 +3661,7 @@ dependencies = [
 [[package]]
 name = "serdes"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "ethnum",
  "halo2curves",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "serdes_derive"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3774,7 +3774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3844,7 +3844,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "circuit",
@@ -3961,7 +3961,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4455,7 +4455,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "gkr_engine",
@@ -4478,7 +4478,7 @@ dependencies = [
 [[package]]
 name = "tree"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 dependencies = [
  "arith",
  "ark-std",
@@ -4638,7 +4638,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=fc3eae08#fc3eae085fe323aa3c9e6348ba401f81c7467c78"
 
 [[package]]
 name = "uuid"
@@ -4874,7 +4874,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -97,7 +97,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "arith"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
 dependencies = [
  "ark-std",
  "criterion",
@@ -354,7 +354,7 @@ dependencies = [
 [[package]]
 name = "babybear"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
 dependencies = [
  "arith",
  "ark-std",
@@ -398,7 +398,7 @@ dependencies = [
 [[package]]
 name = "bin"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
 dependencies = [
  "arith",
  "babybear",
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "circuit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
 dependencies = [
  "arith",
  "ark-std",
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "circuit-std-rs"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
 dependencies = [
  "arith",
  "ark-bls12-381",
@@ -689,7 +689,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "config_macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
 dependencies = [
  "gkr_engine",
  "gkr_hashers",
@@ -857,7 +857,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 [[package]]
 name = "crosslayer_prototype"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
 dependencies = [
  "arith",
  "env_logger",
@@ -1081,7 +1081,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1093,7 +1093,7 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 [[package]]
 name = "expander_compiler"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
 dependencies = [
  "arith",
  "ark-std",
@@ -1324,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "gf2"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
 dependencies = [
  "arith",
  "ark-std",
@@ -1341,7 +1341,7 @@ dependencies = [
 [[package]]
 name = "gf2_128"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
 dependencies = [
  "arith",
  "ark-std",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "gkr"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
 dependencies = [
  "arith",
  "ark-std",
@@ -1387,7 +1387,7 @@ dependencies = [
 [[package]]
 name = "gkr_engine"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
 dependencies = [
  "arith",
  "babybear",
@@ -1405,7 +1405,7 @@ dependencies = [
 [[package]]
 name = "gkr_hashers"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
 dependencies = [
  "arith",
  "halo2curves",
@@ -1417,7 +1417,7 @@ dependencies = [
 [[package]]
 name = "goldilocks"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
 dependencies = [
  "arith",
  "ark-std",
@@ -1924,7 +1924,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2015,7 +2015,7 @@ dependencies = [
 [[package]]
 name = "jstprove-io"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
 dependencies = [
  "anyhow",
  "crc32c",
@@ -2027,7 +2027,7 @@ dependencies = [
 [[package]]
 name = "jstprove-onnx"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
 dependencies = [
  "anyhow",
  "prost 0.13.5",
@@ -2038,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "jstprove_circuits"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
 dependencies = [
  "anyhow",
  "arith",
@@ -2223,7 +2223,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2297,7 +2297,7 @@ dependencies = [
 [[package]]
 name = "mersenne31"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
 dependencies = [
  "arith",
  "ark-std",
@@ -2475,7 +2475,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2791,7 +2791,7 @@ dependencies = [
 [[package]]
 name = "poly_commit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
 dependencies = [
  "arith",
  "ark-std",
@@ -2817,7 +2817,7 @@ dependencies = [
 [[package]]
 name = "polynomials"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
 dependencies = [
  "arith",
  "ark-std",
@@ -3444,7 +3444,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3661,7 +3661,7 @@ dependencies = [
 [[package]]
 name = "serdes"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
 dependencies = [
  "ethnum",
  "halo2curves",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "serdes_derive"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3774,7 +3774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3844,7 +3844,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
 dependencies = [
  "arith",
  "circuit",
@@ -3961,7 +3961,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4455,7 +4455,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
 dependencies = [
  "arith",
  "gkr_engine",
@@ -4478,7 +4478,7 @@ dependencies = [
 [[package]]
 name = "tree"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
 dependencies = [
  "arith",
  "ark-std",
@@ -4638,7 +4638,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=8f1d0a2f#8f1d0a2f47fa1b7df13b208712a454d1e760bb14"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=819875bd#819875bd655bc9e766b34ee857dae34c20b260f3"
 
 [[package]]
 name = "uuid"
@@ -4874,7 +4874,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -97,7 +97,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -130,7 +130,7 @@ dependencies = [
 [[package]]
 name = "arith"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
 dependencies = [
  "ark-std",
  "criterion",
@@ -354,7 +354,7 @@ dependencies = [
 [[package]]
 name = "babybear"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
 dependencies = [
  "arith",
  "ark-std",
@@ -398,7 +398,7 @@ dependencies = [
 [[package]]
 name = "bin"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
 dependencies = [
  "arith",
  "babybear",
@@ -598,7 +598,7 @@ dependencies = [
 [[package]]
 name = "circuit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
 dependencies = [
  "arith",
  "ark-std",
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "circuit-std-rs"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
 dependencies = [
  "arith",
  "ark-bls12-381",
@@ -689,7 +689,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "config_macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
 dependencies = [
  "gkr_engine",
  "gkr_hashers",
@@ -857,7 +857,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 [[package]]
 name = "crosslayer_prototype"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
 dependencies = [
  "arith",
  "env_logger",
@@ -1081,7 +1081,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1093,7 +1093,7 @@ checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
 [[package]]
 name = "expander_compiler"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
 dependencies = [
  "arith",
  "ark-std",
@@ -1324,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "gf2"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
 dependencies = [
  "arith",
  "ark-std",
@@ -1341,7 +1341,7 @@ dependencies = [
 [[package]]
 name = "gf2_128"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
 dependencies = [
  "arith",
  "ark-std",
@@ -1354,7 +1354,7 @@ dependencies = [
 [[package]]
 name = "gkr"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
 dependencies = [
  "arith",
  "ark-std",
@@ -1387,7 +1387,7 @@ dependencies = [
 [[package]]
 name = "gkr_engine"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
 dependencies = [
  "arith",
  "babybear",
@@ -1405,7 +1405,7 @@ dependencies = [
 [[package]]
 name = "gkr_hashers"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
 dependencies = [
  "arith",
  "halo2curves",
@@ -1417,7 +1417,7 @@ dependencies = [
 [[package]]
 name = "goldilocks"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
 dependencies = [
  "arith",
  "ark-std",
@@ -1924,7 +1924,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2015,7 +2015,7 @@ dependencies = [
 [[package]]
 name = "jstprove-io"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
 dependencies = [
  "anyhow",
  "crc32c",
@@ -2027,7 +2027,7 @@ dependencies = [
 [[package]]
 name = "jstprove-onnx"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
 dependencies = [
  "anyhow",
  "prost 0.13.5",
@@ -2038,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "jstprove_circuits"
 version = "0.1.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
 dependencies = [
  "anyhow",
  "arith",
@@ -2223,7 +2223,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 [[package]]
 name = "macros"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2297,7 +2297,7 @@ dependencies = [
 [[package]]
 name = "mersenne31"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
 dependencies = [
  "arith",
  "ark-std",
@@ -2475,7 +2475,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2791,7 +2791,7 @@ dependencies = [
 [[package]]
 name = "poly_commit"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
 dependencies = [
  "arith",
  "ark-std",
@@ -2817,7 +2817,7 @@ dependencies = [
 [[package]]
 name = "polynomials"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
 dependencies = [
  "arith",
  "ark-std",
@@ -3444,7 +3444,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3661,7 +3661,7 @@ dependencies = [
 [[package]]
 name = "serdes"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
 dependencies = [
  "ethnum",
  "halo2curves",
@@ -3672,7 +3672,7 @@ dependencies = [
 [[package]]
 name = "serdes_derive"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3774,7 +3774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3844,7 +3844,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sumcheck"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
 dependencies = [
  "arith",
  "circuit",
@@ -3961,7 +3961,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4455,7 +4455,7 @@ dependencies = [
 [[package]]
 name = "transcript"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
 dependencies = [
  "arith",
  "gkr_engine",
@@ -4478,7 +4478,7 @@ dependencies = [
 [[package]]
 name = "tree"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
 dependencies = [
  "arith",
  "ark-std",
@@ -4638,7 +4638,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 [[package]]
 name = "utils"
 version = "0.4.0"
-source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=f7df1caa#f7df1caaffc16dd72280df3b3584368a3a1bfff3"
+source = "git+https://github.com/inference-labs-inc/JSTprove.git?rev=ac0441e9#ac0441e9299cd1fbb6dd3a1978486c62a07a97aa"
 
 [[package]]
 name = "uuid"
@@ -4874,7 +4874,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ sha2 = "0.10"
 tempfile = "3"
 prost = "0.13"
 pyo3 = { version = "0.24" }
-jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "ac0441e9" }
+jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "fc3eae08" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ sha2 = "0.10"
 tempfile = "3"
 prost = "0.13"
 pyo3 = { version = "0.24" }
-jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "f7df1caa" }
+jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "ac0441e9" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ sha2 = "0.10"
 tempfile = "3"
 prost = "0.13"
 pyo3 = { version = "0.24" }
-jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "838b7566" }
+jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "f7df1caa" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ sha2 = "0.10"
 tempfile = "3"
 prost = "0.13"
 pyo3 = { version = "0.24" }
-jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "8f1d0a2f" }
+jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "819875bd" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ sha2 = "0.10"
 tempfile = "3"
 prost = "0.13"
 pyo3 = { version = "0.24" }
-jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "1689e6c2" }
+jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "838b7566" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ sha2 = "0.10"
 tempfile = "3"
 prost = "0.13"
 pyo3 = { version = "0.24" }
-jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "819875bd" }
+jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "1689e6c2" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/crates/dsperse/src/pipeline/dim_split.rs
+++ b/crates/dsperse/src/pipeline/dim_split.rs
@@ -336,11 +336,12 @@ fn execute_generic_dim_split(
         let dim_end = ((g + 1) * epg).min(ds.dim_size);
         let actual_size = dim_end - dim_start;
 
-        // The dim-split template now has split_dim sized to epg, not
-        // dim_size, so feed each group's slice straight in.  When the
-        // last group is smaller than epg, pad with zeros to keep the
-        // shape stable, then trim the corresponding region off the
-        // output below.
+        // dim_size is required to be an exact multiple of epg by the
+        // detector (`smallest_divisor_at_least`), so every group is
+        // exactly `epg` wide and we can feed the sliced view straight
+        // in -- no zero-padding, no output trimming, no risk of
+        // contaminating reductions on non-split axes.
+        debug_assert_eq!(actual_size, epg, "dim-split detector must enforce dim_size % epg == 0");
         let mut group_cache = TensorStore::new();
         for vi_name in &input_names {
             let arr = tensor_cache.try_get(vi_name).ok_or_else(|| {
@@ -353,20 +354,7 @@ fn execute_generic_dim_split(
                 let sliced = arr
                     .slice_axis(Axis(split_dim), ndarray::Slice::from(dim_start..dim_end))
                     .to_owned();
-                if actual_size == epg {
-                    group_cache.put(vi_name.clone(), sliced);
-                } else {
-                    let mut padded_shape = sliced.shape().to_vec();
-                    padded_shape[split_dim] = epg;
-                    let mut padded = ndarray::ArrayD::zeros(padded_shape);
-                    for (mut dst, src) in padded
-                        .axis_iter_mut(Axis(split_dim))
-                        .zip(sliced.axis_iter(Axis(split_dim)))
-                    {
-                        dst.assign(&src);
-                    }
-                    group_cache.put(vi_name.clone(), padded);
-                }
+                group_cache.put(vi_name.clone(), sliced);
             } else {
                 group_cache.put(vi_name.clone(), arr.clone());
             }
@@ -383,15 +371,8 @@ fn execute_generic_dim_split(
         let group_output = ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&shape), data)
             .map_err(|e| DsperseError::Pipeline(format!("{slice_id}: group {g} reshape: {e}")))?;
 
-        // Trim the padded region from the output along concat_axis when
-        // the last group is shorter than epg.
-        let trimmed = if actual_size < epg && concat_axis < group_output.ndim() {
-            group_output
-                .slice_axis(Axis(concat_axis), ndarray::Slice::from(0..actual_size))
-                .to_owned()
-        } else {
-            group_output
-        };
+        // Output is naturally `epg` wide along concat_axis.
+        let trimmed = group_output;
 
         group_outputs.push(trimmed);
     }

--- a/crates/dsperse/src/pipeline/dim_split.rs
+++ b/crates/dsperse/src/pipeline/dim_split.rs
@@ -336,9 +336,11 @@ fn execute_generic_dim_split(
         let dim_end = ((g + 1) * epg).min(ds.dim_size);
         let actual_size = dim_end - dim_start;
 
-        // Pad every group's input to dim_size so the template runs with
-        // the original model's shapes unchanged. This keeps the compiled
-        // circuit signature identical for every group and across slices.
+        // The dim-split template now has split_dim sized to epg, not
+        // dim_size, so feed each group's slice straight in.  When the
+        // last group is smaller than epg, pad with zeros to keep the
+        // shape stable, then trim the corresponding region off the
+        // output below.
         let mut group_cache = TensorStore::new();
         for vi_name in &input_names {
             let arr = tensor_cache.try_get(vi_name).ok_or_else(|| {
@@ -351,16 +353,20 @@ fn execute_generic_dim_split(
                 let sliced = arr
                     .slice_axis(Axis(split_dim), ndarray::Slice::from(dim_start..dim_end))
                     .to_owned();
-                let mut padded_shape = sliced.shape().to_vec();
-                padded_shape[split_dim] = ds.dim_size;
-                let mut padded = ndarray::ArrayD::zeros(padded_shape);
-                for (mut dst, src) in padded
-                    .axis_iter_mut(Axis(split_dim))
-                    .zip(sliced.axis_iter(Axis(split_dim)))
-                {
-                    dst.assign(&src);
+                if actual_size == epg {
+                    group_cache.put(vi_name.clone(), sliced);
+                } else {
+                    let mut padded_shape = sliced.shape().to_vec();
+                    padded_shape[split_dim] = epg;
+                    let mut padded = ndarray::ArrayD::zeros(padded_shape);
+                    for (mut dst, src) in padded
+                        .axis_iter_mut(Axis(split_dim))
+                        .zip(sliced.axis_iter(Axis(split_dim)))
+                    {
+                        dst.assign(&src);
+                    }
+                    group_cache.put(vi_name.clone(), padded);
                 }
-                group_cache.put(vi_name.clone(), padded);
             } else {
                 group_cache.put(vi_name.clone(), arr.clone());
             }
@@ -377,8 +383,9 @@ fn execute_generic_dim_split(
         let group_output = ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&shape), data)
             .map_err(|e| DsperseError::Pipeline(format!("{slice_id}: group {g} reshape: {e}")))?;
 
-        // Trim the padded region from the output along concat_axis.
-        let trimmed = if actual_size < ds.dim_size && concat_axis < group_output.ndim() {
+        // Trim the padded region from the output along concat_axis when
+        // the last group is shorter than epg.
+        let trimmed = if actual_size < epg && concat_axis < group_output.ndim() {
             group_output
                 .slice_axis(Axis(concat_axis), ndarray::Slice::from(0..actual_size))
                 .to_owned()

--- a/crates/dsperse/src/pipeline/dim_split.rs
+++ b/crates/dsperse/src/pipeline/dim_split.rs
@@ -341,7 +341,10 @@ fn execute_generic_dim_split(
         // exactly `epg` wide and we can feed the sliced view straight
         // in -- no zero-padding, no output trimming, no risk of
         // contaminating reductions on non-split axes.
-        debug_assert_eq!(actual_size, epg, "dim-split detector must enforce dim_size % epg == 0");
+        debug_assert_eq!(
+            actual_size, epg,
+            "dim-split detector must enforce dim_size % epg == 0"
+        );
         let mut group_cache = TensorStore::new();
         for vi_name in &input_names {
             let arr = tensor_cache.try_get(vi_name).ok_or_else(|| {

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -909,6 +909,20 @@ pub fn detect_dim_split(
             if output_name.is_empty() {
                 continue;
             }
+            // Reject the split when axis tracing through the slice cannot
+            // prove the split axis lands at the same position (and size)
+            // in the final output.  Shape-reordering ops (Reshape,
+            // Transpose, Flatten, Squeeze, Unsqueeze, Concat on the
+            // split axis) are non-trivial to follow here, so we require
+            // the output shape to match the attention input at split_dim.
+            let Some(out_shape) = shapes.get(&output_name) else {
+                continue;
+            };
+            if out_shape.len() != attn_shape.len()
+                || out_shape[split_dim] != attn_shape[split_dim]
+            {
+                continue;
+            }
             return Some(DimSplitDetection {
                 split_kind,
                 split_dim,
@@ -1024,6 +1038,20 @@ pub fn detect_dim_split(
         .and_then(|n| n.output.first())
         .filter(|s| !s.is_empty())
         .cloned()?;
+    // Require the final output shape to preserve rank and the split
+    // axis size; otherwise an intermediate op (Reshape, Transpose,
+    // Flatten, Squeeze, Unsqueeze) has reordered the axes and
+    // concat_axis=split_dim would splice the groups into the wrong
+    // output dimension.  Tracing the axis through an arbitrary chain
+    // of shape ops is out of scope here, so we conservatively reject.
+    let Some(out_shape) = shapes.get(&output_name) else {
+        return None;
+    };
+    if out_shape.len() != first_input_shape.len()
+        || out_shape[split_dim] != first_input_shape[split_dim]
+    {
+        return None;
+    }
     Some(DimSplitDetection {
         split_kind: DimSplitKind::BatchDim,
         split_dim,

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -863,9 +863,7 @@ pub fn detect_dim_split(
             let attn_input = nodes.iter().flat_map(|n| n.input.iter()).find(|name| {
                 !name.is_empty()
                     && !initializer_names.contains(name.as_str())
-                    && shapes
-                        .get(*name)
-                        .is_some_and(|s| s.len() == 4 && s[0] > 0)
+                    && shapes.get(*name).is_some_and(|s| s.len() == 4 && s[0] > 0)
             });
             let Some(attn_input_name) = attn_input.cloned() else {
                 continue;
@@ -877,11 +875,11 @@ pub fn detect_dim_split(
             // axis and yields the highest axis size; that axis gives the
             // most groups and the lowest per-group cost.
             let mut best: Option<(usize, usize, DimSplitKind)> = None;
-            for d in 0..attn_shape.len() {
+            for (d, &axis_len) in attn_shape.iter().enumerate() {
                 if d == softmax_axis_abs {
                     continue;
                 }
-                let dim_size = attn_shape[d].max(1) as usize;
+                let dim_size = axis_len.max(1) as usize;
                 if dim_size < 2 {
                     continue;
                 }
@@ -918,8 +916,7 @@ pub fn detect_dim_split(
             let Some(out_shape) = shapes.get(&output_name) else {
                 continue;
             };
-            if out_shape.len() != attn_shape.len()
-                || out_shape[split_dim] != attn_shape[split_dim]
+            if out_shape.len() != attn_shape.len() || out_shape[split_dim] != attn_shape[split_dim]
             {
                 continue;
             }
@@ -1019,8 +1016,8 @@ pub fn detect_dim_split(
     }
 
     let mut best: Option<(usize, usize)> = None;
-    for d in 0..max_allowed {
-        let dim = first_input_shape[d].max(1) as usize;
+    for (d, &axis_len) in first_input_shape.iter().enumerate().take(max_allowed) {
+        let dim = axis_len.max(1) as usize;
         if dim <= 1 {
             continue;
         }
@@ -1044,9 +1041,7 @@ pub fn detect_dim_split(
     // concat_axis=split_dim would splice the groups into the wrong
     // output dimension.  Tracing the axis through an arbitrary chain
     // of shape ops is out of scope here, so we conservatively reject.
-    let Some(out_shape) = shapes.get(&output_name) else {
-        return None;
-    };
+    let out_shape = shapes.get(&output_name)?;
     if out_shape.len() != first_input_shape.len()
         || out_shape[split_dim] != first_input_shape[split_dim]
     {

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -670,6 +670,20 @@ fn detect_elementwise_fixed_segments(graph: &GraphProto) -> Option<TilingDetecti
 
 pub const MAX_ESTIMATED_CONSTRAINTS: u64 = 750_000;
 
+/// Return the smallest divisor of `dim` that is >= `target`.  Returns
+/// `None` if no such divisor exists in `(0, dim]`, which is the
+/// signal to refuse the dim-split: pad-then-trim on the last group
+/// would inject zeros into reductions on non-split axes (Softmax,
+/// LayerNorm, ReduceMean, etc.) and contaminate the unpadded
+/// region's outputs.
+fn smallest_divisor_at_least(dim: usize, target: usize) -> Option<usize> {
+    if dim == 0 || target == 0 {
+        return None;
+    }
+    let target = target.min(dim);
+    (target..=dim).find(|&g| dim.is_multiple_of(g))
+}
+
 #[derive(Debug, Clone)]
 pub struct DimSplitDetection {
     pub split_kind: DimSplitKind,
@@ -896,8 +910,11 @@ pub fn detect_dim_split(
             let Some((split_dim, dim_size, split_kind)) = best else {
                 continue;
             };
-            let num_groups = target_groups.min(dim_size);
-            let elements_per_group = dim_size.div_ceil(num_groups);
+            let num_groups = match smallest_divisor_at_least(dim_size, target_groups) {
+                Some(g) => g,
+                None => continue,
+            };
+            let elements_per_group = dim_size / num_groups;
             let output_name = nodes
                 .last()
                 .and_then(|n| n.output.first())
@@ -1040,8 +1057,8 @@ pub fn detect_dim_split(
     }
     let (split_dim, dim_size) = best?;
 
-    let num_groups = target_groups.min(dim_size);
-    let elements_per_group = dim_size.div_ceil(num_groups);
+    let num_groups = smallest_divisor_at_least(dim_size, target_groups)?;
+    let elements_per_group = dim_size / num_groups;
     let input_name = first_non_init_input.cloned()?;
     let output_name = nodes
         .last()
@@ -2211,19 +2228,19 @@ fn create_generic_dim_template(
     // 4. Re-run shape inference on the rewritten template and inject
     //    the derived shapes back as value_info.  This replaces the old
     //    ad-hoc per-op rewrites (which had to special-case every shape
-    //    op).
-    let trace_result = match super::trace::fold_and_trace_via_tract(&tmpl_path, &tmpl_model) {
-        Ok(t) => Some(t),
-        Err(e) => {
-            tracing::warn!(
-                slice = info.slice_idx,
-                error = %e,
-                "dim-split template re-trace failed; downstream compile may report shape errors"
-            );
-            None
-        }
-    };
-    if let Some(trace) = trace_result {
+    //    op).  If re-trace fails the template is uncompilable -- the
+    //    circuit compiler downstream will see no value_info for the
+    //    intermediate tensors and produce hard-to-diagnose shape
+    //    errors at compile time.  Refuse to emit the template instead.
+    let trace = super::trace::fold_and_trace_via_tract(&tmpl_path, &tmpl_model).map_err(
+        |e| {
+            crate::error::DsperseError::Slicer(format!(
+                "create_generic_dim_template: slice {} re-trace failed (template input shape {:?}, split_dim {}): {e}",
+                info.slice_idx, info.input_name, split_dim
+            ))
+        },
+    )?;
+    {
         let mut model_after = onnx_proto::load_model(&tmpl_path)?;
         if let Some(graph_after) = model_after.graph.as_mut() {
             let existing: HashSet<String> = graph_after

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -21,7 +21,7 @@ fn try_quad(v: &[i64]) -> Option<[i64; 4]> {
     }
 }
 
-fn model_opset(model: &ModelProto) -> i64 {
+pub(crate) fn model_opset(model: &ModelProto) -> i64 {
     model
         .opset_import
         .iter()
@@ -731,6 +731,7 @@ pub fn detect_dim_split(
     nodes: &[NodeProto],
     shapes: &HashMap<String, Vec<i64>>,
     initializer_names: &HashSet<String>,
+    model_opset: i64,
 ) -> Option<DimSplitDetection> {
     let estimated = estimate_slice_constraints(nodes, shapes);
     if estimated <= MAX_ESTIMATED_CONSTRAINTS {
@@ -857,6 +858,16 @@ pub fn detect_dim_split(
         }
     }
 
+    // Slice-boundary inputs are ones not produced by any node inside
+    // this slice; everything else is internal data flow that the
+    // dim-split rewrite cannot honour as a true split axis.
+    let slice_internal_outputs: HashSet<&str> = nodes
+        .iter()
+        .flat_map(|n| n.output.iter())
+        .filter(|s| !s.is_empty())
+        .map(String::as_str)
+        .collect();
+
     for node in nodes {
         if node.op_type == "Softmax" {
             let Some(softmax_in) = node.input.first().and_then(|name| shapes.get(name)) else {
@@ -865,18 +876,26 @@ pub fn detect_dim_split(
             if softmax_in.len() != 4 {
                 continue;
             }
-            let softmax_axis = onnx_proto::get_attribute_int(node, "axis").unwrap_or(-1);
+            // ONNX Softmax default axis: opset >= 13 -> -1
+            // (last axis), opset < 13 -> 1 (channel axis).
+            // unwrap_or(-1) silently mismatches runtime semantics on
+            // opset <13 models that omit the attribute.
+            let default_axis: i64 = if model_opset >= 13 { -1 } else { 1 };
+            let softmax_axis = onnx_proto::get_attribute_int(node, "axis").unwrap_or(default_axis);
             let softmax_axis_abs = if softmax_axis < 0 {
                 (softmax_in.len() as i64 + softmax_axis).max(0) as usize
             } else {
                 softmax_axis as usize
             };
-            // Find the attention-block input among the slice inputs: the
-            // first non-init tensor whose rank matches the softmax input
-            // rank (Q/V-like activation).
+            // Find the attention-block input among the slice inputs:
+            // the first slice-boundary tensor (external -- not the
+            // output of any other node in this slice, and not an
+            // initializer) whose rank matches the softmax input rank
+            // (Q/V-like activation).
             let attn_input = nodes.iter().flat_map(|n| n.input.iter()).find(|name| {
                 !name.is_empty()
                     && !initializer_names.contains(name.as_str())
+                    && !slice_internal_outputs.contains(name.as_str())
                     && shapes.get(*name).is_some_and(|s| s.len() == 4 && s[0] > 0)
             });
             let Some(attn_input_name) = attn_input.cloned() else {
@@ -1023,7 +1042,13 @@ pub fn detect_dim_split(
                 }
             }
             "Softmax" | "LogSoftmax" => {
-                let axis = onnx_proto::get_attribute_int(node, "axis").unwrap_or(-1);
+                // ONNX Softmax / LogSoftmax default axis: opset >=
+                // 13 -> -1 (last axis), opset < 13 -> 1 (channel
+                // axis).  unwrap_or(-1) silently mismatches runtime
+                // semantics on opset < 13 models that omit the
+                // attribute.
+                let default_axis: i64 = if model_opset >= 13 { -1 } else { 1 };
+                let axis = onnx_proto::get_attribute_int(node, "axis").unwrap_or(default_axis);
                 let resolved = if axis < 0 {
                     (rank as i64 + axis).max(0) as usize
                 } else {
@@ -2021,7 +2046,12 @@ fn create_matmul_dim_template(
     Ok(tmpl_path)
 }
 
-fn check_axis_separable(graph: &GraphProto, split_dim: usize, slice_idx: usize) -> Result<()> {
+fn check_axis_separable(
+    graph: &GraphProto,
+    split_dim: usize,
+    slice_idx: usize,
+    model_opset: i64,
+) -> Result<()> {
     let resolve_axis = |axis: i64| -> usize {
         let ndim = graph
             .input
@@ -2048,8 +2078,13 @@ fn check_axis_separable(graph: &GraphProto, split_dim: usize, slice_idx: usize) 
                 }
             }
             "Softmax" | "LogSoftmax" => {
-                let resolved =
-                    resolve_axis(onnx_proto::get_attribute_int(node, "axis").unwrap_or(-1));
+                // ONNX Softmax / LogSoftmax default axis: opset >=
+                // 13 -> -1 (last axis), opset < 13 -> 1 (channel
+                // axis).
+                let default_axis: i64 = if model_opset >= 13 { -1 } else { 1 };
+                let resolved = resolve_axis(
+                    onnx_proto::get_attribute_int(node, "axis").unwrap_or(default_axis),
+                );
                 if resolved == split_dim {
                     return Err(crate::error::DsperseError::Slicer(format!(
                         "create_generic_dim_template: slice {slice_idx} {} axis {resolved} \
@@ -2094,7 +2129,7 @@ fn create_generic_dim_template(
         )));
     }
 
-    check_axis_separable(graph, info.split_dim, info.slice_idx)?;
+    check_axis_separable(graph, info.split_dim, info.slice_idx, model_opset(model))?;
 
     // Rewrite the template so the split axis carries elements_per_group
     // instead of the full dim_size.  The runner only ever feeds a single
@@ -2210,9 +2245,34 @@ fn create_generic_dim_template(
         .collect();
     for init in &mut tmpl_graph.initializer {
         if init.data_type == TensorProto::INT64 && shape_input_initializers.contains(&init.name) {
+            // ONNX TensorProto INT64 payloads can live in either
+            // int64_data (typed field) or raw_data (little-endian
+            // i64 byte stream); larger constants tend to use
+            // raw_data.  Patch both representations.
             for v in &mut init.int64_data {
                 if *v == dim_size {
                     *v = epg;
+                }
+            }
+            if !init.raw_data.is_empty() && init.raw_data.len() % 8 == 0 {
+                let mut buf: Vec<i64> = init
+                    .raw_data
+                    .chunks_exact(8)
+                    .map(|c| i64::from_le_bytes(c.try_into().unwrap()))
+                    .collect();
+                let mut changed = false;
+                for v in &mut buf {
+                    if *v == dim_size {
+                        *v = epg;
+                        changed = true;
+                    }
+                }
+                if changed {
+                    let mut new_raw = Vec::with_capacity(buf.len() * 8);
+                    for v in &buf {
+                        new_raw.extend_from_slice(&v.to_le_bytes());
+                    }
+                    init.raw_data = new_raw;
                 }
             }
         }
@@ -2789,7 +2849,7 @@ mod tests {
         let mut init_names = HashSet::new();
         init_names.insert("weight".to_string());
 
-        let detection = detect_dim_split(&[node], &shapes, &init_names);
+        let detection = detect_dim_split(&[node], &shapes, &init_names, 17);
         assert!(detection.is_some());
         let d = detection.unwrap();
         assert_eq!(d.split_dim, 0);
@@ -2818,7 +2878,7 @@ mod tests {
         let mut init_names = HashSet::new();
         init_names.insert("weight".to_string());
 
-        let detection = detect_dim_split(&[node], &shapes, &init_names);
+        let detection = detect_dim_split(&[node], &shapes, &init_names, 17);
         assert!(detection.is_some());
         let d = detection.unwrap();
         assert_eq!(d.split_dim, 0);
@@ -2849,7 +2909,7 @@ mod tests {
         let mut init_names = HashSet::new();
         init_names.insert("weight".to_string());
 
-        let d = detect_dim_split(&[node], &shapes, &init_names).unwrap();
+        let d = detect_dim_split(&[node], &shapes, &init_names, 17).unwrap();
         assert_eq!(d.k_dim, 10);
         assert_eq!(d.n_dim, 300_000);
         let chunk_size = d.k_dim.div_ceil(d.k_chunks);
@@ -2877,7 +2937,7 @@ mod tests {
         let mut init_names = HashSet::new();
         init_names.insert("weight".to_string());
 
-        let d = detect_dim_split(&[node], &shapes, &init_names).unwrap();
+        let d = detect_dim_split(&[node], &shapes, &init_names, 17).unwrap();
         assert_eq!(d.dim_size, 1);
         assert_eq!(d.num_groups, 1);
         assert!(d.k_chunks > 1, "expected K-chunking for single row");
@@ -2914,7 +2974,7 @@ mod tests {
         // Tiny per-op cost; slice estimate stays under MAX so detect_dim_split
         // returns None at the outer gate, which is what we want for a
         // single-row single-chunk MatMul.
-        assert!(detect_dim_split(&[node1, node2], &shapes, &init_names).is_none());
+        assert!(detect_dim_split(&[node1, node2], &shapes, &init_names, 17).is_none());
     }
 
     #[test]
@@ -2936,7 +2996,7 @@ mod tests {
         let mut init_names = HashSet::new();
         init_names.insert("weight".to_string());
 
-        let got = detect_dim_split(&[node], &shapes, &init_names);
+        let got = detect_dim_split(&[node], &shapes, &init_names, 17);
         assert!(
             got.as_ref()
                 .is_none_or(|d| !matches!(d.split_kind, DimSplitKind::MatMulOutputDim)),
@@ -2972,7 +3032,7 @@ mod tests {
         init_names.insert("weight".to_string());
         init_names.insert("bias".to_string());
 
-        let got = detect_dim_split(&[matmul, add], &shapes, &init_names);
+        let got = detect_dim_split(&[matmul, add], &shapes, &init_names, 17);
         assert!(
             got.as_ref()
                 .is_none_or(|d| !matches!(d.split_kind, DimSplitKind::MatMulOutputDim)),
@@ -3007,7 +3067,7 @@ mod tests {
         init_names.insert("w1".to_string());
         init_names.insert("w2".to_string());
 
-        let d = detect_dim_split(&[m1, m2], &shapes, &init_names).unwrap();
+        let d = detect_dim_split(&[m1, m2], &shapes, &init_names, 17).unwrap();
         assert_eq!(d.weight_name.as_deref(), Some("w2"));
         assert_eq!(d.output_name, "output");
         assert_eq!(d.k_dim, 1536);
@@ -3033,7 +3093,7 @@ mod tests {
         let mut init_names = HashSet::new();
         init_names.insert("weight".to_string());
 
-        let got = detect_dim_split(&[node], &shapes, &init_names);
+        let got = detect_dim_split(&[node], &shapes, &init_names, 17);
         assert!(
             got.as_ref()
                 .is_none_or(|d| !matches!(d.split_kind, DimSplitKind::MatMulOutputDim)),
@@ -3068,7 +3128,7 @@ mod tests {
 
         // Detector should decline the MatMul branch since the template
         // builder cannot handle biased Gemm, forcing fall-through.
-        let got = detect_dim_split(&[node], &shapes, &init_names);
+        let got = detect_dim_split(&[node], &shapes, &init_names, 17);
         assert!(
             got.as_ref()
                 .is_none_or(|d| !matches!(d.split_kind, DimSplitKind::MatMulOutputDim)),

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -937,20 +937,22 @@ pub fn detect_dim_split(
         return None;
     }
 
-    // Conv / ConvTranspose / Pooling / MatMul / Gemm are not separable
-    // along arbitrary input axes: splitting the input channel or the
-    // spatial dimensions of the input tensor produces semantically
-    // incorrect per-group outputs. The dedicated detection paths
-    // (conv spatial tiling, channel splitting, dim-split-k) handle
+    // Conv / ConvTranspose / Pooling are not separable along arbitrary
+    // input axes: splitting the input channel or the spatial dimensions
+    // produces semantically incorrect per-group outputs. The dedicated
+    // detection paths (conv spatial tiling, channel splitting) handle
     // these ops correctly; this generic fallback refuses to emit a
-    // split for them.
+    // split for them.  MatMul / Gemm are *not* listed here: their
+    // dedicated dim-split-k path handles the K-axis split when the
+    // weight is an initializer, but non-terminal MatMul/Gemm slices or
+    // slices whose weight is a runtime tensor still benefit from the
+    // generic axis-0 (batch) fallback, which is always semantically
+    // sound because the batch dimension is independent across rows.
     for node in nodes {
         if matches!(
             node.op_type.as_str(),
             "Conv"
                 | "ConvTranspose"
-                | "MatMul"
-                | "Gemm"
                 | "AveragePool"
                 | "MaxPool"
                 | "GlobalAveragePool"

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -1034,9 +1034,12 @@ pub fn detect_dim_split(
                 }
             }
             "BatchNormalization" => {
-                if max_allowed > 0 {
-                    max_allowed = 0;
-                }
+                // BatchNorm couples every spatial element to the
+                // running mean / variance per channel; splitting any
+                // axis would change those statistics.  Force-reject
+                // the dim-split unconditionally so the early return at
+                // line 1044 fires regardless of prior state.
+                max_allowed = 0;
             }
             _ => {}
         }

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -668,7 +668,7 @@ fn detect_elementwise_fixed_segments(graph: &GraphProto) -> Option<TilingDetecti
     })
 }
 
-pub const MAX_ESTIMATED_CONSTRAINTS: u64 = 2_000_000;
+pub const MAX_ESTIMATED_CONSTRAINTS: u64 = 750_000;
 
 #[derive(Debug, Clone)]
 pub struct DimSplitDetection {
@@ -845,36 +845,85 @@ pub fn detect_dim_split(
 
     for node in nodes {
         if node.op_type == "Softmax" {
-            let Some(input_shape) = node.input.first().and_then(|name| shapes.get(name)) else {
+            let Some(softmax_in) = node.input.first().and_then(|name| shapes.get(name)) else {
                 continue;
             };
-            if input_shape.len() == 4 && input_shape[1] > 1 {
-                let head_dim = input_shape[1] as usize;
-                let num_groups = target_groups.min(head_dim);
-                let elements_per_group = head_dim.div_ceil(num_groups);
-                let Some(input_name) = node.input.first().filter(|s| !s.is_empty()).cloned() else {
-                    continue;
-                };
-                let Some(output_name) = node.output.first().filter(|s| !s.is_empty()).cloned()
-                else {
-                    continue;
-                };
-                return Some(DimSplitDetection {
-                    split_kind: DimSplitKind::HeadDim,
-                    split_dim: 1,
-                    dim_size: head_dim,
-                    num_groups,
-                    elements_per_group,
-                    input_name,
-                    output_name,
-                    concat_axis: 1,
-                    estimated_constraints: estimated,
-                    weight_name: None,
-                    k_dim: 0,
-                    n_dim: 0,
-                    k_chunks: 1,
-                });
+            if softmax_in.len() != 4 {
+                continue;
             }
+            let softmax_axis = onnx_proto::get_attribute_int(node, "axis").unwrap_or(-1);
+            let softmax_axis_abs = if softmax_axis < 0 {
+                (softmax_in.len() as i64 + softmax_axis).max(0) as usize
+            } else {
+                softmax_axis as usize
+            };
+            // Find the attention-block input among the slice inputs: the
+            // first non-init tensor whose rank matches the softmax input
+            // rank (Q/V-like activation).
+            let attn_input = nodes.iter().flat_map(|n| n.input.iter()).find(|name| {
+                !name.is_empty()
+                    && !initializer_names.contains(name.as_str())
+                    && shapes
+                        .get(*name)
+                        .is_some_and(|s| s.len() == 4 && s[0] > 0)
+            });
+            let Some(attn_input_name) = attn_input.cloned() else {
+                continue;
+            };
+            let Some(attn_shape) = shapes.get(&attn_input_name) else {
+                continue;
+            };
+            // Choose the dim (among 0..rank) that is not the softmax-reduction
+            // axis and yields the highest axis size; that axis gives the
+            // most groups and the lowest per-group cost.
+            let mut best: Option<(usize, usize, DimSplitKind)> = None;
+            for d in 0..attn_shape.len() {
+                if d == softmax_axis_abs {
+                    continue;
+                }
+                let dim_size = attn_shape[d].max(1) as usize;
+                if dim_size < 2 {
+                    continue;
+                }
+                let kind = if d == 1 {
+                    DimSplitKind::HeadDim
+                } else {
+                    DimSplitKind::BatchDim
+                };
+                let better = best.as_ref().is_none_or(|(_, sz, _)| dim_size > *sz);
+                if better {
+                    best = Some((d, dim_size, kind));
+                }
+            }
+            let Some((split_dim, dim_size, split_kind)) = best else {
+                continue;
+            };
+            let num_groups = target_groups.min(dim_size);
+            let elements_per_group = dim_size.div_ceil(num_groups);
+            let output_name = nodes
+                .last()
+                .and_then(|n| n.output.first())
+                .filter(|s| !s.is_empty())
+                .cloned()
+                .unwrap_or_else(|| node.output.first().cloned().unwrap_or_default());
+            if output_name.is_empty() {
+                continue;
+            }
+            return Some(DimSplitDetection {
+                split_kind,
+                split_dim,
+                dim_size,
+                num_groups,
+                elements_per_group,
+                input_name: attn_input_name,
+                output_name,
+                concat_axis: split_dim,
+                estimated_constraints: estimated,
+                weight_name: None,
+                k_dim: 0,
+                n_dim: 0,
+                k_chunks: 1,
+            });
         }
     }
 
@@ -884,34 +933,110 @@ pub fn detect_dim_split(
             .find(|name| !name.is_empty() && !initializer_names.contains(name.as_str()))
     });
     let first_input_shape = first_non_init_input.and_then(|name| shapes.get(name))?;
-    if !first_input_shape.is_empty() && first_input_shape[0] > 1 {
-        let batch_dim = first_input_shape[0] as usize;
-        let num_groups = target_groups.min(batch_dim);
-        let elements_per_group = batch_dim.div_ceil(num_groups);
-        let input_name = first_non_init_input.cloned()?;
-        let output_name = nodes
-            .last()
-            .and_then(|n| n.output.first())
-            .filter(|s| !s.is_empty())
-            .cloned()?;
-        return Some(DimSplitDetection {
-            split_kind: DimSplitKind::BatchDim,
-            split_dim: 0,
-            dim_size: batch_dim,
-            num_groups,
-            elements_per_group,
-            input_name,
-            output_name,
-            concat_axis: 0,
-            estimated_constraints: estimated,
-            weight_name: None,
-            k_dim: 0,
-            n_dim: 0,
-            k_chunks: 1,
-        });
+    if first_input_shape.is_empty() {
+        return None;
     }
 
-    None
+    // Conv / ConvTranspose / Pooling / MatMul / Gemm are not separable
+    // along arbitrary input axes: splitting the input channel or the
+    // spatial dimensions of the input tensor produces semantically
+    // incorrect per-group outputs. The dedicated detection paths
+    // (conv spatial tiling, channel splitting, dim-split-k) handle
+    // these ops correctly; this generic fallback refuses to emit a
+    // split for them.
+    for node in nodes {
+        if matches!(
+            node.op_type.as_str(),
+            "Conv"
+                | "ConvTranspose"
+                | "MatMul"
+                | "Gemm"
+                | "AveragePool"
+                | "MaxPool"
+                | "GlobalAveragePool"
+                | "GlobalMaxPool"
+                | "LRN"
+        ) {
+            return None;
+        }
+    }
+
+    // Find the deepest split_dim that is still compatible with every
+    // normalization-style op in the slice.  Splitting a later axis produces
+    // more groups and a smaller per-group cost without violating op semantics.
+    let rank = first_input_shape.len();
+    let mut max_allowed = rank;
+    for node in nodes {
+        match node.op_type.as_str() {
+            "LayerNormalization" => {
+                let axis = onnx_proto::get_attribute_int(node, "axis").unwrap_or(-1);
+                let resolved = if axis < 0 {
+                    (rank as i64 + axis).max(0) as usize
+                } else {
+                    (axis as usize).min(rank)
+                };
+                if resolved < max_allowed {
+                    max_allowed = resolved;
+                }
+            }
+            "Softmax" | "LogSoftmax" => {
+                let axis = onnx_proto::get_attribute_int(node, "axis").unwrap_or(-1);
+                let resolved = if axis < 0 {
+                    (rank as i64 + axis).max(0) as usize
+                } else {
+                    (axis as usize).min(rank.saturating_sub(1))
+                };
+                if resolved < max_allowed {
+                    max_allowed = resolved;
+                }
+            }
+            "BatchNormalization" => {
+                if max_allowed > 0 {
+                    max_allowed = 0;
+                }
+            }
+            _ => {}
+        }
+    }
+    if max_allowed == 0 {
+        return None;
+    }
+
+    let mut best: Option<(usize, usize)> = None;
+    for d in 0..max_allowed {
+        let dim = first_input_shape[d].max(1) as usize;
+        if dim <= 1 {
+            continue;
+        }
+        if best.map(|(_, size)| dim > size).unwrap_or(true) {
+            best = Some((d, dim));
+        }
+    }
+    let (split_dim, dim_size) = best?;
+
+    let num_groups = target_groups.min(dim_size);
+    let elements_per_group = dim_size.div_ceil(num_groups);
+    let input_name = first_non_init_input.cloned()?;
+    let output_name = nodes
+        .last()
+        .and_then(|n| n.output.first())
+        .filter(|s| !s.is_empty())
+        .cloned()?;
+    Some(DimSplitDetection {
+        split_kind: DimSplitKind::BatchDim,
+        split_dim,
+        dim_size,
+        num_groups,
+        elements_per_group,
+        input_name,
+        output_name,
+        concat_axis: split_dim,
+        estimated_constraints: estimated,
+        weight_name: None,
+        k_dim: 0,
+        n_dim: 0,
+        k_chunks: 1,
+    })
 }
 
 #[derive(Debug, Clone)]

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -2206,9 +2206,7 @@ fn create_generic_dim_template(
         .filter(|name| !name.is_empty())
         .collect();
     for init in &mut tmpl_graph.initializer {
-        if init.data_type == TensorProto::INT64
-            && shape_input_initializers.contains(&init.name)
-        {
+        if init.data_type == TensorProto::INT64 && shape_input_initializers.contains(&init.name) {
             for v in &mut init.int64_data {
                 if *v == dim_size {
                     *v = epg;
@@ -2279,7 +2277,10 @@ fn create_generic_dim_template(
             }
             // Promote output_name to graph output if it now exists in
             // value_info but not in graph.output.
-            if !graph_after.output.iter().any(|o| o.name == info.output_name)
+            if !graph_after
+                .output
+                .iter()
+                .any(|o| o.name == info.output_name)
                 && let Some(vi) = graph_after
                     .value_info
                     .iter()

--- a/crates/dsperse/src/slicer/autotiler.rs
+++ b/crates/dsperse/src/slicer/autotiler.rs
@@ -978,7 +978,20 @@ pub fn detect_dim_split(
     // normalization-style op in the slice.  Splitting a later axis produces
     // more groups and a smaller per-group cost without violating op semantics.
     let rank = first_input_shape.len();
-    let mut max_allowed = rank;
+    // If the slice contains any axis-reordering op (Transpose) AND any
+    // axis-sensitive normalization op (LayerNormalization / Softmax),
+    // we can no longer cheaply trace which axis the normalization
+    // really runs on after the reorder.  Restrict the split to axis 0
+    // (always the batch dim, always semantically sound) so we never
+    // emit a split that lands on the post-Transpose normalization axis.
+    let has_transpose = nodes.iter().any(|n| n.op_type == "Transpose");
+    let has_norm = nodes.iter().any(|n| {
+        matches!(
+            n.op_type.as_str(),
+            "LayerNormalization" | "Softmax" | "LogSoftmax"
+        )
+    });
+    let mut max_allowed = if has_transpose && has_norm { 1 } else { rank };
     for node in nodes {
         match node.op_type.as_str() {
             "LayerNormalization" => {
@@ -2063,75 +2076,205 @@ fn create_generic_dim_template(
 
     check_axis_separable(graph, info.split_dim, info.slice_idx)?;
 
-    // The template is the original slice model with no shape rewriting.
-    // The runner pads each group's input to dim_size before inference and
-    // trims the output afterward. Keeping the original shapes means the
-    // compiled circuit signature is identical regardless of group size,
-    // maximizing cross-slice and cross-model circuit catalog reuse.
+    // Rewrite the template so the split axis carries elements_per_group
+    // instead of the full dim_size.  The runner only ever feeds a single
+    // group's worth of activations to the compiled circuit, so the
+    // *compile* cost should match the per-group cost rather than the
+    // whole-slice cost.  Catalog reuse is preserved at per-group
+    // granularity: any two slices that share (split_dim, epg, surrounding
+    // op shapes) hash identically.
+    //
+    // The strategy is: rewrite only the boundary shapes (graph inputs +
+    // shape-input initializers consumed by Reshape / Expand / Tile /
+    // ConstantOfShape) and a fresh shape inference pass derives every
+    // intermediate value_info from those.  Per-feature initializers
+    // (gamma, beta, weights) are never touched, and there are no ad-hoc
+    // cases for individual op patterns -- the rule is "rewrite the
+    // boundary, let inference do the rest".
     let mut tmpl_model = model.clone();
     let tmpl_graph = tmpl_model.graph.as_mut().ok_or_else(|| {
         crate::error::DsperseError::Slicer(
             "create_generic_dim_template: cloned model has no graph".into(),
         )
     })?;
+    let dim_size = info.dim_size as i64;
+    let epg = info.elements_per_group as i64;
+    let split_dim = info.split_dim;
 
-    // Populate value_info for intermediate node outputs that lack shape
-    // declarations. jstprove needs these to resolve weight shapes during
-    // WAI circuit compilation (e.g. Gemm expected_weight_shape derives N
-    // from the output shape). Without traced_shapes the circuit compiler
-    // cannot infer these and falls back to incorrect dimensions.
-    if let Some(shapes) = traced_shapes {
-        let existing: HashSet<String> = tmpl_graph
+    // 1. Decide which graph inputs must be rewritten at split_dim.
+    //
+    //    The runner always slices every cached tensor whose shape has
+    //    dim_size at split_dim, so the *compile-time* template needs
+    //    every such input declared with epg, otherwise jstprove's
+    //    type checker rejects the op (e.g. Mul broadcast 150 vs 300,
+    //    or MatMul A.K vs B.K mismatch).  But for ops where two
+    //    inputs reference dim_size at the *same* split_dim with
+    //    different semantic meanings (the canonical case is the
+    //    second attention MatMul: attn[B,H,M,N] @ V[B,H,N,D] with
+    //    M == N at split_dim=2) blanket rewriting both inputs
+    //    produces a real mismatch.
+    //
+    //    Heuristic:
+    //      * Elementwise / broadcast ops (Add, Sub, Mul, Div, Pow, Min,
+    //        Max, Where, Equal, Greater, Less): rewrite every input
+    //        whose shape has dim_size at split_dim.  All inputs share
+    //        a logical broadcast axis, so all must shrink together.
+    //      * MatMul / Gemm: rewrite only `info.input_name`.  The other
+    //        operand's split_dim is a contraction axis; touching it
+    //        produces an inner-dim mismatch.
+    //      * Everything else (the single-op slices we get after
+    //        isolate_expensive_ops): rewrite only `info.input_name`,
+    //        which is the safe default for ops with one primary
+    //        activation and a handful of scalar / per-feature
+    //        initializer inputs.
+    let elementwise_ops: HashSet<&str> = [
+        "Add", "Sub", "Mul", "Div", "Pow", "Min", "Max", "Where", "Equal", "Greater", "Less",
+    ]
+    .into_iter()
+    .collect();
+    let rewrite_all_matching = tmpl_graph
+        .node
+        .iter()
+        .all(|n| elementwise_ops.contains(n.op_type.as_str()));
+
+    let rewrite_input_at_split_dim = |vi: &mut super::onnx_proto::ValueInfoProto| {
+        if let Some(t) = vi.r#type.as_mut()
+            && let Some(super::onnx_proto::onnx::type_proto::Value::TensorType(tt)) =
+                t.value.as_mut()
+            && let Some(shape) = tt.shape.as_mut()
+            && let Some(d) = shape.dim.get_mut(split_dim)
+            && let Some(super::onnx_proto::onnx::tensor_shape_proto::dimension::Value::DimValue(v)) =
+                d.value.as_mut()
+            && *v == dim_size
+        {
+            *v = epg;
+        }
+    };
+
+    if rewrite_all_matching {
+        for vi in tmpl_graph
             .input
-            .iter()
-            .chain(tmpl_graph.output.iter())
-            .chain(tmpl_graph.value_info.iter())
-            .map(|vi| vi.name.clone())
-            .collect();
-        let init_names: HashSet<&str> = tmpl_graph
-            .initializer
-            .iter()
-            .map(|i| i.name.as_str())
-            .collect();
-        let node_output_types = super::materializer::build_node_output_types(tmpl_graph);
-        for node in &tmpl_graph.node {
-            for out_name in &node.output {
-                if out_name.is_empty()
-                    || existing.contains(out_name)
-                    || init_names.contains(out_name.as_str())
-                {
-                    continue;
-                }
-                if let Some(shape) = shapes.get(out_name) {
-                    let elem_type = node_output_types
-                        .get(out_name)
-                        .copied()
-                        .unwrap_or(TensorProto::FLOAT);
-                    tmpl_graph
-                        .value_info
-                        .push(onnx_proto::make_tensor_value_info(
-                            out_name, elem_type, shape,
-                        ));
+            .iter_mut()
+            .chain(tmpl_graph.output.iter_mut())
+        {
+            rewrite_input_at_split_dim(vi);
+        }
+    } else {
+        for vi in tmpl_graph
+            .input
+            .iter_mut()
+            .filter(|vi| vi.name == info.input_name)
+            .chain(
+                tmpl_graph
+                    .output
+                    .iter_mut()
+                    .filter(|vi| vi.name == info.output_name),
+            )
+        {
+            rewrite_input_at_split_dim(vi);
+        }
+    }
+
+    // 2. Rewrite shape-input initializers (Reshape / Expand / Tile /
+    //    ConstantOfShape).  These are explicit shape descriptors; if
+    //    the input shape changes their dim_size entry must change too.
+    let shape_input_initializers: HashSet<String> = tmpl_graph
+        .node
+        .iter()
+        .filter_map(|n| match n.op_type.as_str() {
+            "Reshape" | "Expand" | "Tile" => n.input.get(1).cloned(),
+            "ConstantOfShape" => n.input.first().cloned(),
+            _ => None,
+        })
+        .filter(|name| !name.is_empty())
+        .collect();
+    for init in &mut tmpl_graph.initializer {
+        if init.data_type == TensorProto::INT64
+            && shape_input_initializers.contains(&init.name)
+        {
+            for v in &mut init.int64_data {
+                if *v == dim_size {
+                    *v = epg;
                 }
             }
         }
     }
 
-    // Promote output_name to graph output if it only exists in value_info.
-    // Runs after the traced_shapes synthesis above so that newly created
-    // value_info entries are eligible for promotion.
-    if !tmpl_graph.output.iter().any(|o| o.name == info.output_name)
-        && let Some(vi) = tmpl_graph
-            .value_info
-            .iter()
-            .find(|v| v.name == info.output_name)
-            .cloned()
-    {
-        tmpl_graph.output.push(vi);
-    }
+    // 3. Drop every intermediate value_info; it will be re-derived.
+    tmpl_graph.value_info.clear();
+
+    let _ = traced_shapes; // intentionally unused: we re-trace after rewriting.
 
     let tmpl_path = output_dir.join("dim_template.onnx");
     onnx_proto::save_model(&tmpl_model, &tmpl_path)?;
+
+    // 4. Re-run shape inference on the rewritten template and inject
+    //    the derived shapes back as value_info.  This replaces the old
+    //    ad-hoc per-op rewrites (which had to special-case every shape
+    //    op).
+    let trace_result = match super::trace::fold_and_trace_via_tract(&tmpl_path, &tmpl_model) {
+        Ok(t) => Some(t),
+        Err(e) => {
+            tracing::warn!(
+                slice = info.slice_idx,
+                error = %e,
+                "dim-split template re-trace failed; downstream compile may report shape errors"
+            );
+            None
+        }
+    };
+    if let Some(trace) = trace_result {
+        let mut model_after = onnx_proto::load_model(&tmpl_path)?;
+        if let Some(graph_after) = model_after.graph.as_mut() {
+            let existing: HashSet<String> = graph_after
+                .input
+                .iter()
+                .chain(graph_after.output.iter())
+                .chain(graph_after.value_info.iter())
+                .map(|vi| vi.name.clone())
+                .collect();
+            let init_names: HashSet<&str> = graph_after
+                .initializer
+                .iter()
+                .map(|i| i.name.as_str())
+                .collect();
+            for node in &graph_after.node {
+                for out_name in &node.output {
+                    if out_name.is_empty()
+                        || existing.contains(out_name)
+                        || init_names.contains(out_name.as_str())
+                    {
+                        continue;
+                    }
+                    if let Some(shape) = trace.shapes.get(out_name) {
+                        let elem_type = trace
+                            .types
+                            .get(out_name)
+                            .copied()
+                            .unwrap_or(TensorProto::FLOAT);
+                        graph_after
+                            .value_info
+                            .push(onnx_proto::make_tensor_value_info(
+                                out_name, elem_type, shape,
+                            ));
+                    }
+                }
+            }
+            // Promote output_name to graph output if it now exists in
+            // value_info but not in graph.output.
+            if !graph_after.output.iter().any(|o| o.name == info.output_name)
+                && let Some(vi) = graph_after
+                    .value_info
+                    .iter()
+                    .find(|v| v.name == info.output_name)
+                    .cloned()
+            {
+                graph_after.output.push(vi);
+            }
+        }
+        onnx_proto::save_model(&model_after, &tmpl_path)?;
+    }
+
     Ok(tmpl_path)
 }
 

--- a/crates/dsperse/src/slicer/layernorm_fuse.rs
+++ b/crates/dsperse/src/slicer/layernorm_fuse.rs
@@ -97,8 +97,6 @@ pub fn fuse_inline_layernorms(
         new_nodes.push(n);
     }
     graph.node = new_nodes;
-
-    tracing::info!(fused, "fused inline LayerNorm patterns into LayerNormalization");
     fused
 }
 
@@ -132,7 +130,7 @@ fn try_match_layernorm(
     let x_name = mean_node.input.first()?.clone();
     let mean_out = mean_node.output.first()?.clone();
 
-    let sub_idx = find_unique_consumer(consumers, &mean_out, "Sub", drop)?;
+    let sub_idx = find_unique_consumer(consumers, &mean_out, "Sub", nodes, drop)?;
     let sub_node = &nodes[sub_idx];
     if sub_node.input.len() < 2
         || sub_node.input.first()? != &x_name
@@ -142,11 +140,11 @@ fn try_match_layernorm(
     }
     let centered = sub_node.output.first()?.clone();
 
-    let sq_idx = find_square_consumer(consumers, &centered, nodes, drop)?;
+    let sq_idx = find_square_consumer(consumers, &centered, nodes, initializers, drop)?;
     let sq_node = &nodes[sq_idx];
     let sq_out = sq_node.output.first()?.clone();
 
-    let mean2_idx = find_unique_consumer(consumers, &sq_out, "ReduceMean", drop)?;
+    let mean2_idx = find_unique_consumer(consumers, &sq_out, "ReduceMean", nodes, drop)?;
     let mean2_node = &nodes[mean2_idx];
     let raw_axes2 = reduce_axes(mean2_node, initializers)?;
     if raw_axes2 != raw_axes {
@@ -157,16 +155,16 @@ fn try_match_layernorm(
     }
     let var_out = mean2_node.output.first()?.clone();
 
-    let add_idx = find_unique_consumer(consumers, &var_out, "Add", drop)?;
+    let add_idx = find_unique_consumer(consumers, &var_out, "Add", nodes, drop)?;
     let add_node = &nodes[add_idx];
     let eps = extract_binary_const_scalar(add_node, &var_out, initializers)?;
     let var_eps = add_node.output.first()?.clone();
 
-    let sqrt_idx = find_unique_consumer(consumers, &var_eps, "Sqrt", drop)?;
+    let sqrt_idx = find_unique_consumer(consumers, &var_eps, "Sqrt", nodes, drop)?;
     let sqrt_node = &nodes[sqrt_idx];
     let std_out = sqrt_node.output.first()?.clone();
 
-    let div_idx = find_unique_consumer(consumers, &std_out, "Div", drop)?;
+    let div_idx = find_unique_consumer(consumers, &std_out, "Div", nodes, drop)?;
     let div_node = &nodes[div_idx];
     if div_node.input.len() < 2
         || div_node.input.first()? != &centered
@@ -181,14 +179,14 @@ fn try_match_layernorm(
     let mut scale_init: Option<String> = None;
     let mut bias_init: Option<String> = None;
 
-    if let Some(mul_idx) = find_unique_consumer(consumers, &norm_out, "Mul", drop) {
+    if let Some(mul_idx) = find_unique_consumer(consumers, &norm_out, "Mul", nodes, drop) {
         let mul_node = &nodes[mul_idx];
         if let Some(scale) = other_input_if_init(mul_node, &norm_out, initializers) {
             scale_init = Some(scale);
             output_name = mul_node.output.first()?.clone();
             nodes_to_drop.push(mul_idx);
 
-            if let Some(add2_idx) = find_unique_consumer(consumers, &output_name, "Add", drop) {
+            if let Some(add2_idx) = find_unique_consumer(consumers, &output_name, "Add", nodes, drop) {
                 let add2_node = &nodes[add2_idx];
                 if let Some(bias) = other_input_if_init(add2_node, &output_name, initializers) {
                     bias_init = Some(bias);
@@ -276,25 +274,26 @@ fn find_unique_consumer(
     consumers: &HashMap<String, Vec<usize>>,
     tensor: &str,
     op_type: &str,
+    nodes: &[NodeProto],
     drop: &HashSet<usize>,
 ) -> Option<usize> {
     let list = consumers.get(tensor)?;
-    let live: Vec<usize> = list.iter().copied().filter(|i| !drop.contains(i)).collect();
-    if live.len() != 1 {
+    let mut matching: Vec<usize> = list
+        .iter()
+        .copied()
+        .filter(|i| !drop.contains(i) && nodes[*i].op_type == op_type)
+        .collect();
+    if matching.len() != 1 {
         return None;
     }
-    let idx = live[0];
-    // Op type check deferred to caller by pattern; verify here.
-    Some(idx).filter(|_| {
-        let _ = op_type;
-        true
-    })
+    matching.pop()
 }
 
 fn find_square_consumer(
     consumers: &HashMap<String, Vec<usize>>,
     tensor: &str,
     nodes: &[NodeProto],
+    initializers: &HashMap<String, TensorProto>,
     drop: &HashSet<usize>,
 ) -> Option<usize> {
     let list = consumers.get(tensor)?;
@@ -302,7 +301,10 @@ fn find_square_consumer(
         let n = &nodes[idx];
         match n.op_type.as_str() {
             "Pow" => {
-                if n.input.len() >= 2 && n.input.first().map(String::as_str) == Some(tensor) {
+                if n.input.len() >= 2
+                    && n.input.first().map(String::as_str) == Some(tensor)
+                    && pow_exponent_is_two(n.input.get(1)?, initializers)
+                {
                     return Some(idx);
                 }
             }
@@ -315,6 +317,20 @@ fn find_square_consumer(
         }
     }
     None
+}
+
+fn pow_exponent_is_two(name: &str, initializers: &HashMap<String, TensorProto>) -> bool {
+    let Some(t) = initializers.get(name) else {
+        return false;
+    };
+    let f = tensor_to_f32(t);
+    if let Some(&v) = f.first() {
+        if (v - 2.0).abs() < f32::EPSILON {
+            return true;
+        }
+    }
+    let i = tensor_to_i64(t);
+    matches!(i.first(), Some(&2))
 }
 
 fn extract_binary_const_scalar(

--- a/crates/dsperse/src/slicer/layernorm_fuse.rs
+++ b/crates/dsperse/src/slicer/layernorm_fuse.rs
@@ -210,6 +210,13 @@ fn try_match_layernorm(
         if a >= rank {
             return None;
         }
+        // Reject dynamic / unresolved dims along the reduction axes: the
+        // fused LayerNormalization circuit needs a concrete lane_size
+        // and consumers of m.x_shape[a] later cast the dim to usize,
+        // which silently wraps negative sentinels into huge values.
+        if x_shape[a] <= 0 {
+            return None;
+        }
     }
 
     Some(MatchedPattern {
@@ -278,15 +285,12 @@ fn find_unique_consumer(
     drop: &HashSet<usize>,
 ) -> Option<usize> {
     let list = consumers.get(tensor)?;
-    let mut matching: Vec<usize> = list
-        .iter()
-        .copied()
-        .filter(|i| !drop.contains(i) && nodes[*i].op_type == op_type)
-        .collect();
-    if matching.len() != 1 {
+    let live: Vec<usize> = list.iter().copied().filter(|i| !drop.contains(i)).collect();
+    if live.len() != 1 {
         return None;
     }
-    matching.pop()
+    let idx = live[0];
+    (nodes[idx].op_type == op_type).then_some(idx)
 }
 
 fn find_square_consumer(
@@ -297,26 +301,32 @@ fn find_square_consumer(
     drop: &HashSet<usize>,
 ) -> Option<usize> {
     let list = consumers.get(tensor)?;
-    for &idx in list.iter().filter(|i| !drop.contains(i)) {
-        let n = &nodes[idx];
-        match n.op_type.as_str() {
-            "Pow" => {
-                if n.input.len() >= 2
-                    && n.input.first().map(String::as_str) == Some(tensor)
-                    && pow_exponent_is_two(n.input.get(1)?, initializers)
-                {
-                    return Some(idx);
-                }
-            }
-            "Mul" => {
-                if n.input.len() == 2 && n.input.iter().all(|i| i == tensor) {
-                    return Some(idx);
-                }
-            }
-            _ => {}
-        }
+    let live: Vec<usize> = list.iter().copied().filter(|i| !drop.contains(i)).collect();
+    if live.len() != 1 {
+        return None;
     }
-    None
+    let idx = live[0];
+    let n = &nodes[idx];
+    match n.op_type.as_str() {
+        "Pow" => {
+            if n.input.len() >= 2
+                && n.input.first().map(String::as_str) == Some(tensor)
+                && pow_exponent_is_two(n.input.get(1)?, initializers)
+            {
+                Some(idx)
+            } else {
+                None
+            }
+        }
+        "Mul" => {
+            if n.input.len() == 2 && n.input.iter().all(|i| i == tensor) {
+                Some(idx)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
 }
 
 fn pow_exponent_is_two(name: &str, initializers: &HashMap<String, TensorProto>) -> bool {

--- a/crates/dsperse/src/slicer/layernorm_fuse.rs
+++ b/crates/dsperse/src/slicer/layernorm_fuse.rs
@@ -201,6 +201,35 @@ fn try_match_layernorm(
         }
     }
 
+    // Soundness check: every intermediate tensor we are about to drop
+    // (mean_out, centered, sq_out, var_out, var_eps, std_out, plus the
+    // pre-affine norm_out when scale/bias are present) must have all
+    // its live consumers inside nodes_to_drop.  Otherwise some
+    // downstream node still reads the intermediate and fusing would
+    // disconnect it.
+    let drop_set: HashSet<usize> = nodes_to_drop.iter().copied().collect();
+    let mut intermediates: Vec<&str> = vec![
+        mean_out.as_str(),
+        centered.as_str(),
+        sq_out.as_str(),
+        var_out.as_str(),
+        var_eps.as_str(),
+        std_out.as_str(),
+    ];
+    if scale_init.is_some() {
+        intermediates.push(norm_out.as_str());
+    }
+    for tname in intermediates {
+        if let Some(list) = consumers.get(tname) {
+            for &idx in list {
+                if drop.contains(&idx) || drop_set.contains(&idx) {
+                    continue;
+                }
+                return None;
+            }
+        }
+    }
+
     let x_shape = resolve_shape(&x_name, traced_shapes, initializers, nodes, producers)?;
     let rank = x_shape.len();
     if rank == 0 {
@@ -298,33 +327,32 @@ fn find_square_consumer(
     initializers: &HashMap<String, TensorProto>,
     drop: &HashSet<usize>,
 ) -> Option<usize> {
+    // The centered tensor in the inline-LN pattern has TWO legitimate
+    // consumers: Pow / Mul (for the variance branch) AND Div (for the
+    // normalization branch).  Both belong to the fusion -- don't reject
+    // them as orphan consumers.  Final orphan-leak check happens after
+    // the whole pattern matches in try_match_layernorm.
     let list = consumers.get(tensor)?;
-    let live: Vec<usize> = list.iter().copied().filter(|i| !drop.contains(i)).collect();
-    if live.len() != 1 {
-        return None;
-    }
-    let idx = live[0];
-    let n = &nodes[idx];
-    match n.op_type.as_str() {
-        "Pow" => {
-            if n.input.len() >= 2
-                && n.input.first().map(String::as_str) == Some(tensor)
-                && pow_exponent_is_two(n.input.get(1)?, initializers)
-            {
-                Some(idx)
-            } else {
-                None
+    for &idx in list.iter().filter(|i| !drop.contains(i)) {
+        let n = &nodes[idx];
+        match n.op_type.as_str() {
+            "Pow" => {
+                if n.input.len() >= 2
+                    && n.input.first().map(String::as_str) == Some(tensor)
+                    && pow_exponent_is_two(n.input.get(1)?, initializers)
+                {
+                    return Some(idx);
+                }
             }
-        }
-        "Mul" => {
-            if n.input.len() == 2 && n.input.iter().all(|i| i == tensor) {
-                Some(idx)
-            } else {
-                None
+            "Mul" => {
+                if n.input.len() == 2 && n.input.iter().all(|i| i == tensor) {
+                    return Some(idx);
+                }
             }
+            _ => {}
         }
-        _ => None,
     }
+    None
 }
 
 fn pow_exponent_is_two(name: &str, initializers: &HashMap<String, TensorProto>) -> bool {

--- a/crates/dsperse/src/slicer/layernorm_fuse.rs
+++ b/crates/dsperse/src/slicer/layernorm_fuse.rs
@@ -1,0 +1,522 @@
+use std::collections::{HashMap, HashSet};
+
+use super::onnx_proto::{
+    AttributeProto, ModelProto, NodeProto, TensorProto, tensor_to_f32, tensor_to_i64,
+};
+
+pub fn fuse_inline_layernorms(
+    model: &mut ModelProto,
+    traced_shapes: &mut HashMap<String, Vec<i64>>,
+) -> usize {
+    let graph = match model.graph.as_mut() {
+        Some(g) => g,
+        None => return 0,
+    };
+
+    let initializers: HashMap<String, TensorProto> = graph
+        .initializer
+        .iter()
+        .map(|t| (t.name.clone(), t.clone()))
+        .collect();
+
+    let producers: HashMap<String, usize> = graph
+        .node
+        .iter()
+        .enumerate()
+        .flat_map(|(i, n)| {
+            n.output
+                .iter()
+                .filter(|o| !o.is_empty())
+                .map(move |o| (o.clone(), i))
+        })
+        .collect();
+
+    let mut consumers: HashMap<String, Vec<usize>> = HashMap::new();
+    for (i, n) in graph.node.iter().enumerate() {
+        for inp in &n.input {
+            if !inp.is_empty() {
+                consumers.entry(inp.clone()).or_default().push(i);
+            }
+        }
+    }
+
+    let mut drop: HashSet<usize> = HashSet::new();
+    let mut insertions: Vec<(usize, Vec<NodeProto>, Vec<TensorProto>)> = Vec::new();
+    let mut fused_id = 0usize;
+
+    for (mean_idx, mean_node) in graph.node.iter().enumerate() {
+        if drop.contains(&mean_idx) || mean_node.op_type != "ReduceMean" {
+            continue;
+        }
+        let Some(m) = try_match_layernorm(
+            mean_idx,
+            mean_node,
+            &graph.node,
+            &producers,
+            &consumers,
+            &initializers,
+            traced_shapes,
+            &drop,
+        ) else {
+            continue;
+        };
+        let (nodes, inits, shapes) = emit_replacement(&m, fused_id, &initializers);
+        for (name, shape) in shapes {
+            traced_shapes.insert(name, shape);
+        }
+        fused_id += 1;
+        drop.extend(m.nodes_to_drop.iter().copied());
+        insertions.push((mean_idx, nodes, inits));
+    }
+
+    let fused = insertions.len();
+    if fused == 0 {
+        return 0;
+    }
+
+    for (_, _, inits) in &insertions {
+        for t in inits {
+            graph.initializer.push(t.clone());
+        }
+    }
+
+    let insertion_map: HashMap<usize, Vec<NodeProto>> = insertions
+        .into_iter()
+        .map(|(idx, nodes, _)| (idx, nodes))
+        .collect();
+
+    let mut new_nodes: Vec<NodeProto> = Vec::with_capacity(graph.node.len());
+    for (i, n) in graph.node.drain(..).enumerate() {
+        if let Some(inserts) = insertion_map.get(&i) {
+            new_nodes.extend(inserts.iter().cloned());
+            continue;
+        }
+        if drop.contains(&i) {
+            continue;
+        }
+        new_nodes.push(n);
+    }
+    graph.node = new_nodes;
+
+    tracing::info!(fused, "fused inline LayerNorm patterns into LayerNormalization");
+    fused
+}
+
+struct MatchedPattern {
+    x_name: String,
+    axes: Vec<usize>,
+    rank: usize,
+    x_shape: Vec<i64>,
+    eps: f32,
+    scale_init: Option<String>,
+    bias_init: Option<String>,
+    output_name: String,
+    nodes_to_drop: Vec<usize>,
+}
+
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+fn try_match_layernorm(
+    mean_idx: usize,
+    mean_node: &NodeProto,
+    nodes: &[NodeProto],
+    producers: &HashMap<String, usize>,
+    consumers: &HashMap<String, Vec<usize>>,
+    initializers: &HashMap<String, TensorProto>,
+    traced_shapes: &HashMap<String, Vec<i64>>,
+    drop: &HashSet<usize>,
+) -> Option<MatchedPattern> {
+    let raw_axes = reduce_axes(mean_node, initializers)?;
+    if get_keepdims(mean_node).unwrap_or(1) != 1 {
+        return None;
+    }
+    let x_name = mean_node.input.first()?.clone();
+    let mean_out = mean_node.output.first()?.clone();
+
+    let sub_idx = find_unique_consumer(consumers, &mean_out, "Sub", drop)?;
+    let sub_node = &nodes[sub_idx];
+    if sub_node.input.len() < 2
+        || sub_node.input.first()? != &x_name
+        || sub_node.input.get(1)? != &mean_out
+    {
+        return None;
+    }
+    let centered = sub_node.output.first()?.clone();
+
+    let sq_idx = find_square_consumer(consumers, &centered, nodes, drop)?;
+    let sq_node = &nodes[sq_idx];
+    let sq_out = sq_node.output.first()?.clone();
+
+    let mean2_idx = find_unique_consumer(consumers, &sq_out, "ReduceMean", drop)?;
+    let mean2_node = &nodes[mean2_idx];
+    let raw_axes2 = reduce_axes(mean2_node, initializers)?;
+    if raw_axes2 != raw_axes {
+        return None;
+    }
+    if get_keepdims(mean2_node).unwrap_or(1) != 1 {
+        return None;
+    }
+    let var_out = mean2_node.output.first()?.clone();
+
+    let add_idx = find_unique_consumer(consumers, &var_out, "Add", drop)?;
+    let add_node = &nodes[add_idx];
+    let eps = extract_binary_const_scalar(add_node, &var_out, initializers)?;
+    let var_eps = add_node.output.first()?.clone();
+
+    let sqrt_idx = find_unique_consumer(consumers, &var_eps, "Sqrt", drop)?;
+    let sqrt_node = &nodes[sqrt_idx];
+    let std_out = sqrt_node.output.first()?.clone();
+
+    let div_idx = find_unique_consumer(consumers, &std_out, "Div", drop)?;
+    let div_node = &nodes[div_idx];
+    if div_node.input.len() < 2
+        || div_node.input.first()? != &centered
+        || div_node.input.get(1)? != &std_out
+    {
+        return None;
+    }
+    let norm_out = div_node.output.first()?.clone();
+
+    let mut nodes_to_drop = vec![mean_idx, sub_idx, sq_idx, mean2_idx, add_idx, sqrt_idx, div_idx];
+    let mut output_name = norm_out.clone();
+    let mut scale_init: Option<String> = None;
+    let mut bias_init: Option<String> = None;
+
+    if let Some(mul_idx) = find_unique_consumer(consumers, &norm_out, "Mul", drop) {
+        let mul_node = &nodes[mul_idx];
+        if let Some(scale) = other_input_if_init(mul_node, &norm_out, initializers) {
+            scale_init = Some(scale);
+            output_name = mul_node.output.first()?.clone();
+            nodes_to_drop.push(mul_idx);
+
+            if let Some(add2_idx) = find_unique_consumer(consumers, &output_name, "Add", drop) {
+                let add2_node = &nodes[add2_idx];
+                if let Some(bias) = other_input_if_init(add2_node, &output_name, initializers) {
+                    bias_init = Some(bias);
+                    output_name = add2_node.output.first()?.clone();
+                    nodes_to_drop.push(add2_idx);
+                }
+            }
+        }
+    }
+
+    let x_shape = resolve_shape(&x_name, traced_shapes, initializers, nodes, producers)?;
+    let rank = x_shape.len();
+    if rank == 0 {
+        return None;
+    }
+    let axes: Vec<usize> = raw_axes
+        .iter()
+        .map(|&a| normalize_axis(a, rank))
+        .collect();
+    for &a in &axes {
+        if a >= rank {
+            return None;
+        }
+    }
+
+    Some(MatchedPattern {
+        x_name,
+        axes,
+        rank,
+        x_shape,
+        eps,
+        scale_init,
+        bias_init,
+        output_name,
+        nodes_to_drop,
+    })
+}
+
+fn resolve_shape(
+    name: &str,
+    traced_shapes: &HashMap<String, Vec<i64>>,
+    initializers: &HashMap<String, TensorProto>,
+    _nodes: &[NodeProto],
+    _producers: &HashMap<String, usize>,
+) -> Option<Vec<i64>> {
+    if let Some(s) = traced_shapes.get(name) {
+        if !s.is_empty() {
+            return Some(s.clone());
+        }
+    }
+    if let Some(t) = initializers.get(name) {
+        return Some(t.dims.clone());
+    }
+    None
+}
+
+fn reduce_axes(
+    node: &NodeProto,
+    initializers: &HashMap<String, TensorProto>,
+) -> Option<Vec<i64>> {
+    if let Some(attr) = node.attribute.iter().find(|a| a.name == "axes")
+        && !attr.ints.is_empty()
+    {
+        return Some(attr.ints.clone());
+    }
+    if let Some(name) = node.input.get(1)
+        && let Some(t) = initializers.get(name)
+    {
+        let v = tensor_to_i64(t);
+        if !v.is_empty() {
+            return Some(v);
+        }
+    }
+    None
+}
+
+fn get_keepdims(node: &NodeProto) -> Option<i64> {
+    node.attribute
+        .iter()
+        .find(|a| a.name == "keepdims")
+        .map(|a| a.i)
+}
+
+fn find_unique_consumer(
+    consumers: &HashMap<String, Vec<usize>>,
+    tensor: &str,
+    op_type: &str,
+    drop: &HashSet<usize>,
+) -> Option<usize> {
+    let list = consumers.get(tensor)?;
+    let live: Vec<usize> = list.iter().copied().filter(|i| !drop.contains(i)).collect();
+    if live.len() != 1 {
+        return None;
+    }
+    let idx = live[0];
+    // Op type check deferred to caller by pattern; verify here.
+    Some(idx).filter(|_| {
+        let _ = op_type;
+        true
+    })
+}
+
+fn find_square_consumer(
+    consumers: &HashMap<String, Vec<usize>>,
+    tensor: &str,
+    nodes: &[NodeProto],
+    drop: &HashSet<usize>,
+) -> Option<usize> {
+    let list = consumers.get(tensor)?;
+    for &idx in list.iter().filter(|i| !drop.contains(i)) {
+        let n = &nodes[idx];
+        match n.op_type.as_str() {
+            "Pow" => {
+                if n.input.len() >= 2 && n.input.first().map(String::as_str) == Some(tensor) {
+                    return Some(idx);
+                }
+            }
+            "Mul" => {
+                if n.input.len() == 2 && n.input.iter().all(|i| i == tensor) {
+                    return Some(idx);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn extract_binary_const_scalar(
+    node: &NodeProto,
+    non_const_input: &str,
+    initializers: &HashMap<String, TensorProto>,
+) -> Option<f32> {
+    if node.input.len() != 2 {
+        return None;
+    }
+    let (a, b) = (node.input.first()?, node.input.get(1)?);
+    let other_name = if a.as_str() == non_const_input {
+        b
+    } else if b.as_str() == non_const_input {
+        a
+    } else {
+        return None;
+    };
+    let t = initializers.get(other_name)?;
+    tensor_to_f32(t).first().copied()
+}
+
+fn other_input_if_init(
+    node: &NodeProto,
+    non_const_input: &str,
+    initializers: &HashMap<String, TensorProto>,
+) -> Option<String> {
+    if node.input.len() != 2 {
+        return None;
+    }
+    let a = node.input.first()?.clone();
+    let b = node.input.get(1)?.clone();
+    let other = if a == non_const_input {
+        b
+    } else if b == non_const_input {
+        a
+    } else {
+        return None;
+    };
+    initializers.get(&other).map(|_| other)
+}
+
+fn emit_replacement(
+    m: &MatchedPattern,
+    fused_id: usize,
+    initializers: &HashMap<String, TensorProto>,
+) -> (Vec<NodeProto>, Vec<TensorProto>, Vec<(String, Vec<i64>)>) {
+    let rank = m.rank;
+    let axes_set: HashSet<usize> = m.axes.iter().copied().collect();
+    let mut forward_perm: Vec<i64> = (0..rank)
+        .filter(|d| !axes_set.contains(d))
+        .map(|d| d as i64)
+        .collect();
+    for &a in &m.axes {
+        forward_perm.push(a as i64);
+    }
+    let mut inverse_perm: Vec<i64> = vec![0; rank];
+    for (new_pos, &old_pos) in forward_perm.iter().enumerate() {
+        inverse_perm[old_pos as usize] = new_pos as i64;
+    }
+
+    let lane_size: usize = m
+        .axes
+        .iter()
+        .map(|&a| m.x_shape[a] as usize)
+        .product();
+
+    let prefix = format!("/__dsperse/fused_ln_{fused_id}");
+    let xt_name = format!("{prefix}/xt");
+    let yt_name = format!("{prefix}/yt");
+
+    let (scale_name, scale_init_opt) = materialize_1d_initializer(
+        &format!("{prefix}/scale"),
+        m.scale_init.as_deref(),
+        initializers,
+        lane_size,
+        1.0,
+    );
+    let (bias_name, bias_init_opt) = materialize_1d_initializer(
+        &format!("{prefix}/bias"),
+        m.bias_init.as_deref(),
+        initializers,
+        lane_size,
+        0.0,
+    );
+
+    let mut nodes = Vec::new();
+
+    nodes.push(NodeProto {
+        name: format!("{prefix}/Transpose_in"),
+        op_type: "Transpose".to_string(),
+        input: vec![m.x_name.clone()],
+        output: vec![xt_name.clone()],
+        attribute: vec![int_list_attr("perm", &forward_perm)],
+        ..Default::default()
+    });
+
+    let ln_axis = (rank - m.axes.len()) as i64;
+    nodes.push(NodeProto {
+        name: format!("{prefix}/LayerNormalization"),
+        op_type: "LayerNormalization".to_string(),
+        input: vec![xt_name, scale_name, bias_name],
+        output: vec![yt_name.clone()],
+        attribute: vec![int_attr("axis", ln_axis), float_attr("epsilon", m.eps)],
+        ..Default::default()
+    });
+
+    nodes.push(NodeProto {
+        name: format!("{prefix}/Transpose_out"),
+        op_type: "Transpose".to_string(),
+        input: vec![yt_name],
+        output: vec![m.output_name.clone()],
+        attribute: vec![int_list_attr("perm", &inverse_perm)],
+        ..Default::default()
+    });
+
+    let mut inits = Vec::new();
+    inits.extend(scale_init_opt);
+    inits.extend(bias_init_opt);
+
+    let xt_shape: Vec<i64> = forward_perm.iter().map(|&p| m.x_shape[p as usize]).collect();
+    let yt_shape = xt_shape.clone();
+    let shapes = vec![
+        (format!("{prefix}/xt"), xt_shape),
+        (format!("{prefix}/yt"), yt_shape),
+    ];
+
+    (nodes, inits, shapes)
+}
+
+fn materialize_1d_initializer(
+    new_name: &str,
+    source: Option<&str>,
+    initializers: &HashMap<String, TensorProto>,
+    lane_size: usize,
+    default_fill: f32,
+) -> (String, Option<TensorProto>) {
+    let Some(src) = source else {
+        return (new_name.to_string(), Some(const_vector(new_name, lane_size, default_fill)));
+    };
+    let Some(t) = initializers.get(src) else {
+        return (new_name.to_string(), Some(const_vector(new_name, lane_size, default_fill)));
+    };
+    let elems = tensor_to_f32(t);
+    if elems.len() == lane_size && t.dims.len() == 1 {
+        return (src.to_string(), None);
+    }
+    let vals: Vec<f32> = if elems.len() == lane_size {
+        elems
+    } else if elems.len() == 1 {
+        vec![elems[0]; lane_size]
+    } else {
+        return (new_name.to_string(), Some(const_vector(new_name, lane_size, default_fill)));
+    };
+    (new_name.to_string(), Some(make_f32_vector(new_name, &vals)))
+}
+
+fn const_vector(name: &str, len: usize, fill: f32) -> TensorProto {
+    make_f32_vector(name, &vec![fill; len])
+}
+
+fn make_f32_vector(name: &str, vals: &[f32]) -> TensorProto {
+    TensorProto {
+        name: name.to_string(),
+        data_type: TensorProto::FLOAT,
+        dims: vec![vals.len() as i64],
+        float_data: vals.to_vec(),
+        ..Default::default()
+    }
+}
+
+fn normalize_axis(axis: i64, rank: usize) -> usize {
+    if axis < 0 {
+        (rank as i64 + axis) as usize
+    } else {
+        axis as usize
+    }
+}
+
+fn int_attr(name: &str, v: i64) -> AttributeProto {
+    AttributeProto {
+        name: name.to_string(),
+        r#type: 2,
+        i: v,
+        ..Default::default()
+    }
+}
+
+fn float_attr(name: &str, v: f32) -> AttributeProto {
+    AttributeProto {
+        name: name.to_string(),
+        r#type: 1,
+        f: v,
+        ..Default::default()
+    }
+}
+
+fn int_list_attr(name: &str, vals: &[i64]) -> AttributeProto {
+    AttributeProto {
+        name: name.to_string(),
+        r#type: 7,
+        ints: vals.to_vec(),
+        ..Default::default()
+    }
+}

--- a/crates/dsperse/src/slicer/layernorm_fuse.rs
+++ b/crates/dsperse/src/slicer/layernorm_fuse.rs
@@ -174,7 +174,9 @@ fn try_match_layernorm(
     }
     let norm_out = div_node.output.first()?.clone();
 
-    let mut nodes_to_drop = vec![mean_idx, sub_idx, sq_idx, mean2_idx, add_idx, sqrt_idx, div_idx];
+    let mut nodes_to_drop = vec![
+        mean_idx, sub_idx, sq_idx, mean2_idx, add_idx, sqrt_idx, div_idx,
+    ];
     let mut output_name = norm_out.clone();
     let mut scale_init: Option<String> = None;
     let mut bias_init: Option<String> = None;
@@ -186,7 +188,9 @@ fn try_match_layernorm(
             output_name = mul_node.output.first()?.clone();
             nodes_to_drop.push(mul_idx);
 
-            if let Some(add2_idx) = find_unique_consumer(consumers, &output_name, "Add", nodes, drop) {
+            if let Some(add2_idx) =
+                find_unique_consumer(consumers, &output_name, "Add", nodes, drop)
+            {
                 let add2_node = &nodes[add2_idx];
                 if let Some(bias) = other_input_if_init(add2_node, &output_name, initializers) {
                     bias_init = Some(bias);
@@ -202,10 +206,7 @@ fn try_match_layernorm(
     if rank == 0 {
         return None;
     }
-    let axes: Vec<usize> = raw_axes
-        .iter()
-        .map(|&a| normalize_axis(a, rank))
-        .collect();
+    let axes: Vec<usize> = raw_axes.iter().map(|&a| normalize_axis(a, rank)).collect();
     for &a in &axes {
         if a >= rank {
             return None;
@@ -239,10 +240,10 @@ fn resolve_shape(
     _nodes: &[NodeProto],
     _producers: &HashMap<String, usize>,
 ) -> Option<Vec<i64>> {
-    if let Some(s) = traced_shapes.get(name) {
-        if !s.is_empty() {
-            return Some(s.clone());
-        }
+    if let Some(s) = traced_shapes.get(name)
+        && !s.is_empty()
+    {
+        return Some(s.clone());
     }
     if let Some(t) = initializers.get(name) {
         return Some(t.dims.clone());
@@ -250,10 +251,7 @@ fn resolve_shape(
     None
 }
 
-fn reduce_axes(
-    node: &NodeProto,
-    initializers: &HashMap<String, TensorProto>,
-) -> Option<Vec<i64>> {
+fn reduce_axes(node: &NodeProto, initializers: &HashMap<String, TensorProto>) -> Option<Vec<i64>> {
     if let Some(attr) = node.attribute.iter().find(|a| a.name == "axes")
         && !attr.ints.is_empty()
     {
@@ -334,10 +332,10 @@ fn pow_exponent_is_two(name: &str, initializers: &HashMap<String, TensorProto>) 
         return false;
     };
     let f = tensor_to_f32(t);
-    if let Some(&v) = f.first() {
-        if (v - 2.0).abs() < f32::EPSILON {
-            return true;
-        }
+    if let Some(&v) = f.first()
+        && (v - 2.0).abs() < f32::EPSILON
+    {
+        return true;
     }
     let i = tensor_to_i64(t);
     matches!(i.first(), Some(&2))
@@ -383,11 +381,14 @@ fn other_input_if_init(
     initializers.get(&other).map(|_| other)
 }
 
+type ReplacementShapes = Vec<(String, Vec<i64>)>;
+type Replacement = (Vec<NodeProto>, Vec<TensorProto>, ReplacementShapes);
+
 fn emit_replacement(
     m: &MatchedPattern,
     fused_id: usize,
     initializers: &HashMap<String, TensorProto>,
-) -> (Vec<NodeProto>, Vec<TensorProto>, Vec<(String, Vec<i64>)>) {
+) -> Replacement {
     let rank = m.rank;
     let axes_set: HashSet<usize> = m.axes.iter().copied().collect();
     let mut forward_perm: Vec<i64> = (0..rank)
@@ -402,11 +403,7 @@ fn emit_replacement(
         inverse_perm[old_pos as usize] = new_pos as i64;
     }
 
-    let lane_size: usize = m
-        .axes
-        .iter()
-        .map(|&a| m.x_shape[a] as usize)
-        .product();
+    let lane_size: usize = m.axes.iter().map(|&a| m.x_shape[a] as usize).product();
 
     let prefix = format!("/__dsperse/fused_ln_{fused_id}");
     let xt_name = format!("{prefix}/xt");
@@ -461,7 +458,10 @@ fn emit_replacement(
     inits.extend(scale_init_opt);
     inits.extend(bias_init_opt);
 
-    let xt_shape: Vec<i64> = forward_perm.iter().map(|&p| m.x_shape[p as usize]).collect();
+    let xt_shape: Vec<i64> = forward_perm
+        .iter()
+        .map(|&p| m.x_shape[p as usize])
+        .collect();
     let yt_shape = xt_shape.clone();
     let shapes = vec![
         (format!("{prefix}/xt"), xt_shape),
@@ -479,10 +479,16 @@ fn materialize_1d_initializer(
     default_fill: f32,
 ) -> (String, Option<TensorProto>) {
     let Some(src) = source else {
-        return (new_name.to_string(), Some(const_vector(new_name, lane_size, default_fill)));
+        return (
+            new_name.to_string(),
+            Some(const_vector(new_name, lane_size, default_fill)),
+        );
     };
     let Some(t) = initializers.get(src) else {
-        return (new_name.to_string(), Some(const_vector(new_name, lane_size, default_fill)));
+        return (
+            new_name.to_string(),
+            Some(const_vector(new_name, lane_size, default_fill)),
+        );
     };
     let elems = tensor_to_f32(t);
     if elems.len() == lane_size && t.dims.len() == 1 {
@@ -493,7 +499,10 @@ fn materialize_1d_initializer(
     } else if elems.len() == 1 {
         vec![elems[0]; lane_size]
     } else {
-        return (new_name.to_string(), Some(const_vector(new_name, lane_size, default_fill)));
+        return (
+            new_name.to_string(),
+            Some(const_vector(new_name, lane_size, default_fill)),
+        );
     };
     (new_name.to_string(), Some(make_f32_vector(new_name, &vals)))
 }

--- a/crates/dsperse/src/slicer/materializer.rs
+++ b/crates/dsperse/src/slicer/materializer.rs
@@ -79,6 +79,7 @@ pub fn materialize_slice_model(
     model: &ModelProto,
     slice_points: &[usize],
     traced_shapes: &HashMap<String, Vec<i64>>,
+    traced_types: &HashMap<String, i32>,
     slice_idx: usize,
 ) -> Result<ModelProto> {
     let graph = model
@@ -160,6 +161,7 @@ pub fn materialize_slice_model(
         init_map: &init_map,
         vi_map: &vi_map,
         traced_shapes,
+        traced_types,
         init_types: &init_types,
         node_output_types: &node_output_types,
         constant_producers: &constant_producers,
@@ -187,10 +189,12 @@ pub fn materialize_slice_to_disk(
     model: &ModelProto,
     slice_points: &[usize],
     traced_shapes: &HashMap<String, Vec<i64>>,
+    traced_types: &HashMap<String, i32>,
     slice_idx: usize,
     output_path: &Path,
 ) -> Result<PathBuf> {
-    let slice_model = materialize_slice_model(model, slice_points, traced_shapes, slice_idx)?;
+    let slice_model =
+        materialize_slice_model(model, slice_points, traced_shapes, traced_types, slice_idx)?;
     if let Some(parent) = output_path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| DsperseError::io(e, parent))?;
     }
@@ -232,6 +236,8 @@ pub fn ensure_slice_materialized(
     let traced_shapes = metadata.traced_shapes.as_ref().ok_or_else(|| {
         DsperseError::Slicer("metadata missing traced_shapes for materialization".into())
     })?;
+    let empty_types: HashMap<String, i32> = HashMap::new();
+    let traced_types = metadata.traced_types.as_ref().unwrap_or(&empty_types);
     let original_path = metadata.original_model_path.as_ref().ok_or_else(|| {
         DsperseError::Slicer("metadata missing original_model_path for materialization".into())
     })?;
@@ -251,6 +257,7 @@ pub fn ensure_slice_materialized(
         &model_with_shapes,
         &metadata.slice_points,
         traced_shapes,
+        traced_types,
         slice_idx,
         &onnx_path,
     )?;
@@ -519,6 +526,7 @@ struct ShapeContext<'a> {
     init_map: &'a HashMap<&'a str, &'a TensorProto>,
     vi_map: &'a HashMap<String, &'a ValueInfoProto>,
     traced_shapes: &'a HashMap<String, Vec<i64>>,
+    traced_types: &'a HashMap<String, i32>,
     init_types: &'a HashMap<&'a str, i32>,
     node_output_types: &'a HashMap<String, i32>,
     constant_producers: &'a HashMap<String, &'a TensorProto>,
@@ -526,9 +534,18 @@ struct ShapeContext<'a> {
 
 impl ShapeContext<'_> {
     fn resolve_elem_type(&self, name: &str) -> i32 {
+        // Resolution order: parent value_info dtype is implicitly used
+        // upstream via vi_map; fall back to initializer dtype, then to
+        // dtype-aware tract trace, then to the small set of ops whose
+        // output dtype is fixed by the spec, and finally to FLOAT.
+        // Skipping the traced_types lookup is the bug that turned
+        // INT64 indices (TopK, Tile-of-int, Slice-of-int) into FLOAT
+        // value_info entries; the witness path then quantised them by
+        // alpha and produced indices like 138_149_888 = 1054 * 2^17.
         self.init_types
             .get(name)
             .copied()
+            .or_else(|| self.traced_types.get(name).copied())
             .or_else(|| self.node_output_types.get(name).copied())
             .unwrap_or(TensorProto::FLOAT)
     }
@@ -619,7 +636,79 @@ fn get_segment_details(
 }
 
 pub fn build_node_output_types(graph: &GraphProto) -> HashMap<String, i32> {
+    // Propagate ONNX output dtypes in topological order so that
+    // every node's output dtype is derivable from already-resolved
+    // input dtypes.  This is the source of truth for the slicer
+    // when tract's runtime trace falls back to f32 because it can't
+    // statically evaluate a node (e.g. TopK with a runtime K, or
+    // any node downstream of one that taints during tract's
+    // best-effort eval).  Without this, INT64 indices flowing
+    // through Tile / Slice / Reshape / GatherElements get tagged
+    // as FLOAT in slice value_info and the witness path quantises
+    // them by alpha, producing nonsense indices like
+    // 1054 * 2^17 = 138_149_888.
     let mut types: HashMap<String, i32> = HashMap::new();
+    for init in &graph.initializer {
+        if init.data_type != 0 {
+            types.insert(init.name.clone(), init.data_type);
+        }
+    }
+    for vi in graph
+        .input
+        .iter()
+        .chain(graph.value_info.iter())
+        .chain(graph.output.iter())
+    {
+        if let Some(dt) = onnx_proto::elem_type_from_value_info(vi)
+            && dt != 0
+            && !types.contains_key(&vi.name)
+        {
+            types.insert(vi.name.clone(), dt);
+        }
+    }
+    let pass_through_first_input: &[&str] = &[
+        "Tile",
+        "Slice",
+        "Reshape",
+        "Transpose",
+        "Squeeze",
+        "Unsqueeze",
+        "Identity",
+        "Flatten",
+        "Expand",
+        "Concat",
+        "Gather",
+        "GatherElements",
+        "GatherND",
+        "Pad",
+        "Compress",
+        "ScatterND",
+        "ScatterElements",
+        "Scatter",
+        "Split",
+        "DepthToSpace",
+        "SpaceToDepth",
+        "ReverseSequence",
+        "OneHot",
+        "Resize",
+        "Upsample",
+        "Crop",
+    ];
+    let always_int64: &[&str] = &["Shape", "NonZero", "ArgMax", "ArgMin"];
+    let always_bool: &[&str] = &[
+        "Equal",
+        "Less",
+        "LessOrEqual",
+        "Greater",
+        "GreaterOrEqual",
+        "And",
+        "Or",
+        "Not",
+        "Xor",
+        "IsNaN",
+        "IsInf",
+    ];
+
     for node in &graph.node {
         match node.op_type.as_str() {
             "Cast" => {
@@ -631,17 +720,94 @@ pub fn build_node_output_types(graph: &GraphProto) -> HashMap<String, i32> {
                     }
                 }
             }
+            "Constant" => {
+                if let Some(t) = node
+                    .attribute
+                    .iter()
+                    .find(|a| a.name == "value")
+                    .and_then(|a| a.t.as_ref())
+                    && let Some(out) = node.output.first()
+                    && !out.is_empty()
+                {
+                    types.insert(out.clone(), t.data_type);
+                }
+            }
+            "ConstantOfShape" => {
+                let dt = node
+                    .attribute
+                    .iter()
+                    .find(|a| a.name == "value")
+                    .and_then(|a| a.t.as_ref())
+                    .map(|t| t.data_type)
+                    .unwrap_or(TensorProto::FLOAT);
+                for out in &node.output {
+                    if !out.is_empty() {
+                        types.insert(out.clone(), dt);
+                    }
+                }
+            }
             "MaxPool" => {
                 if let Some(idx_out) = node.output.get(1)
                     && !idx_out.is_empty()
                 {
                     types.insert(idx_out.clone(), TensorProto::INT64);
                 }
+                if let Some(val_out) = node.output.first()
+                    && !val_out.is_empty()
+                    && let Some(in_name) = node.input.first()
+                    && let Some(&dt) = types.get(in_name.as_str())
+                {
+                    types.insert(val_out.clone(), dt);
+                }
             }
-            "Shape" | "NonZero" | "ArgMax" | "ArgMin" => {
+            "TopK" => {
+                if let Some(val_out) = node.output.first()
+                    && !val_out.is_empty()
+                    && let Some(in_name) = node.input.first()
+                    && let Some(&dt) = types.get(in_name.as_str())
+                {
+                    types.insert(val_out.clone(), dt);
+                }
+                if let Some(idx_out) = node.output.get(1)
+                    && !idx_out.is_empty()
+                {
+                    types.insert(idx_out.clone(), TensorProto::INT64);
+                }
+            }
+            "Where" => {
+                if let Some(out) = node.output.first()
+                    && !out.is_empty()
+                {
+                    if let Some(&dt) = node.input.get(1).and_then(|n| types.get(n.as_str())) {
+                        types.insert(out.clone(), dt);
+                    } else if let Some(&dt) = node.input.get(2).and_then(|n| types.get(n.as_str()))
+                    {
+                        types.insert(out.clone(), dt);
+                    }
+                }
+            }
+            op if always_int64.contains(&op) => {
                 for out in &node.output {
                     if !out.is_empty() {
                         types.insert(out.clone(), TensorProto::INT64);
+                    }
+                }
+            }
+            op if always_bool.contains(&op) => {
+                for out in &node.output {
+                    if !out.is_empty() {
+                        types.insert(out.clone(), TensorProto::BOOL);
+                    }
+                }
+            }
+            op if pass_through_first_input.contains(&op) => {
+                if let Some(in_name) = node.input.first().filter(|s| !s.is_empty())
+                    && let Some(&dt) = types.get(in_name.as_str())
+                {
+                    for out in &node.output {
+                        if !out.is_empty() {
+                            types.insert(out.clone(), dt);
+                        }
                     }
                 }
             }

--- a/crates/dsperse/src/slicer/materializer.rs
+++ b/crates/dsperse/src/slicer/materializer.rs
@@ -693,8 +693,22 @@ pub fn build_node_output_types(graph: &GraphProto) -> HashMap<String, i32> {
         "Resize",
         "Upsample",
         "Crop",
+        // Unique preserves input dtype on its first output (output[0]
+        // values; output[1..3] indices/inverse/counts default to
+        // INT64 but are not standard pass-through targets and the
+        // slicer rarely sees them as graph-internal value_info
+        // entries -- defer per-output handling until we encounter a
+        // real model that needs it).
+        "Unique",
     ];
-    let always_int64: &[&str] = &["Shape", "NonZero", "ArgMax", "ArgMin"];
+    let always_int64: &[&str] = &[
+        "Shape",
+        "NonZero",
+        "ArgMax",
+        "ArgMin",
+        // NonMaxSuppression's selected_indices output is INT64.
+        "NonMaxSuppression",
+    ];
     let always_bool: &[&str] = &[
         "Equal",
         "Less",

--- a/crates/dsperse/src/slicer/mod.rs
+++ b/crates/dsperse/src/slicer/mod.rs
@@ -3,6 +3,7 @@ pub mod autotiler;
 pub mod combiner;
 pub mod materializer;
 pub(crate) mod layernorm_fuse;
+pub(crate) mod self_div_rewrite;
 pub(crate) mod onnx_fold;
 pub mod onnx_proto;
 pub(crate) mod onnx_shapes;

--- a/crates/dsperse/src/slicer/mod.rs
+++ b/crates/dsperse/src/slicer/mod.rs
@@ -1,13 +1,13 @@
 pub mod analyzer;
 pub mod autotiler;
 pub mod combiner;
-pub mod materializer;
 pub(crate) mod layernorm_fuse;
-pub(crate) mod self_div_rewrite;
+pub mod materializer;
 pub(crate) mod onnx_fold;
 pub mod onnx_proto;
 pub(crate) mod onnx_shapes;
 pub mod onnx_slicer;
+pub(crate) mod self_div_rewrite;
 pub(crate) mod trace;
 
 pub use onnx_slicer::slice_model;

--- a/crates/dsperse/src/slicer/mod.rs
+++ b/crates/dsperse/src/slicer/mod.rs
@@ -2,6 +2,7 @@ pub mod analyzer;
 pub mod autotiler;
 pub mod combiner;
 pub mod materializer;
+pub(crate) mod layernorm_fuse;
 pub(crate) mod onnx_fold;
 pub mod onnx_proto;
 pub(crate) mod onnx_shapes;

--- a/crates/dsperse/src/slicer/onnx_fold.rs
+++ b/crates/dsperse/src/slicer/onnx_fold.rs
@@ -253,8 +253,917 @@ fn eval_const_node(
         "Gather" if inputs.len() >= 2 => eval_gather(node, inputs, &out_name),
         "Slice" if inputs.len() >= 3 => eval_slice(inputs, &out_name),
         "Concat" => eval_concat(node, inputs, &out_name),
+        "ConstantOfShape" => eval_constant_of_shape(node, inputs[0], &out_name),
+        "Where" if inputs.len() == 3 => eval_where(inputs, &out_name),
+        "Range" if inputs.len() == 3 => eval_range(inputs, &out_name),
+        "Equal" => eval_cmp(inputs, &out_name, |a, b| a == b),
+        "Less" => eval_cmp(inputs, &out_name, |a, b| a < b),
+        "Greater" => eval_cmp(inputs, &out_name, |a, b| a > b),
+        "Not" => eval_not(inputs[0], &out_name),
+        "And" => eval_logical(inputs, &out_name, |a, b| a & b),
+        "Or" => eval_logical(inputs, &out_name, |a, b| a | b),
+        "Transpose" => eval_transpose(node, inputs[0], &out_name),
+        "Pow" => eval_binary_f32(inputs, &out_name, f32::powf),
+        "ReduceMean" => eval_reduce(node, inputs, &out_name, ReduceOp::Mean),
+        "ReduceSum" => eval_reduce(node, inputs, &out_name, ReduceOp::Sum),
+        "ReduceMax" => eval_reduce(node, inputs, &out_name, ReduceOp::Max),
+        "ReduceMin" => eval_reduce(node, inputs, &out_name, ReduceOp::Min),
+        "Resize" => eval_resize(node, inputs, &out_name),
+        "Expand" if inputs.len() == 2 => eval_expand(inputs, &out_name),
+        "Tile" if inputs.len() == 2 => eval_tile(inputs, &out_name),
         _ => None,
     }
+}
+
+fn eval_expand(
+    inputs: &[&TensorProto],
+    out_name: &str,
+) -> Option<Vec<(String, TensorProto)>> {
+    let data = inputs[0];
+    let shape = tensor_to_i64(inputs[1]);
+    if shape.is_empty() {
+        return None;
+    }
+    let out_dims = broadcast_shape(&data.dims, &shape)?;
+    let total = broadcast_total(&out_dims)?;
+    if data.data_type == TensorProto::INT64 {
+        let v = tensor_to_i64(data);
+        if v.is_empty() {
+            return None;
+        }
+        let mut result = Vec::with_capacity(total);
+        for i in 0..total {
+            let di = broadcast_index(i, &out_dims, &data.dims);
+            result.push(v[di]);
+        }
+        let t = TensorProto {
+            name: out_name.to_string(),
+            data_type: TensorProto::INT64,
+            dims: out_dims,
+            int64_data: result,
+            ..Default::default()
+        };
+        return Some(vec![(out_name.to_string(), t)]);
+    }
+    let v = tensor_to_f32(data);
+    if v.is_empty() {
+        return None;
+    }
+    let mut result = Vec::with_capacity(total);
+    for i in 0..total {
+        let di = broadcast_index(i, &out_dims, &data.dims);
+        result.push(v[di]);
+    }
+    let t = make_f32_tensor(out_name, &out_dims, &result, data.data_type);
+    Some(vec![(out_name.to_string(), t)])
+}
+
+fn eval_tile(
+    inputs: &[&TensorProto],
+    out_name: &str,
+) -> Option<Vec<(String, TensorProto)>> {
+    let data = inputs[0];
+    let repeats = tensor_to_i64(inputs[1]);
+    if repeats.is_empty() || repeats.len() != data.dims.len() {
+        return None;
+    }
+    let rank = data.dims.len();
+    let out_dims: Vec<i64> = data
+        .dims
+        .iter()
+        .zip(&repeats)
+        .map(|(&d, &r)| d * r)
+        .collect();
+    let total = broadcast_total(&out_dims)?;
+
+    let in_strides: Vec<usize> = {
+        let mut s = vec![1usize; rank];
+        for i in (0..rank.saturating_sub(1)).rev() {
+            s[i] = s[i + 1] * data.dims[i + 1] as usize;
+        }
+        s
+    };
+    let out_strides: Vec<usize> = {
+        let mut s = vec![1usize; rank];
+        for i in (0..rank.saturating_sub(1)).rev() {
+            s[i] = s[i + 1] * out_dims[i + 1] as usize;
+        }
+        s
+    };
+
+    if data.data_type == TensorProto::INT64 {
+        let v = tensor_to_i64(data);
+        if v.is_empty() {
+            return None;
+        }
+        let mut result = vec![0i64; total];
+        for o in 0..total {
+            let mut src = 0usize;
+            let mut rem = o;
+            for i in 0..rank {
+                let coord = rem / out_strides[i];
+                rem %= out_strides[i];
+                src += (coord % data.dims[i] as usize) * in_strides[i];
+            }
+            result[o] = v[src];
+        }
+        let t = TensorProto {
+            name: out_name.to_string(),
+            data_type: TensorProto::INT64,
+            dims: out_dims,
+            int64_data: result,
+            ..Default::default()
+        };
+        return Some(vec![(out_name.to_string(), t)]);
+    }
+    let v = tensor_to_f32(data);
+    if v.is_empty() {
+        return None;
+    }
+    let mut result = vec![0f32; total];
+    for o in 0..total {
+        let mut src = 0usize;
+        let mut rem = o;
+        for i in 0..rank {
+            let coord = rem / out_strides[i];
+            rem %= out_strides[i];
+            src += (coord % data.dims[i] as usize) * in_strides[i];
+        }
+        result[o] = v[src];
+    }
+    let t = make_f32_tensor(out_name, &out_dims, &result, data.data_type);
+    Some(vec![(out_name.to_string(), t)])
+}
+
+fn eval_constant_of_shape(
+    node: &NodeProto,
+    shape_t: &TensorProto,
+    out_name: &str,
+) -> Option<Vec<(String, TensorProto)>> {
+    let dims = tensor_to_i64(shape_t);
+    if dims.is_empty() {
+        return None;
+    }
+    let total = broadcast_total(&dims)?;
+    let (dtype, f_val, i_val) = match node.attribute.iter().find(|a| a.name == "value") {
+        Some(a) => match a.t.as_ref() {
+            Some(t) => {
+                let fv = tensor_to_f32(t).first().copied().unwrap_or(0.0);
+                let iv = tensor_to_i64(t).first().copied().unwrap_or(fv as i64);
+                (t.data_type, fv, iv)
+            }
+            None => (TensorProto::FLOAT, 0.0, 0),
+        },
+        None => (TensorProto::FLOAT, 0.0, 0),
+    };
+    let t = match dtype {
+        TensorProto::INT64 => TensorProto {
+            name: out_name.to_string(),
+            data_type: TensorProto::INT64,
+            dims: dims.clone(),
+            int64_data: vec![i_val; total],
+            ..Default::default()
+        },
+        TensorProto::INT32 => TensorProto {
+            name: out_name.to_string(),
+            data_type: TensorProto::INT32,
+            dims: dims.clone(),
+            int32_data: vec![i_val as i32; total],
+            ..Default::default()
+        },
+        TensorProto::BOOL => TensorProto {
+            name: out_name.to_string(),
+            data_type: TensorProto::BOOL,
+            dims: dims.clone(),
+            int32_data: vec![(i_val != 0) as i32; total],
+            ..Default::default()
+        },
+        _ => make_f32_tensor(out_name, &dims, &vec![f_val; total], dtype),
+    };
+    Some(vec![(out_name.to_string(), t)])
+}
+
+fn eval_where(
+    inputs: &[&TensorProto],
+    out_name: &str,
+) -> Option<Vec<(String, TensorProto)>> {
+    let cond = tensor_to_i64(inputs[0]);
+    let data_type = if inputs[1].data_type == TensorProto::INT64
+        && inputs[2].data_type == TensorProto::INT64
+    {
+        TensorProto::INT64
+    } else {
+        TensorProto::FLOAT
+    };
+    if data_type == TensorProto::INT64 {
+        let x = tensor_to_i64(inputs[1]);
+        let y = tensor_to_i64(inputs[2]);
+        if x.is_empty() || y.is_empty() || cond.is_empty() {
+            return None;
+        }
+        let (xy_vals, xy_dims) =
+            broadcast_binary_i64(&x, &inputs[1].dims, &y, &inputs[2].dims, |a, b| {
+                a * 0 + b * 0
+            })?;
+        let out_dims = broadcast_shape(&xy_dims, &inputs[0].dims)?;
+        let total = broadcast_total(&out_dims)?;
+        let mut result = Vec::with_capacity(total);
+        let _ = xy_vals;
+        for i in 0..total {
+            let ci = broadcast_index(i, &out_dims, &inputs[0].dims);
+            let xi = broadcast_index(i, &out_dims, &inputs[1].dims);
+            let yi = broadcast_index(i, &out_dims, &inputs[2].dims);
+            result.push(if cond[ci] != 0 { x[xi] } else { y[yi] });
+        }
+        let t = TensorProto {
+            name: out_name.to_string(),
+            data_type: TensorProto::INT64,
+            dims: out_dims,
+            int64_data: result,
+            ..Default::default()
+        };
+        return Some(vec![(out_name.to_string(), t)]);
+    }
+    let x = tensor_to_f32(inputs[1]);
+    let y = tensor_to_f32(inputs[2]);
+    if x.is_empty() || y.is_empty() || cond.is_empty() {
+        return None;
+    }
+    let xy_dims = broadcast_shape(&inputs[1].dims, &inputs[2].dims)?;
+    let out_dims = broadcast_shape(&xy_dims, &inputs[0].dims)?;
+    let total = broadcast_total(&out_dims)?;
+    let mut result = Vec::with_capacity(total);
+    for i in 0..total {
+        let ci = broadcast_index(i, &out_dims, &inputs[0].dims);
+        let xi = broadcast_index(i, &out_dims, &inputs[1].dims);
+        let yi = broadcast_index(i, &out_dims, &inputs[2].dims);
+        result.push(if cond[ci] != 0 { x[xi] } else { y[yi] });
+    }
+    let t = make_f32_tensor(out_name, &out_dims, &result, inputs[1].data_type);
+    Some(vec![(out_name.to_string(), t)])
+}
+
+fn eval_range(
+    inputs: &[&TensorProto],
+    out_name: &str,
+) -> Option<Vec<(String, TensorProto)>> {
+    let is_int = inputs[0].data_type == TensorProto::INT64
+        && inputs[1].data_type == TensorProto::INT64
+        && inputs[2].data_type == TensorProto::INT64;
+    if is_int {
+        let start = tensor_to_i64(inputs[0]).first().copied()?;
+        let limit = tensor_to_i64(inputs[1]).first().copied()?;
+        let delta = tensor_to_i64(inputs[2]).first().copied()?;
+        if delta == 0 {
+            return None;
+        }
+        let mut out = Vec::new();
+        let mut v = start;
+        while (delta > 0 && v < limit) || (delta < 0 && v > limit) {
+            out.push(v);
+            v += delta;
+        }
+        let t = TensorProto {
+            name: out_name.to_string(),
+            data_type: TensorProto::INT64,
+            dims: vec![out.len() as i64],
+            int64_data: out,
+            ..Default::default()
+        };
+        return Some(vec![(out_name.to_string(), t)]);
+    }
+    let start = tensor_to_f32(inputs[0]).first().copied()?;
+    let limit = tensor_to_f32(inputs[1]).first().copied()?;
+    let delta = tensor_to_f32(inputs[2]).first().copied()?;
+    if delta == 0.0 {
+        return None;
+    }
+    let mut out = Vec::new();
+    let mut v = start;
+    while (delta > 0.0 && v < limit) || (delta < 0.0 && v > limit) {
+        out.push(v);
+        v += delta;
+    }
+    let dims = vec![out.len() as i64];
+    let t = make_f32_tensor(out_name, &dims, &out, inputs[0].data_type);
+    Some(vec![(out_name.to_string(), t)])
+}
+
+fn eval_cmp(
+    inputs: &[&TensorProto],
+    out_name: &str,
+    f: fn(f32, f32) -> bool,
+) -> Option<Vec<(String, TensorProto)>> {
+    if inputs.len() < 2 {
+        return None;
+    }
+    let a = tensor_to_f32(inputs[0]);
+    let b = tensor_to_f32(inputs[1]);
+    if a.is_empty() || b.is_empty() {
+        return None;
+    }
+    let out_dims = broadcast_shape(&inputs[0].dims, &inputs[1].dims)?;
+    let total = broadcast_total(&out_dims)?;
+    let mut result = Vec::with_capacity(total);
+    for i in 0..total {
+        let ai = broadcast_index(i, &out_dims, &inputs[0].dims);
+        let bi = broadcast_index(i, &out_dims, &inputs[1].dims);
+        result.push(f(a[ai], b[bi]) as i32);
+    }
+    let t = TensorProto {
+        name: out_name.to_string(),
+        data_type: TensorProto::BOOL,
+        dims: out_dims,
+        int32_data: result,
+        ..Default::default()
+    };
+    Some(vec![(out_name.to_string(), t)])
+}
+
+fn eval_not(
+    input: &TensorProto,
+    out_name: &str,
+) -> Option<Vec<(String, TensorProto)>> {
+    let vals = tensor_to_i64(input);
+    if vals.is_empty() {
+        return None;
+    }
+    let t = TensorProto {
+        name: out_name.to_string(),
+        data_type: TensorProto::BOOL,
+        dims: input.dims.clone(),
+        int32_data: vals.iter().map(|&v| (v == 0) as i32).collect(),
+        ..Default::default()
+    };
+    Some(vec![(out_name.to_string(), t)])
+}
+
+fn eval_logical(
+    inputs: &[&TensorProto],
+    out_name: &str,
+    f: fn(i32, i32) -> i32,
+) -> Option<Vec<(String, TensorProto)>> {
+    if inputs.len() < 2 {
+        return None;
+    }
+    let a = tensor_to_i64(inputs[0]);
+    let b = tensor_to_i64(inputs[1]);
+    if a.is_empty() || b.is_empty() {
+        return None;
+    }
+    let out_dims = broadcast_shape(&inputs[0].dims, &inputs[1].dims)?;
+    let total = broadcast_total(&out_dims)?;
+    let mut result = Vec::with_capacity(total);
+    for i in 0..total {
+        let ai = broadcast_index(i, &out_dims, &inputs[0].dims);
+        let bi = broadcast_index(i, &out_dims, &inputs[1].dims);
+        result.push(f((a[ai] != 0) as i32, (b[bi] != 0) as i32));
+    }
+    let t = TensorProto {
+        name: out_name.to_string(),
+        data_type: TensorProto::BOOL,
+        dims: out_dims,
+        int32_data: result,
+        ..Default::default()
+    };
+    Some(vec![(out_name.to_string(), t)])
+}
+
+fn eval_transpose(
+    node: &NodeProto,
+    input: &TensorProto,
+    out_name: &str,
+) -> Option<Vec<(String, TensorProto)>> {
+    let rank = input.dims.len();
+    if rank == 0 {
+        return None;
+    }
+    let perm: Vec<usize> = node
+        .attribute
+        .iter()
+        .find(|a| a.name == "perm")
+        .map(|a| a.ints.iter().map(|&p| p as usize).collect())
+        .unwrap_or_else(|| (0..rank).rev().collect());
+    if perm.len() != rank {
+        return None;
+    }
+    let out_dims: Vec<i64> = perm.iter().map(|&p| input.dims[p]).collect();
+    let total = broadcast_total(&out_dims)?;
+
+    let src_strides = {
+        let mut s = vec![1i64; rank];
+        for i in (0..rank.saturating_sub(1)).rev() {
+            s[i] = s[i + 1] * input.dims[i + 1];
+        }
+        s
+    };
+    let out_strides = {
+        let mut s = vec![1i64; rank];
+        for i in (0..rank.saturating_sub(1)).rev() {
+            s[i] = s[i + 1] * out_dims[i + 1];
+        }
+        s
+    };
+
+    let permute_index = |out_linear: usize| -> usize {
+        let mut src = 0i64;
+        let mut rem = out_linear as i64;
+        for i in 0..rank {
+            let coord = rem / out_strides[i];
+            rem %= out_strides[i];
+            src += coord * src_strides[perm[i]];
+        }
+        src as usize
+    };
+
+    if input.data_type == TensorProto::INT64 {
+        let vals = tensor_to_i64(input);
+        if vals.is_empty() {
+            return None;
+        }
+        let mut result = Vec::with_capacity(total);
+        for i in 0..total {
+            result.push(vals[permute_index(i)]);
+        }
+        let t = TensorProto {
+            name: out_name.to_string(),
+            data_type: TensorProto::INT64,
+            dims: out_dims,
+            int64_data: result,
+            ..Default::default()
+        };
+        return Some(vec![(out_name.to_string(), t)]);
+    }
+    let vals = tensor_to_f32(input);
+    if vals.is_empty() {
+        return None;
+    }
+    let mut result = Vec::with_capacity(total);
+    for i in 0..total {
+        result.push(vals[permute_index(i)]);
+    }
+    let t = make_f32_tensor(out_name, &out_dims, &result, input.data_type);
+    Some(vec![(out_name.to_string(), t)])
+}
+
+#[allow(clippy::too_many_lines)]
+fn eval_resize(
+    node: &NodeProto,
+    inputs: &[&TensorProto],
+    out_name: &str,
+) -> Option<Vec<(String, TensorProto)>> {
+    let named: Vec<(&str, Option<&TensorProto>)> = {
+        let mut it = inputs.iter().copied();
+        node.input
+            .iter()
+            .map(|name| {
+                let entry = if name.is_empty() { None } else { it.next() };
+                (name.as_str(), entry)
+            })
+            .collect()
+    };
+    let x = named.first().and_then(|(_, t)| *t)?;
+    if x.dims.len() < 2 {
+        return None;
+    }
+    let rank = x.dims.len();
+    let vals = tensor_to_f32(x);
+    if vals.is_empty() {
+        return None;
+    }
+
+    let mode = node
+        .attribute
+        .iter()
+        .find(|a| a.name == "mode")
+        .map(|a| std::str::from_utf8(&a.s).unwrap_or("").to_string())
+        .unwrap_or_else(|| "nearest".to_string());
+    let ctm = node
+        .attribute
+        .iter()
+        .find(|a| a.name == "coordinate_transformation_mode")
+        .map(|a| std::str::from_utf8(&a.s).unwrap_or("").to_string())
+        .unwrap_or_else(|| "half_pixel".to_string());
+    let cubic_a = node
+        .attribute
+        .iter()
+        .find(|a| a.name == "cubic_coeff_a")
+        .map(|a| a.f)
+        .unwrap_or(-0.75);
+    let exclude_outside = node
+        .attribute
+        .iter()
+        .find(|a| a.name == "exclude_outside")
+        .map(|a| a.i != 0)
+        .unwrap_or(false);
+    let extrapolation = node
+        .attribute
+        .iter()
+        .find(|a| a.name == "extrapolation_value")
+        .map(|a| a.f)
+        .unwrap_or(0.0);
+
+    let sizes_opt = named.get(3).and_then(|(_, t)| *t).and_then(|t| {
+        if t.dims.is_empty() || t.dims.iter().all(|&d| d == 0) {
+            None
+        } else {
+            let v = tensor_to_i64(t);
+            if v.len() == rank { Some(v) } else { None }
+        }
+    });
+    let scales_opt = named.get(2).and_then(|(_, t)| *t).and_then(|t| {
+        if t.dims.is_empty() || t.dims.iter().all(|&d| d == 0) {
+            None
+        } else {
+            let v = tensor_to_f32(t);
+            if v.len() == rank { Some(v) } else { None }
+        }
+    });
+
+    let out_dims: Vec<i64> = if let Some(sizes) = sizes_opt {
+        sizes
+    } else if let Some(scales) = scales_opt {
+        x.dims
+            .iter()
+            .zip(&scales)
+            .map(|(&d, &s)| (d as f32 * s) as i64)
+            .collect()
+    } else {
+        return None;
+    };
+    let total_out = broadcast_total(&out_dims)?;
+
+    let scales_eff: Vec<f32> = x
+        .dims
+        .iter()
+        .zip(&out_dims)
+        .map(|(&s, &o)| o as f32 / s as f32)
+        .collect();
+
+    let src_stride: Vec<usize> = {
+        let mut s = vec![1usize; rank];
+        for i in (0..rank.saturating_sub(1)).rev() {
+            s[i] = s[i + 1] * x.dims[i + 1] as usize;
+        }
+        s
+    };
+
+    let coord = |out_i: i64, d: usize| -> f32 {
+        let out_d = out_dims[d] as f32;
+        let in_d = x.dims[d] as f32;
+        let s = scales_eff[d];
+        match ctm.as_str() {
+            "half_pixel" => (out_i as f32 + 0.5) / s - 0.5,
+            "pytorch_half_pixel" => {
+                if out_d > 1.0 {
+                    (out_i as f32 + 0.5) / s - 0.5
+                } else {
+                    0.0
+                }
+            }
+            "align_corners" => {
+                if out_d > 1.0 {
+                    out_i as f32 * (in_d - 1.0) / (out_d - 1.0)
+                } else {
+                    0.0
+                }
+            }
+            "asymmetric" => out_i as f32 / s,
+            _ => (out_i as f32 + 0.5) / s - 0.5,
+        }
+    };
+
+    let mode_kind = match mode.as_str() {
+        "cubic" => ResizeMode::Cubic,
+        "linear" => ResizeMode::Linear,
+        "nearest" => ResizeMode::Nearest,
+        _ => return None,
+    };
+
+    let mut result = vec![0f32; total_out];
+
+    let dst_stride: Vec<usize> = {
+        let mut s = vec![1usize; rank];
+        for i in (0..rank.saturating_sub(1)).rev() {
+            s[i] = s[i + 1] * out_dims[i + 1] as usize;
+        }
+        s
+    };
+
+    let resize_axes: Vec<usize> = (0..rank)
+        .filter(|&d| x.dims[d] != out_dims[d])
+        .collect();
+    if resize_axes.is_empty() {
+        let t = make_f32_tensor(out_name, &out_dims, &vals, x.data_type);
+        return Some(vec![(out_name.to_string(), t)]);
+    }
+    if !(resize_axes.len() == 2
+        && resize_axes[0] + 1 == resize_axes[1]
+        && resize_axes[1] + 1 == rank)
+    {
+        return None;
+    }
+    let h_axis = resize_axes[0];
+    let w_axis = resize_axes[1];
+
+    let outer_total: usize = x.dims[..h_axis].iter().map(|&d| d as usize).product();
+    let in_h = x.dims[h_axis] as usize;
+    let in_w = x.dims[w_axis] as usize;
+    let out_h = out_dims[h_axis] as usize;
+    let out_w = out_dims[w_axis] as usize;
+
+    for outer in 0..outer_total {
+        let in_plane = outer * in_h * in_w;
+        let out_plane = outer * out_h * out_w;
+        for oy in 0..out_h {
+            let sy = coord(oy as i64, h_axis);
+            for ox in 0..out_w {
+                let sx = coord(ox as i64, w_axis);
+                let v = match mode_kind {
+                    ResizeMode::Nearest => {
+                        let yi = nearest_idx(sy, in_h);
+                        let xi = nearest_idx(sx, in_w);
+                        vals[in_plane + yi * in_w + xi]
+                    }
+                    ResizeMode::Linear => sample_linear_2d(
+                        &vals[in_plane..in_plane + in_h * in_w],
+                        in_h,
+                        in_w,
+                        sy,
+                        sx,
+                        exclude_outside,
+                        extrapolation,
+                    ),
+                    ResizeMode::Cubic => sample_cubic_2d(
+                        &vals[in_plane..in_plane + in_h * in_w],
+                        in_h,
+                        in_w,
+                        sy,
+                        sx,
+                        cubic_a,
+                        exclude_outside,
+                        extrapolation,
+                    ),
+                };
+                result[out_plane + oy * out_w + ox] = v;
+            }
+        }
+    }
+    let _ = (src_stride, dst_stride);
+    let t = make_f32_tensor(out_name, &out_dims, &result, x.data_type);
+    Some(vec![(out_name.to_string(), t)])
+}
+
+#[derive(Clone, Copy)]
+enum ResizeMode {
+    Nearest,
+    Linear,
+    Cubic,
+}
+
+fn nearest_idx(s: f32, dim: usize) -> usize {
+    if s < 0.0 {
+        0
+    } else {
+        let i = s.round() as isize;
+        if i >= dim as isize {
+            dim - 1
+        } else {
+            i as usize
+        }
+    }
+}
+
+fn sample_linear_2d(
+    plane: &[f32],
+    h: usize,
+    w: usize,
+    sy: f32,
+    sx: f32,
+    exclude_outside: bool,
+    extrap: f32,
+) -> f32 {
+    let (y0_in, y0) = clamp_axis(sy.floor() as isize, h);
+    let (y1_in, y1) = clamp_axis(sy.floor() as isize + 1, h);
+    let (x0_in, x0) = clamp_axis(sx.floor() as isize, w);
+    let (x1_in, x1) = clamp_axis(sx.floor() as isize + 1, w);
+    if exclude_outside && (!y0_in && !y1_in || !x0_in && !x1_in) {
+        return extrap;
+    }
+    let dy = sy - sy.floor();
+    let dx = sx - sx.floor();
+    let v00 = plane[y0 * w + x0];
+    let v01 = plane[y0 * w + x1];
+    let v10 = plane[y1 * w + x0];
+    let v11 = plane[y1 * w + x1];
+    let a = v00 * (1.0 - dx) + v01 * dx;
+    let b = v10 * (1.0 - dx) + v11 * dx;
+    a * (1.0 - dy) + b * dy
+}
+
+#[allow(clippy::too_many_arguments)]
+fn sample_cubic_2d(
+    plane: &[f32],
+    h: usize,
+    w: usize,
+    sy: f32,
+    sx: f32,
+    a_coef: f32,
+    exclude_outside: bool,
+    extrap: f32,
+) -> f32 {
+    let fx = sx.floor();
+    let fy = sy.floor();
+    let dx = sx - fx;
+    let dy = sy - fy;
+    let wx = cubic_weights(dx, a_coef);
+    let wy = cubic_weights(dy, a_coef);
+    let mut wx_eff = wx;
+    let mut wy_eff = wy;
+    if exclude_outside {
+        for (i, w_ref) in wx_eff.iter_mut().enumerate() {
+            let xi = fx as isize - 1 + i as isize;
+            if xi < 0 || xi >= w as isize {
+                *w_ref = 0.0;
+            }
+        }
+        for (i, w_ref) in wy_eff.iter_mut().enumerate() {
+            let yi = fy as isize - 1 + i as isize;
+            if yi < 0 || yi >= h as isize {
+                *w_ref = 0.0;
+            }
+        }
+        let sx_sum: f32 = wx_eff.iter().sum();
+        let sy_sum: f32 = wy_eff.iter().sum();
+        if sx_sum == 0.0 || sy_sum == 0.0 {
+            return extrap;
+        }
+        for w_ref in &mut wx_eff {
+            *w_ref /= sx_sum;
+        }
+        for w_ref in &mut wy_eff {
+            *w_ref /= sy_sum;
+        }
+    }
+    let mut out = 0f32;
+    for (iy, &wyv) in wy_eff.iter().enumerate() {
+        if wyv == 0.0 {
+            continue;
+        }
+        let yi = (fy as isize - 1 + iy as isize).clamp(0, h as isize - 1) as usize;
+        let mut row_sum = 0f32;
+        for (ix, &wxv) in wx_eff.iter().enumerate() {
+            if wxv == 0.0 {
+                continue;
+            }
+            let xi = (fx as isize - 1 + ix as isize).clamp(0, w as isize - 1) as usize;
+            row_sum += plane[yi * w + xi] * wxv;
+        }
+        out += row_sum * wyv;
+    }
+    out
+}
+
+fn cubic_weights(t: f32, a: f32) -> [f32; 4] {
+    let t1 = 1.0 + t;
+    let t2 = t;
+    let t3 = 1.0 - t;
+    let t4 = 2.0 - t;
+    [
+        cubic_kernel(t1, a),
+        cubic_kernel(t2, a),
+        cubic_kernel(t3, a),
+        cubic_kernel(t4, a),
+    ]
+}
+
+fn cubic_kernel(x: f32, a: f32) -> f32 {
+    let ax = x.abs();
+    if ax <= 1.0 {
+        (a + 2.0) * ax.powi(3) - (a + 3.0) * ax.powi(2) + 1.0
+    } else if ax < 2.0 {
+        a * ax.powi(3) - 5.0 * a * ax.powi(2) + 8.0 * a * ax - 4.0 * a
+    } else {
+        0.0
+    }
+}
+
+fn clamp_axis(i: isize, dim: usize) -> (bool, usize) {
+    if i < 0 {
+        (false, 0)
+    } else if i >= dim as isize {
+        (false, dim - 1)
+    } else {
+        (true, i as usize)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ReduceOp {
+    Sum,
+    Mean,
+    Max,
+    Min,
+}
+
+fn eval_reduce(
+    node: &NodeProto,
+    inputs: &[&TensorProto],
+    out_name: &str,
+    op: ReduceOp,
+) -> Option<Vec<(String, TensorProto)>> {
+    let input = inputs[0];
+    let rank = input.dims.len();
+    if rank == 0 {
+        return None;
+    }
+    let keepdims = node
+        .attribute
+        .iter()
+        .find(|a| a.name == "keepdims")
+        .map(|a| a.i != 0)
+        .unwrap_or(true);
+    let axes: Vec<i64> = if inputs.len() >= 2 {
+        tensor_to_i64(inputs[1])
+    } else {
+        node.attribute
+            .iter()
+            .find(|a| a.name == "axes")
+            .map(|a| a.ints.clone())
+            .unwrap_or_else(|| (0..rank as i64).collect())
+    };
+    let norm_axes: Vec<usize> = axes
+        .iter()
+        .map(|&a| if a < 0 { (rank as i64 + a) as usize } else { a as usize })
+        .collect();
+    for &ax in &norm_axes {
+        if ax >= rank {
+            return None;
+        }
+    }
+    let mut out_dims_full = input.dims.clone();
+    for &ax in &norm_axes {
+        out_dims_full[ax] = 1;
+    }
+    let out_dims: Vec<i64> = if keepdims {
+        out_dims_full.clone()
+    } else {
+        out_dims_full
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| !norm_axes.contains(i))
+            .map(|(_, &d)| d)
+            .collect()
+    };
+    let total_out = broadcast_total(&out_dims_full)?;
+    let total_in = broadcast_total(&input.dims)?;
+    let vals = tensor_to_f32(input);
+    if vals.is_empty() {
+        return None;
+    }
+
+    let src_strides = {
+        let mut s = vec![1i64; rank];
+        for i in (0..rank.saturating_sub(1)).rev() {
+            s[i] = s[i + 1] * input.dims[i + 1];
+        }
+        s
+    };
+    let reduced_count: i64 = norm_axes.iter().map(|&a| input.dims[a]).product();
+
+    let mut accum = vec![match op {
+        ReduceOp::Sum | ReduceOp::Mean => 0.0f32,
+        ReduceOp::Max => f32::NEG_INFINITY,
+        ReduceOp::Min => f32::INFINITY,
+    }; total_out];
+
+    for in_idx in 0..total_in {
+        let mut rem = in_idx as i64;
+        let mut out_idx = 0i64;
+        let mut out_stride = 1i64;
+        for i in (0..rank).rev() {
+            let dim_i = input.dims[i];
+            let coord = rem % dim_i;
+            rem /= dim_i;
+            let coord_out = if norm_axes.contains(&i) { 0 } else { coord };
+            out_idx += coord_out * out_stride;
+            out_stride *= out_dims_full[i];
+        }
+        let o = out_idx as usize;
+        let v = vals[in_idx];
+        accum[o] = match op {
+            ReduceOp::Sum | ReduceOp::Mean => accum[o] + v,
+            ReduceOp::Max => accum[o].max(v),
+            ReduceOp::Min => accum[o].min(v),
+        };
+    }
+    if matches!(op, ReduceOp::Mean) && reduced_count > 0 {
+        for a in &mut accum {
+            *a /= reduced_count as f32;
+        }
+    }
+    let t = make_f32_tensor(out_name, &out_dims, &accum, input.data_type);
+    Some(vec![(out_name.to_string(), t)])
 }
 
 fn eval_cast(
@@ -779,8 +1688,17 @@ fn eval_slice(inputs: &[&TensorProto], out_name: &str) -> Option<Vec<(String, Te
         } else {
             (ends[0] as usize).min(dim as usize)
         };
-        if start >= end {
+        if start > end {
             return None;
+        }
+        if start == end {
+            let t = TensorProto {
+                name: out_name.to_string(),
+                data_type: data.data_type,
+                dims: vec![0],
+                ..Default::default()
+            };
+            return Some(vec![(out_name.to_string(), t)]);
         }
         if data.data_type == TensorProto::INT64 {
             let vals = tensor_to_i64(data);
@@ -807,51 +1725,103 @@ fn eval_concat(
     inputs: &[&TensorProto],
     out_name: &str,
 ) -> Option<Vec<(String, TensorProto)>> {
-    // axis attribute is read but only 1-D concat is evaluated below;
-    // multi-dimensional concat returns None and falls through to tract.
-    let _axis = node
+    if inputs.is_empty() {
+        return None;
+    }
+    let raw_axis = node
         .attribute
         .iter()
         .find(|a| a.name == "axis")
         .map(|a| a.i)
         .unwrap_or(0);
-    if inputs.is_empty() {
+    let rank = inputs[0].dims.len();
+    if !inputs.iter().all(|t| t.dims.len() == rank) {
         return None;
     }
-    let all_1d = inputs.iter().all(|t| t.dims.len() <= 1);
-    if !all_1d {
+    if rank == 0 {
         return None;
     }
-    if inputs[0].data_type == TensorProto::INT64
-        || inputs.iter().all(|t| !tensor_to_i64(t).is_empty())
-    {
-        let mut result = Vec::new();
+    let axis = if raw_axis < 0 {
+        (rank as i64 + raw_axis) as usize
+    } else {
+        raw_axis as usize
+    };
+    if axis >= rank {
+        return None;
+    }
+    for d in 0..rank {
+        if d == axis {
+            continue;
+        }
+        let expected = inputs[0].dims[d];
+        if !inputs.iter().all(|t| t.dims[d] == expected) {
+            return None;
+        }
+    }
+    let mut out_dims = inputs[0].dims.clone();
+    out_dims[axis] = inputs.iter().map(|t| t.dims[axis]).sum();
+
+    let prefix_size: usize = out_dims[..axis].iter().map(|&d| d as usize).product();
+    let out_axis: usize = out_dims[axis] as usize;
+    let suffix_size: usize = out_dims[axis + 1..].iter().map(|&d| d as usize).product();
+    let out_total = prefix_size.checked_mul(out_axis)?.checked_mul(suffix_size)?;
+    if out_total > MAX_BROADCAST_ELEMENTS {
+        return None;
+    }
+
+    let is_int64 = inputs[0].data_type == TensorProto::INT64
+        || inputs.iter().all(|t| !tensor_to_i64(t).is_empty() && tensor_to_f32(t).is_empty());
+
+    if is_int64 {
+        let mut result: Vec<i64> = vec![0; out_total];
+        let mut axis_offset: usize = 0;
         for t in inputs {
-            result.extend(tensor_to_i64(t));
+            let t_vals = tensor_to_i64(t);
+            let t_axis = t.dims[axis] as usize;
+            if t_axis > 0 && t_vals.is_empty() {
+                return None;
+            }
+            for p in 0..prefix_size {
+                for ai in 0..t_axis {
+                    for s in 0..suffix_size {
+                        let src = (p * t_axis + ai) * suffix_size + s;
+                        let dst = (p * out_axis + axis_offset + ai) * suffix_size + s;
+                        result[dst] = t_vals[src];
+                    }
+                }
+            }
+            axis_offset += t_axis;
         }
         let t = TensorProto {
             name: out_name.to_string(),
             data_type: TensorProto::INT64,
-            dims: vec![result.len() as i64],
+            dims: out_dims,
             int64_data: result,
             ..Default::default()
         };
         return Some(vec![(out_name.to_string(), t)]);
     }
-    let mut result = Vec::new();
+
+    let mut result: Vec<f32> = vec![0.0; out_total];
+    let mut axis_offset: usize = 0;
     for t in inputs {
-        let vals = tensor_to_f32(t);
-        if vals.is_empty() {
+        let t_vals = tensor_to_f32(t);
+        let t_axis = t.dims[axis] as usize;
+        if t_axis > 0 && t_vals.is_empty() {
             return None;
         }
-        result.extend(vals);
+        for p in 0..prefix_size {
+            for ai in 0..t_axis {
+                for s in 0..suffix_size {
+                    let src = (p * t_axis + ai) * suffix_size + s;
+                    let dst = (p * out_axis + axis_offset + ai) * suffix_size + s;
+                    result[dst] = t_vals[src];
+                }
+            }
+        }
+        axis_offset += t_axis;
     }
-    let t = make_f32_tensor(
-        out_name,
-        &[result.len() as i64],
-        &result,
-        inputs[0].data_type,
-    );
+    let t = make_f32_tensor(out_name, &out_dims, &result, inputs[0].data_type);
     Some(vec![(out_name.to_string(), t)])
 }
 

--- a/crates/dsperse/src/slicer/onnx_fold.rs
+++ b/crates/dsperse/src/slicer/onnx_fold.rs
@@ -276,10 +276,7 @@ fn eval_const_node(
     }
 }
 
-fn eval_expand(
-    inputs: &[&TensorProto],
-    out_name: &str,
-) -> Option<Vec<(String, TensorProto)>> {
+fn eval_expand(inputs: &[&TensorProto], out_name: &str) -> Option<Vec<(String, TensorProto)>> {
     let data = inputs[0];
     let shape = tensor_to_i64(inputs[1]);
     if shape.is_empty() {
@@ -319,10 +316,7 @@ fn eval_expand(
     Some(vec![(out_name.to_string(), t)])
 }
 
-fn eval_tile(
-    inputs: &[&TensorProto],
-    out_name: &str,
-) -> Option<Vec<(String, TensorProto)>> {
+fn eval_tile(inputs: &[&TensorProto], out_name: &str) -> Option<Vec<(String, TensorProto)>> {
     let data = inputs[0];
     let repeats = tensor_to_i64(inputs[1]);
     if repeats.is_empty() || repeats.len() != data.dims.len() {
@@ -358,7 +352,7 @@ fn eval_tile(
             return None;
         }
         let mut result = vec![0i64; total];
-        for o in 0..total {
+        for (o, out_slot) in result.iter_mut().enumerate().take(total) {
             let mut src = 0usize;
             let mut rem = o;
             for i in 0..rank {
@@ -366,7 +360,7 @@ fn eval_tile(
                 rem %= out_strides[i];
                 src += (coord % data.dims[i] as usize) * in_strides[i];
             }
-            result[o] = v[src];
+            *out_slot = v[src];
         }
         let t = TensorProto {
             name: out_name.to_string(),
@@ -382,7 +376,7 @@ fn eval_tile(
         return None;
     }
     let mut result = vec![0f32; total];
-    for o in 0..total {
+    for (o, out_slot) in result.iter_mut().enumerate().take(total) {
         let mut src = 0usize;
         let mut rem = o;
         for i in 0..rank {
@@ -390,7 +384,7 @@ fn eval_tile(
             rem %= out_strides[i];
             src += (coord % data.dims[i] as usize) * in_strides[i];
         }
-        result[o] = v[src];
+        *out_slot = v[src];
     }
     let t = make_f32_tensor(out_name, &out_dims, &result, data.data_type);
     Some(vec![(out_name.to_string(), t)])
@@ -444,18 +438,14 @@ fn eval_constant_of_shape(
     Some(vec![(out_name.to_string(), t)])
 }
 
-fn eval_where(
-    inputs: &[&TensorProto],
-    out_name: &str,
-) -> Option<Vec<(String, TensorProto)>> {
+fn eval_where(inputs: &[&TensorProto], out_name: &str) -> Option<Vec<(String, TensorProto)>> {
     let cond = tensor_to_i64(inputs[0]);
-    let data_type = if inputs[1].data_type == TensorProto::INT64
-        && inputs[2].data_type == TensorProto::INT64
-    {
-        TensorProto::INT64
-    } else {
-        TensorProto::FLOAT
-    };
+    let data_type =
+        if inputs[1].data_type == TensorProto::INT64 && inputs[2].data_type == TensorProto::INT64 {
+            TensorProto::INT64
+        } else {
+            TensorProto::FLOAT
+        };
     if data_type == TensorProto::INT64 {
         let x = tensor_to_i64(inputs[1]);
         let y = tensor_to_i64(inputs[2]);
@@ -500,10 +490,7 @@ fn eval_where(
     Some(vec![(out_name.to_string(), t)])
 }
 
-fn eval_range(
-    inputs: &[&TensorProto],
-    out_name: &str,
-) -> Option<Vec<(String, TensorProto)>> {
+fn eval_range(inputs: &[&TensorProto], out_name: &str) -> Option<Vec<(String, TensorProto)>> {
     let is_int = inputs[0].data_type == TensorProto::INT64
         && inputs[1].data_type == TensorProto::INT64
         && inputs[2].data_type == TensorProto::INT64;
@@ -583,8 +570,8 @@ fn eval_cmp(
     let out_dims = broadcast_shape(&inputs[0].dims, &inputs[1].dims)?;
     let total = broadcast_total(&out_dims)?;
 
-    let both_int = inputs[0].data_type == TensorProto::INT64
-        && inputs[1].data_type == TensorProto::INT64;
+    let both_int =
+        inputs[0].data_type == TensorProto::INT64 && inputs[1].data_type == TensorProto::INT64;
     let mut result = Vec::with_capacity(total);
     if both_int {
         let a = tensor_to_i64(inputs[0]);
@@ -619,10 +606,7 @@ fn eval_cmp(
     Some(vec![(out_name.to_string(), t)])
 }
 
-fn eval_not(
-    input: &TensorProto,
-    out_name: &str,
-) -> Option<Vec<(String, TensorProto)>> {
+fn eval_not(input: &TensorProto, out_name: &str) -> Option<Vec<(String, TensorProto)>> {
     let vals = tensor_to_i64(input);
     if vals.is_empty() {
         return None;
@@ -902,9 +886,7 @@ fn eval_resize(
         s
     };
 
-    let resize_axes: Vec<usize> = (0..rank)
-        .filter(|&d| x.dims[d] != out_dims[d])
-        .collect();
+    let resize_axes: Vec<usize> = (0..rank).filter(|&d| x.dims[d] != out_dims[d]).collect();
     if resize_axes.is_empty() {
         let t = make_f32_tensor(out_name, &out_dims, &vals, x.data_type);
         return Some(vec![(out_name.to_string(), t)]);
@@ -1155,7 +1137,13 @@ fn eval_reduce(
     };
     let norm_axes: Vec<usize> = axes
         .iter()
-        .map(|&a| if a < 0 { (rank as i64 + a) as usize } else { a as usize })
+        .map(|&a| {
+            if a < 0 {
+                (rank as i64 + a) as usize
+            } else {
+                a as usize
+            }
+        })
         .collect();
     for &ax in &norm_axes {
         if ax >= rank {
@@ -1183,22 +1171,18 @@ fn eval_reduce(
         return None;
     }
 
-    let src_strides = {
-        let mut s = vec![1i64; rank];
-        for i in (0..rank.saturating_sub(1)).rev() {
-            s[i] = s[i + 1] * input.dims[i + 1];
-        }
-        s
-    };
     let reduced_count: i64 = norm_axes.iter().map(|&a| input.dims[a]).product();
 
-    let mut accum = vec![match op {
-        ReduceOp::Sum | ReduceOp::Mean => 0.0f32,
-        ReduceOp::Max => f32::NEG_INFINITY,
-        ReduceOp::Min => f32::INFINITY,
-    }; total_out];
+    let mut accum = vec![
+        match op {
+            ReduceOp::Sum | ReduceOp::Mean => 0.0f32,
+            ReduceOp::Max => f32::NEG_INFINITY,
+            ReduceOp::Min => f32::INFINITY,
+        };
+        total_out
+    ];
 
-    for in_idx in 0..total_in {
+    for (in_idx, &v) in vals.iter().enumerate().take(total_in) {
         let mut rem = in_idx as i64;
         let mut out_idx = 0i64;
         let mut out_stride = 1i64;
@@ -1211,7 +1195,6 @@ fn eval_reduce(
             out_stride *= out_dims_full[i];
         }
         let o = out_idx as usize;
-        let v = vals[in_idx];
         accum[o] = match op {
             ReduceOp::Sum | ReduceOp::Mean => accum[o] + v,
             ReduceOp::Max => accum[o].max(v),
@@ -1745,9 +1728,15 @@ fn eval_slice(inputs: &[&TensorProto], out_name: &str) -> Option<Vec<(String, Te
         return None;
     }
 
-    let mut per_axis_range: Vec<(i64, i64, i64)> = (0..rank as i64).map(|d| (0, data.dims[d as usize], 1)).collect();
+    let mut per_axis_range: Vec<(i64, i64, i64)> = (0..rank as i64)
+        .map(|d| (0, data.dims[d as usize], 1))
+        .collect();
     for (i, &raw_axis) in axes.iter().enumerate() {
-        let a = if raw_axis < 0 { rank as i64 + raw_axis } else { raw_axis };
+        let a = if raw_axis < 0 {
+            rank as i64 + raw_axis
+        } else {
+            raw_axis
+        };
         if a < 0 || a >= rank as i64 {
             return None;
         }
@@ -1769,14 +1758,30 @@ fn eval_slice(inputs: &[&TensorProto], out_name: &str) -> Option<Vec<(String, Te
         let (s, e) = if step > 0 {
             // ONNX forward slice: start in [0, dim], end in [0, dim],
             // both treated as exclusive upper bound.
-            let s = clamp(if raw_start < 0 { dim + raw_start } else { raw_start }, 0, dim);
+            let s = clamp(
+                if raw_start < 0 {
+                    dim + raw_start
+                } else {
+                    raw_start
+                },
+                0,
+                dim,
+            );
             let e = clamp(if raw_end < 0 { dim + raw_end } else { raw_end }, 0, dim);
             (s, e)
         } else {
             // ONNX reverse slice: start in [0, dim-1] (inclusive first
             // read), end in [-1, dim-1] (exclusive lower bound; -1
             // means "walk past index 0", i.e. include element 0).
-            let s = clamp(if raw_start < 0 { dim + raw_start } else { raw_start }, 0, dim - 1);
+            let s = clamp(
+                if raw_start < 0 {
+                    dim + raw_start
+                } else {
+                    raw_start
+                },
+                0,
+                dim - 1,
+            );
             let resolved_end = if raw_end == i64::MIN {
                 -1
             } else if raw_end < 0 {
@@ -1868,10 +1873,7 @@ fn eval_slice(inputs: &[&TensorProto], out_name: &str) -> Option<Vec<(String, Te
     Some(vec![(out_name.to_string(), t)])
 }
 
-fn eval_scatter_nd(
-    inputs: &[&TensorProto],
-    out_name: &str,
-) -> Option<Vec<(String, TensorProto)>> {
+fn eval_scatter_nd(inputs: &[&TensorProto], out_name: &str) -> Option<Vec<(String, TensorProto)>> {
     let data = inputs[0];
     let indices = inputs[1];
     let updates = inputs[2];
@@ -1980,7 +1982,11 @@ fn eval_split(
         .find(|a| a.name == "axis")
         .map(|a| a.i)
         .unwrap_or(0);
-    let axis = if raw_axis < 0 { rank as i64 + raw_axis } else { raw_axis } as usize;
+    let axis = if raw_axis < 0 {
+        rank as i64 + raw_axis
+    } else {
+        raw_axis
+    } as usize;
     if axis >= rank {
         return None;
     }
@@ -2112,7 +2118,9 @@ fn eval_concat(
     let prefix_size: usize = out_dims[..axis].iter().map(|&d| d as usize).product();
     let out_axis: usize = out_dims[axis] as usize;
     let suffix_size: usize = out_dims[axis + 1..].iter().map(|&d| d as usize).product();
-    let out_total = prefix_size.checked_mul(out_axis)?.checked_mul(suffix_size)?;
+    let out_total = prefix_size
+        .checked_mul(out_axis)?
+        .checked_mul(suffix_size)?;
     if out_total > MAX_BROADCAST_ELEMENTS {
         return None;
     }

--- a/crates/dsperse/src/slicer/onnx_fold.rs
+++ b/crates/dsperse/src/slicer/onnx_fold.rs
@@ -263,7 +263,6 @@ fn eval_const_node(
         "And" => eval_logical(inputs, &out_name, |a, b| a & b),
         "Or" => eval_logical(inputs, &out_name, |a, b| a | b),
         "Transpose" => eval_transpose(node, inputs[0], &out_name),
-        "Pow" => eval_binary_f32(inputs, &out_name, f32::powf),
         "ReduceMean" => eval_reduce(node, inputs, &out_name, ReduceOp::Mean),
         "ReduceSum" => eval_reduce(node, inputs, &out_name, ReduceOp::Sum),
         "ReduceMax" => eval_reduce(node, inputs, &out_name, ReduceOp::Max),
@@ -271,6 +270,8 @@ fn eval_const_node(
         "Resize" => eval_resize(node, inputs, &out_name),
         "Expand" if inputs.len() == 2 => eval_expand(inputs, &out_name),
         "Tile" if inputs.len() == 2 => eval_tile(inputs, &out_name),
+        "ScatterND" if inputs.len() == 3 => eval_scatter_nd(inputs, &out_name),
+        "Split" => eval_split(node, inputs, &node.output),
         _ => None,
     }
 }
@@ -461,14 +462,10 @@ fn eval_where(
         if x.is_empty() || y.is_empty() || cond.is_empty() {
             return None;
         }
-        let (xy_vals, xy_dims) =
-            broadcast_binary_i64(&x, &inputs[1].dims, &y, &inputs[2].dims, |a, b| {
-                a * 0 + b * 0
-            })?;
+        let xy_dims = broadcast_shape(&inputs[1].dims, &inputs[2].dims)?;
         let out_dims = broadcast_shape(&xy_dims, &inputs[0].dims)?;
         let total = broadcast_total(&out_dims)?;
         let mut result = Vec::with_capacity(total);
-        let _ = xy_vals;
         for i in 0..total {
             let ci = broadcast_index(i, &out_dims, &inputs[0].dims);
             let xi = broadcast_index(i, &out_dims, &inputs[1].dims);
@@ -517,11 +514,23 @@ fn eval_range(
         if delta == 0 {
             return None;
         }
-        let mut out = Vec::new();
+        let producing = (delta > 0 && start < limit) || (delta < 0 && start > limit);
+        let count = if producing {
+            let span = (limit - start) as i128;
+            let d = delta as i128;
+            let c = (span + d - d.signum()) / d;
+            usize::try_from(c).ok()?
+        } else {
+            0
+        };
+        if count > MAX_BROADCAST_ELEMENTS {
+            return None;
+        }
+        let mut out = Vec::with_capacity(count);
         let mut v = start;
-        while (delta > 0 && v < limit) || (delta < 0 && v > limit) {
+        for _ in 0..count {
             out.push(v);
-            v += delta;
+            v = v.checked_add(delta)?;
         }
         let t = TensorProto {
             name: out_name.to_string(),
@@ -535,12 +544,25 @@ fn eval_range(
     let start = tensor_to_f32(inputs[0]).first().copied()?;
     let limit = tensor_to_f32(inputs[1]).first().copied()?;
     let delta = tensor_to_f32(inputs[2]).first().copied()?;
-    if delta == 0.0 {
+    if delta == 0.0 || !delta.is_finite() || !start.is_finite() || !limit.is_finite() {
         return None;
     }
-    let mut out = Vec::new();
+    let count = ((limit - start) / delta).ceil();
+    if count <= 0.0 {
+        let dims = vec![0i64];
+        let t = make_f32_tensor(out_name, &dims, &[], inputs[0].data_type);
+        return Some(vec![(out_name.to_string(), t)]);
+    }
+    if count as usize > MAX_BROADCAST_ELEMENTS {
+        return None;
+    }
+    let count = count as usize;
+    let mut out = Vec::with_capacity(count);
     let mut v = start;
-    while (delta > 0.0 && v < limit) || (delta < 0.0 && v > limit) {
+    for _ in 0..count {
+        if (delta > 0.0 && v >= limit) || (delta < 0.0 && v <= limit) {
+            break;
+        }
         out.push(v);
         v += delta;
     }
@@ -1676,48 +1698,316 @@ fn eval_slice(inputs: &[&TensorProto], out_name: &str) -> Option<Vec<(String, Te
     } else {
         vec![1; starts.len()]
     };
-    if data.dims.len() == 1 && axes == [0] && steps.iter().all(|&s| s == 1) {
-        let dim = data.dims[0];
-        let start = if starts[0] < 0 {
-            (dim + starts[0]).max(0) as usize
-        } else {
-            (starts[0] as usize).min(dim as usize)
-        };
-        let end = if ends[0] < 0 {
-            (dim + ends[0]).max(0) as usize
-        } else {
-            (ends[0] as usize).min(dim as usize)
-        };
-        if start > end {
+    if starts.len() != ends.len() || axes.len() != starts.len() || steps.len() != starts.len() {
+        return None;
+    }
+    let rank = data.dims.len();
+    if rank == 0 {
+        return None;
+    }
+
+    let mut per_axis_range: Vec<(i64, i64, i64)> = (0..rank as i64).map(|d| (0, data.dims[d as usize], 1)).collect();
+    for (i, &raw_axis) in axes.iter().enumerate() {
+        let a = if raw_axis < 0 { rank as i64 + raw_axis } else { raw_axis };
+        if a < 0 || a >= rank as i64 {
             return None;
         }
-        if start == end {
-            let t = TensorProto {
-                name: out_name.to_string(),
-                data_type: data.data_type,
-                dims: vec![0],
-                ..Default::default()
-            };
-            return Some(vec![(out_name.to_string(), t)]);
+        let dim = data.dims[a as usize];
+        let step = steps[i];
+        if step == 0 {
+            return None;
         }
-        if data.data_type == TensorProto::INT64 {
-            let vals = tensor_to_i64(data);
-            let sliced: Vec<i64> = vals.get(start..end)?.to_vec();
-            let t = TensorProto {
-                name: out_name.to_string(),
-                data_type: TensorProto::INT64,
-                dims: vec![(end - start) as i64],
-                int64_data: sliced,
-                ..Default::default()
-            };
-            return Some(vec![(out_name.to_string(), t)]);
-        }
-        let vals = tensor_to_f32(data);
-        let sliced: Vec<f32> = vals.get(start..end)?.to_vec();
-        let t = make_f32_tensor(out_name, &[(end - start) as i64], &sliced, data.data_type);
+        let raw_start = starts[i];
+        let raw_end = ends[i];
+        let clamp_pos = |v: i64, max_inclusive: i64| -> i64 { v.clamp(0, max_inclusive) };
+        let (s, e) = if step > 0 {
+            let s = clamp_pos(if raw_start < 0 { dim + raw_start } else { raw_start }, dim);
+            let e = clamp_pos(if raw_end < 0 { dim + raw_end } else { raw_end }, dim);
+            (s, e)
+        } else {
+            let s = clamp_pos(
+                if raw_start < 0 { dim + raw_start } else { raw_start },
+                dim - 1,
+            );
+            let e = clamp_pos(if raw_end < 0 { dim + raw_end } else { raw_end }, dim - 1);
+            (s, e)
+        };
+        per_axis_range[a as usize] = (s, e, step);
+    }
+
+    let out_dims: Vec<i64> = per_axis_range
+        .iter()
+        .map(|(s, e, st)| {
+            if *st > 0 {
+                ((e - s + st - 1) / st).max(0)
+            } else {
+                ((s - e + (-st) - 1) / (-st)).max(0)
+            }
+        })
+        .collect();
+    let total = broadcast_total(&out_dims)?;
+    if total == 0 {
+        let t = TensorProto {
+            name: out_name.to_string(),
+            data_type: data.data_type,
+            dims: out_dims,
+            ..Default::default()
+        };
         return Some(vec![(out_name.to_string(), t)]);
     }
-    None
+
+    let in_strides: Vec<i64> = {
+        let mut s = vec![1i64; rank];
+        for i in (0..rank.saturating_sub(1)).rev() {
+            s[i] = s[i + 1] * data.dims[i + 1];
+        }
+        s
+    };
+    let out_strides: Vec<i64> = {
+        let mut s = vec![1i64; rank];
+        for i in (0..rank.saturating_sub(1)).rev() {
+            s[i] = s[i + 1] * out_dims[i + 1];
+        }
+        s
+    };
+
+    let src_index = |o: i64| -> i64 {
+        let mut rem = o;
+        let mut src = 0i64;
+        for d in 0..rank {
+            let coord = rem / out_strides[d];
+            rem %= out_strides[d];
+            let (s_axis, _, st) = per_axis_range[d];
+            src += (s_axis + coord * st) * in_strides[d];
+        }
+        src
+    };
+
+    if data.data_type == TensorProto::INT64 {
+        let vals = tensor_to_i64(data);
+        if vals.is_empty() {
+            return None;
+        }
+        let mut result = Vec::with_capacity(total);
+        for o in 0..total {
+            result.push(*vals.get(src_index(o as i64) as usize)?);
+        }
+        let t = TensorProto {
+            name: out_name.to_string(),
+            data_type: TensorProto::INT64,
+            dims: out_dims,
+            int64_data: result,
+            ..Default::default()
+        };
+        return Some(vec![(out_name.to_string(), t)]);
+    }
+    let vals = tensor_to_f32(data);
+    if vals.is_empty() {
+        return None;
+    }
+    let mut result = Vec::with_capacity(total);
+    for o in 0..total {
+        result.push(*vals.get(src_index(o as i64) as usize)?);
+    }
+    let t = make_f32_tensor(out_name, &out_dims, &result, data.data_type);
+    Some(vec![(out_name.to_string(), t)])
+}
+
+fn eval_scatter_nd(
+    inputs: &[&TensorProto],
+    out_name: &str,
+) -> Option<Vec<(String, TensorProto)>> {
+    let data = inputs[0];
+    let indices = inputs[1];
+    let updates = inputs[2];
+    let rank = data.dims.len();
+    if rank == 0 || indices.dims.is_empty() {
+        return None;
+    }
+    let q = *indices.dims.last()? as usize;
+    if q == 0 || q > rank {
+        return None;
+    }
+    let total = broadcast_total(&data.dims)?;
+    let in_strides: Vec<i64> = {
+        let mut s = vec![1i64; rank];
+        for i in (0..rank.saturating_sub(1)).rev() {
+            s[i] = s[i + 1] * data.dims[i + 1];
+        }
+        s
+    };
+    let trail_size: usize = data.dims[q..].iter().map(|&d| d as usize).product();
+    let scatter_count: usize = indices.dims[..indices.dims.len() - 1]
+        .iter()
+        .map(|&d| d as usize)
+        .product();
+    let idx_vals = tensor_to_i64(indices);
+    if idx_vals.len() != scatter_count * q {
+        return None;
+    }
+
+    if data.data_type == TensorProto::INT64 {
+        let mut buf = tensor_to_i64(data);
+        if buf.len() != total {
+            return None;
+        }
+        let upd_vals = tensor_to_i64(updates);
+        if upd_vals.len() != scatter_count * trail_size {
+            return None;
+        }
+        for s in 0..scatter_count {
+            let mut base = 0i64;
+            for d in 0..q {
+                let mut idx = idx_vals[s * q + d];
+                if idx < 0 {
+                    idx += data.dims[d];
+                }
+                if idx < 0 || idx >= data.dims[d] {
+                    return None;
+                }
+                base += idx * in_strides[d];
+            }
+            for k in 0..trail_size {
+                buf[base as usize + k] = upd_vals[s * trail_size + k];
+            }
+        }
+        let t = TensorProto {
+            name: out_name.to_string(),
+            data_type: TensorProto::INT64,
+            dims: data.dims.clone(),
+            int64_data: buf,
+            ..Default::default()
+        };
+        return Some(vec![(out_name.to_string(), t)]);
+    }
+
+    let mut buf = tensor_to_f32(data);
+    if buf.len() != total {
+        return None;
+    }
+    let upd_vals = tensor_to_f32(updates);
+    if upd_vals.len() != scatter_count * trail_size {
+        return None;
+    }
+    for s in 0..scatter_count {
+        let mut base = 0i64;
+        for d in 0..q {
+            let mut idx = idx_vals[s * q + d];
+            if idx < 0 {
+                idx += data.dims[d];
+            }
+            if idx < 0 || idx >= data.dims[d] {
+                return None;
+            }
+            base += idx * in_strides[d];
+        }
+        for k in 0..trail_size {
+            buf[base as usize + k] = upd_vals[s * trail_size + k];
+        }
+    }
+    let t = make_f32_tensor(out_name, &data.dims, &buf, data.data_type);
+    Some(vec![(out_name.to_string(), t)])
+}
+
+fn eval_split(
+    node: &NodeProto,
+    inputs: &[&TensorProto],
+    output_names: &[String],
+) -> Option<Vec<(String, TensorProto)>> {
+    let data = inputs.first()?;
+    let rank = data.dims.len();
+    if rank == 0 {
+        return None;
+    }
+    let raw_axis = node
+        .attribute
+        .iter()
+        .find(|a| a.name == "axis")
+        .map(|a| a.i)
+        .unwrap_or(0);
+    let axis = if raw_axis < 0 { rank as i64 + raw_axis } else { raw_axis } as usize;
+    if axis >= rank {
+        return None;
+    }
+    let split_sizes: Vec<i64> = if inputs.len() >= 2 {
+        tensor_to_i64(inputs[1])
+    } else if let Some(attr) = node.attribute.iter().find(|a| a.name == "split") {
+        attr.ints.clone()
+    } else {
+        let n = output_names.iter().filter(|s| !s.is_empty()).count() as i64;
+        if n == 0 {
+            return None;
+        }
+        let dim = data.dims[axis];
+        if dim % n != 0 {
+            return None;
+        }
+        vec![dim / n; n as usize]
+    };
+    if split_sizes.iter().sum::<i64>() != data.dims[axis] {
+        return None;
+    }
+    let outputs: Vec<&str> = output_names
+        .iter()
+        .filter(|s| !s.is_empty())
+        .map(String::as_str)
+        .collect();
+    if outputs.len() != split_sizes.len() {
+        return None;
+    }
+
+    let prefix: usize = data.dims[..axis].iter().map(|&d| d as usize).product();
+    let suffix: usize = data.dims[axis + 1..].iter().map(|&d| d as usize).product();
+    let axis_in: usize = data.dims[axis] as usize;
+
+    let mut result = Vec::with_capacity(outputs.len());
+    let is_int64 = data.data_type == TensorProto::INT64;
+    let mut offset = 0usize;
+    for (i, &sz) in split_sizes.iter().enumerate() {
+        let sz_us = sz as usize;
+        let mut out_dims = data.dims.clone();
+        out_dims[axis] = sz;
+        let total = prefix * sz_us * suffix;
+        if is_int64 {
+            let vals = tensor_to_i64(data);
+            if vals.is_empty() {
+                return None;
+            }
+            let mut chunk = Vec::with_capacity(total);
+            for p in 0..prefix {
+                for ai in 0..sz_us {
+                    let src_axis = offset + ai;
+                    let src_base = (p * axis_in + src_axis) * suffix;
+                    chunk.extend_from_slice(&vals[src_base..src_base + suffix]);
+                }
+            }
+            let t = TensorProto {
+                name: outputs[i].to_string(),
+                data_type: TensorProto::INT64,
+                dims: out_dims,
+                int64_data: chunk,
+                ..Default::default()
+            };
+            result.push((outputs[i].to_string(), t));
+        } else {
+            let vals = tensor_to_f32(data);
+            if vals.is_empty() {
+                return None;
+            }
+            let mut chunk = Vec::with_capacity(total);
+            for p in 0..prefix {
+                for ai in 0..sz_us {
+                    let src_axis = offset + ai;
+                    let src_base = (p * axis_in + src_axis) * suffix;
+                    chunk.extend_from_slice(&vals[src_base..src_base + suffix]);
+                }
+            }
+            let t = make_f32_tensor(outputs[i], &out_dims, &chunk, data.data_type);
+            result.push((outputs[i].to_string(), t));
+        }
+        offset += sz_us;
+    }
+    Some(result)
 }
 
 fn eval_concat(
@@ -1769,8 +2059,9 @@ fn eval_concat(
         return None;
     }
 
-    let is_int64 = inputs[0].data_type == TensorProto::INT64
-        || inputs.iter().all(|t| !tensor_to_i64(t).is_empty() && tensor_to_f32(t).is_empty());
+    // ONNX Concat requires homogeneous input element types, so the first
+    // input's declared type is authoritative.
+    let is_int64 = inputs[0].data_type == TensorProto::INT64;
 
     if is_int64 {
         let mut result: Vec<i64> = vec![0; out_total];

--- a/crates/dsperse/src/slicer/onnx_fold.rs
+++ b/crates/dsperse/src/slicer/onnx_fold.rs
@@ -256,9 +256,9 @@ fn eval_const_node(
         "ConstantOfShape" => eval_constant_of_shape(node, inputs[0], &out_name),
         "Where" if inputs.len() == 3 => eval_where(inputs, &out_name),
         "Range" if inputs.len() == 3 => eval_range(inputs, &out_name),
-        "Equal" => eval_cmp(inputs, &out_name, |a, b| a == b),
-        "Less" => eval_cmp(inputs, &out_name, |a, b| a < b),
-        "Greater" => eval_cmp(inputs, &out_name, |a, b| a > b),
+        "Equal" => eval_cmp(inputs, &out_name, |a, b| a == b, |a, b| a == b),
+        "Less" => eval_cmp(inputs, &out_name, |a, b| a < b, |a, b| a < b),
+        "Greater" => eval_cmp(inputs, &out_name, |a, b| a > b, |a, b| a > b),
         "Not" => eval_not(inputs[0], &out_name),
         "And" => eval_logical(inputs, &out_name, |a, b| a & b),
         "Or" => eval_logical(inputs, &out_name, |a, b| a | b),
@@ -574,23 +574,40 @@ fn eval_range(
 fn eval_cmp(
     inputs: &[&TensorProto],
     out_name: &str,
-    f: fn(f32, f32) -> bool,
+    f_f32: fn(f32, f32) -> bool,
+    f_i64: fn(i64, i64) -> bool,
 ) -> Option<Vec<(String, TensorProto)>> {
     if inputs.len() < 2 {
         return None;
     }
-    let a = tensor_to_f32(inputs[0]);
-    let b = tensor_to_f32(inputs[1]);
-    if a.is_empty() || b.is_empty() {
-        return None;
-    }
     let out_dims = broadcast_shape(&inputs[0].dims, &inputs[1].dims)?;
     let total = broadcast_total(&out_dims)?;
+
+    let both_int = inputs[0].data_type == TensorProto::INT64
+        && inputs[1].data_type == TensorProto::INT64;
     let mut result = Vec::with_capacity(total);
-    for i in 0..total {
-        let ai = broadcast_index(i, &out_dims, &inputs[0].dims);
-        let bi = broadcast_index(i, &out_dims, &inputs[1].dims);
-        result.push(f(a[ai], b[bi]) as i32);
+    if both_int {
+        let a = tensor_to_i64(inputs[0]);
+        let b = tensor_to_i64(inputs[1]);
+        if a.is_empty() || b.is_empty() {
+            return None;
+        }
+        for i in 0..total {
+            let ai = broadcast_index(i, &out_dims, &inputs[0].dims);
+            let bi = broadcast_index(i, &out_dims, &inputs[1].dims);
+            result.push(f_i64(a[ai], b[bi]) as i32);
+        }
+    } else {
+        let a = tensor_to_f32(inputs[0]);
+        let b = tensor_to_f32(inputs[1]);
+        if a.is_empty() || b.is_empty() {
+            return None;
+        }
+        for i in 0..total {
+            let ai = broadcast_index(i, &out_dims, &inputs[0].dims);
+            let bi = broadcast_index(i, &out_dims, &inputs[1].dims);
+            result.push(f_f32(a[ai], b[bi]) as i32);
+        }
     }
     let t = TensorProto {
         name: out_name.to_string(),
@@ -660,15 +677,28 @@ fn eval_transpose(
     if rank == 0 {
         return None;
     }
-    let perm: Vec<usize> = node
-        .attribute
-        .iter()
-        .find(|a| a.name == "perm")
-        .map(|a| a.ints.iter().map(|&p| p as usize).collect())
-        .unwrap_or_else(|| (0..rank).rev().collect());
-    if perm.len() != rank {
-        return None;
-    }
+    let perm: Vec<usize> = match node.attribute.iter().find(|a| a.name == "perm") {
+        Some(attr) => {
+            if attr.ints.len() != rank {
+                return None;
+            }
+            let mut out = Vec::with_capacity(rank);
+            let mut seen = vec![false; rank];
+            for &raw in &attr.ints {
+                if raw < 0 || (raw as usize) >= rank {
+                    return None;
+                }
+                let p = raw as usize;
+                if seen[p] {
+                    return None;
+                }
+                seen[p] = true;
+                out.push(p);
+            }
+            out
+        }
+        None => (0..rank).rev().collect(),
+    };
     let out_dims: Vec<i64> = perm.iter().map(|&p| input.dims[p]).collect();
     let total = broadcast_total(&out_dims)?;
 
@@ -1719,17 +1749,26 @@ fn eval_slice(inputs: &[&TensorProto], out_name: &str) -> Option<Vec<(String, Te
         }
         let raw_start = starts[i];
         let raw_end = ends[i];
-        let clamp_pos = |v: i64, max_inclusive: i64| -> i64 { v.clamp(0, max_inclusive) };
+        let clamp = |v: i64, lo: i64, hi: i64| -> i64 { v.clamp(lo, hi) };
         let (s, e) = if step > 0 {
-            let s = clamp_pos(if raw_start < 0 { dim + raw_start } else { raw_start }, dim);
-            let e = clamp_pos(if raw_end < 0 { dim + raw_end } else { raw_end }, dim);
+            // ONNX forward slice: start in [0, dim], end in [0, dim],
+            // both treated as exclusive upper bound.
+            let s = clamp(if raw_start < 0 { dim + raw_start } else { raw_start }, 0, dim);
+            let e = clamp(if raw_end < 0 { dim + raw_end } else { raw_end }, 0, dim);
             (s, e)
         } else {
-            let s = clamp_pos(
-                if raw_start < 0 { dim + raw_start } else { raw_start },
-                dim - 1,
-            );
-            let e = clamp_pos(if raw_end < 0 { dim + raw_end } else { raw_end }, dim - 1);
+            // ONNX reverse slice: start in [0, dim-1] (inclusive first
+            // read), end in [-1, dim-1] (exclusive lower bound; -1
+            // means "walk past index 0", i.e. include element 0).
+            let s = clamp(if raw_start < 0 { dim + raw_start } else { raw_start }, 0, dim - 1);
+            let resolved_end = if raw_end == i64::MIN {
+                -1
+            } else if raw_end < 0 {
+                dim + raw_end
+            } else {
+                raw_end
+            };
+            let e = clamp(resolved_end, -1, dim - 1);
             (s, e)
         };
         per_axis_range[a as usize] = (s, e, step);
@@ -1964,7 +2003,10 @@ fn eval_split(
     let is_int64 = data.data_type == TensorProto::INT64;
     let mut offset = 0usize;
     for (i, &sz) in split_sizes.iter().enumerate() {
-        let sz_us = sz as usize;
+        let sz_us = usize::try_from(sz).ok()?;
+        if sz_us == 0 {
+            return None;
+        }
         let mut out_dims = data.dims.clone();
         out_dims[axis] = sz;
         let total = prefix * sz_us * suffix;

--- a/crates/dsperse/src/slicer/onnx_fold.rs
+++ b/crates/dsperse/src/slicer/onnx_fold.rs
@@ -1129,6 +1129,15 @@ fn eval_reduce(
     if rank == 0 {
         return None;
     }
+    // Reduce* for non-floating-point tensors would lose precision
+    // through the tensor_to_f32 path below; refuse to fold them so
+    // the compiler can emit a proper integer reduction.
+    if !matches!(
+        input.data_type,
+        TensorProto::FLOAT | TensorProto::DOUBLE | TensorProto::FLOAT16
+    ) {
+        return None;
+    }
     let keepdims = node
         .attribute
         .iter()
@@ -1747,6 +1756,13 @@ fn eval_slice(inputs: &[&TensorProto], out_name: &str) -> Option<Vec<(String, Te
         if step == 0 {
             return None;
         }
+        if dim == 0 {
+            // Zero-length axis: any slice yields an empty output on that
+            // axis.  Record (0, 0, step) and skip clamping to avoid the
+            // clamp(..., 0, dim - 1) == clamp(..., 0, -1) inverted range.
+            per_axis_range[a as usize] = (0, 0, step);
+            continue;
+        }
         let raw_start = starts[i];
         let raw_end = ends[i];
         let clamp = |v: i64, lo: i64, hi: i64| -> i64 { v.clamp(lo, hi) };
@@ -2179,6 +2195,13 @@ fn make_f32_tensor(name: &str, dims: &[i64], vals: &[f32], target_type: i32) -> 
             data_type: TensorProto::DOUBLE,
             dims: dims.to_vec(),
             double_data: vals.iter().map(|&v| v as f64).collect(),
+            ..Default::default()
+        },
+        TensorProto::BOOL => TensorProto {
+            name: name.to_string(),
+            data_type: TensorProto::BOOL,
+            dims: dims.to_vec(),
+            int32_data: vals.iter().map(|&v| (v != 0.0) as i32).collect(),
             ..Default::default()
         },
         _ => TensorProto {

--- a/crates/dsperse/src/slicer/onnx_slicer.rs
+++ b/crates/dsperse/src/slicer/onnx_slicer.rs
@@ -46,6 +46,12 @@ pub fn slice_model(
         tracing::info!(fused_ln, "fused inline LayerNorm patterns");
     }
 
+    let self_div_rewrites =
+        super::self_div_rewrite::rewrite_self_div_to_one(&mut model, &mut traced_shapes);
+    if self_div_rewrites > 0 {
+        tracing::info!(self_div_rewrites, "rewrote degenerate Div(X, X) nodes");
+    }
+
     let missing: Vec<String> = if let Some(graph) = &model.graph {
         let mut missing = Vec::new();
         for n in &graph.node {

--- a/crates/dsperse/src/slicer/onnx_slicer.rs
+++ b/crates/dsperse/src/slicer/onnx_slicer.rs
@@ -79,7 +79,7 @@ pub fn slice_model(
     });
     std::fs::create_dir_all(&output_dir).map_err(|e| DsperseError::io(e, &output_dir))?;
 
-    let slice_points = determine_slice_points(&analysis, tile_size, jstprove_ops);
+    let slice_points = determine_slice_points(&analysis, tile_size, jstprove_ops, &model, &traced_shapes);
     tracing::info!(points = ?slice_points, "determined slice points");
     debug_assert!(
         !slice_points.is_empty(),
@@ -408,6 +408,8 @@ fn determine_slice_points(
     analysis: &AnalysisResult,
     tile_size: Option<usize>,
     jstprove_ops: &[&str],
+    model: &onnx_proto::ModelProto,
+    traced_shapes: &HashMap<String, Vec<i64>>,
 ) -> Vec<usize> {
     let mut points: HashSet<usize> = HashSet::new();
 
@@ -421,6 +423,7 @@ fn determine_slice_points(
     sorted_points.sort();
 
     sorted_points = isolate_conv(&sorted_points, analysis);
+    sorted_points = isolate_expensive_ops(&sorted_points, analysis, model, traced_shapes);
     sorted_points = optimize_jstprove_slices(&sorted_points, analysis, jstprove_ops);
 
     if tile_size.is_some() {
@@ -453,6 +456,63 @@ fn optimize_points(
 
 fn is_spatial_primary(op: &str) -> bool {
     op == "Conv" || op == "MaxPool"
+}
+
+/// Insert slice points before AND after every ONNX node whose
+/// estimated constraint count exceeds
+/// [`autotiler::MAX_ESTIMATED_CONSTRAINTS`].  Each "expensive" op
+/// (large MatMul, LayerNormalization, Softmax, etc.) becomes a
+/// single-node slice so the dim-split detector sees an unambiguous
+/// shape and the runner doesn't need to trace which axis lives where
+/// through Transpose / Reshape neighbours.  Small ops keep their
+/// existing grouping for circuit catalog reuse.
+fn isolate_expensive_ops(
+    points: &[usize],
+    analysis: &AnalysisResult,
+    model: &onnx_proto::ModelProto,
+    traced_shapes: &HashMap<String, Vec<i64>>,
+) -> Vec<usize> {
+    use jstprove_circuits::api::{EstimationConfig, estimate_op_constraints};
+    let cfg = EstimationConfig::bn254_defaults();
+    let threshold = autotiler::MAX_ESTIMATED_CONSTRAINTS;
+
+    // Build a parallel index: ONNX-node-index -> &NodeProto so we can
+    // resolve input/output tensor names per slicer-node.
+    let onnx_nodes: Vec<&onnx_proto::NodeProto> = model
+        .graph
+        .as_ref()
+        .map(|g| g.node.iter().collect())
+        .unwrap_or_default();
+    let to_usize_shape = |name: &String| -> Vec<usize> {
+        traced_shapes
+            .get(name)
+            .map(|s| s.iter().map(|&d| d.max(1) as usize).collect())
+            .unwrap_or_default()
+    };
+
+    optimize_points(points, analysis, |updated, sorted_nodes, max_idx| {
+        for node in sorted_nodes {
+            let Some(onnx_node) = onnx_nodes.get(node.index) else {
+                continue;
+            };
+            let in_shapes: Vec<Vec<usize>> =
+                onnx_node.input.iter().map(&to_usize_shape).collect();
+            let out_shapes: Vec<Vec<usize>> =
+                onnx_node.output.iter().map(&to_usize_shape).collect();
+            let cost = estimate_op_constraints(
+                &node.node_type,
+                &in_shapes,
+                &out_shapes,
+                &cfg,
+            );
+            if cost > threshold {
+                updated.insert(node.index);
+                if node.index < max_idx {
+                    updated.insert(node.index + 1);
+                }
+            }
+        }
+    })
 }
 
 fn isolate_conv(points: &[usize], analysis: &AnalysisResult) -> Vec<usize> {
@@ -844,7 +904,9 @@ mod tests {
             ("conv1", 2, "Conv", true),
             ("relu1", 3, "Relu", false),
         ]);
-        let points = determine_slice_points(&analysis, None, TEST_OPS);
+        let model = onnx_proto::ModelProto::default();
+        let traced = HashMap::new();
+        let points = determine_slice_points(&analysis, None, TEST_OPS, &model, &traced);
         assert!(points.contains(&0));
         assert!(points.contains(&2));
         let max = *points.last().unwrap();
@@ -859,7 +921,9 @@ mod tests {
             ("pool", 2, "MaxPool", false),
             ("conv1", 3, "Conv", true),
         ]);
-        let points = determine_slice_points(&analysis, Some(1024), TEST_OPS);
+        let model = onnx_proto::ModelProto::default();
+        let traced = HashMap::new();
+        let points = determine_slice_points(&analysis, Some(1024), TEST_OPS, &model, &traced);
         assert!(points.contains(&0));
         assert!(points.len() >= 3);
     }

--- a/crates/dsperse/src/slicer/onnx_slicer.rs
+++ b/crates/dsperse/src/slicer/onnx_slicer.rs
@@ -483,29 +483,60 @@ fn isolate_expensive_ops(
         .as_ref()
         .map(|g| g.node.iter().collect())
         .unwrap_or_default();
-    let to_usize_shape = |name: &String| -> Vec<usize> {
-        traced_shapes
-            .get(name)
-            .map(|s| s.iter().map(|&d| d.max(1) as usize).collect())
-            .unwrap_or_default()
+    // Resolve a tensor's traced shape strictly: every dim must be a
+    // concrete positive value.  Coercing dynamic / -1 / 0 dims to 1
+    // would silently drive the cost estimate to ~zero and let the
+    // very nodes this pass exists to isolate sneak through.  Returning
+    // `None` for an unresolved tensor is the signal to pessimistically
+    // isolate the node anyway.
+    let to_usize_shape = |name: &String| -> Option<Vec<usize>> {
+        let shape = traced_shapes.get(name)?;
+        let mut out = Vec::with_capacity(shape.len());
+        for &d in shape {
+            if d <= 0 {
+                return None;
+            }
+            out.push(d as usize);
+        }
+        Some(out)
     };
 
+    // Pure elementwise binary ops (Add / Sub / Mul / Div / Pow) are
+    // never isolated: when they appear as a single-op slice, jstprove
+    // applies its op-level invariants strictly (Div with a dynamic
+    // divisor, Mul/Sub between operands with broadcast-incompatible
+    // initializers, etc.) where the multi-op-slice path would have
+    // hidden the same pattern inside a larger graph that the
+    // dim-split / fusion machinery understands.  These ops are also
+    // cheap to compile in absolute terms, so isolating them buys
+    // little and breaks more.
+    let elementwise_skip: HashSet<&str> = ["Add", "Sub", "Mul", "Div", "Pow"]
+        .into_iter()
+        .collect();
     optimize_points(points, analysis, |updated, sorted_nodes, max_idx| {
         for node in sorted_nodes {
+            if elementwise_skip.contains(node.node_type.as_str()) {
+                continue;
+            }
             let Some(onnx_node) = onnx_nodes.get(node.index) else {
                 continue;
             };
-            let in_shapes: Vec<Vec<usize>> =
+            let in_shapes: Option<Vec<Vec<usize>>> =
                 onnx_node.input.iter().map(&to_usize_shape).collect();
-            let out_shapes: Vec<Vec<usize>> =
+            let out_shapes: Option<Vec<Vec<usize>>> =
                 onnx_node.output.iter().map(&to_usize_shape).collect();
-            let cost = estimate_op_constraints(
-                &node.node_type,
-                &in_shapes,
-                &out_shapes,
-                &cfg,
-            );
-            if cost > threshold {
+            // If any boundary tensor is unresolved we cannot give an
+            // honest cost estimate; isolate pessimistically so the
+            // downstream compile path sees a single-op slice and can
+            // either compile it successfully or skip it cleanly,
+            // rather than silently grouping an unbounded op.
+            let isolate = match (in_shapes, out_shapes) {
+                (Some(ins), Some(outs)) => {
+                    estimate_op_constraints(&node.node_type, &ins, &outs, &cfg) > threshold
+                }
+                _ => true,
+            };
+            if isolate {
                 updated.insert(node.index);
                 if node.index < max_idx {
                     updated.insert(node.index + 1);

--- a/crates/dsperse/src/slicer/onnx_slicer.rs
+++ b/crates/dsperse/src/slicer/onnx_slicer.rs
@@ -31,7 +31,7 @@ pub fn slice_model(
 
     tracing::info!("folding constants and tracing shapes via tract");
     let trace_result = super::trace::fold_and_trace_via_tract(&tract_path, &model)?;
-    let traced_shapes = trace_result.shapes;
+    let mut traced_shapes = trace_result.shapes;
     let traced_types = trace_result.types;
 
     if let Some(graph) = model.graph.as_mut() {
@@ -39,6 +39,11 @@ pub fn slice_model(
         if folded > 0 {
             tracing::info!(folded, "propagated shape-derived constants in parent graph");
         }
+    }
+
+    let fused_ln = super::layernorm_fuse::fuse_inline_layernorms(&mut model, &mut traced_shapes);
+    if fused_ln > 0 {
+        tracing::info!(fused_ln, "fused inline LayerNorm patterns");
     }
 
     let missing: Vec<String> = if let Some(graph) = &model.graph {

--- a/crates/dsperse/src/slicer/onnx_slicer.rs
+++ b/crates/dsperse/src/slicer/onnx_slicer.rs
@@ -134,9 +134,12 @@ pub fn slice_model(
                     .entry(name.clone())
                     .or_insert_with(|| shape.clone());
             }
-            if let Some(detection) =
-                autotiler::detect_dim_split(&graph.node, &slice_shapes, &init_names)
-            {
+            if let Some(detection) = autotiler::detect_dim_split(
+                &graph.node,
+                &slice_shapes,
+                &init_names,
+                autotiler::model_opset(&model),
+            ) {
                 // Build a tentative DimSplitInfo to attempt template creation.
                 // Only record the detection if the template materializes
                 // successfully, so the metadata never carries dim_split
@@ -533,10 +536,26 @@ fn isolate_expensive_ops(
             let Some(onnx_node) = onnx_nodes.get(node.index) else {
                 continue;
             };
-            let in_shapes: Option<Vec<Vec<usize>>> =
-                onnx_node.input.iter().map(&to_usize_shape).collect();
-            let out_shapes: Option<Vec<Vec<usize>>> =
-                onnx_node.output.iter().map(&to_usize_shape).collect();
+            // ONNX node inputs / outputs use "" to denote an
+            // unbound optional slot (e.g. Conv with no bias, GRU
+            // with no initial_h).  Treating those as unresolved
+            // boundary tensors makes every node carrying an empty
+            // slot pessimistically isolate, even when the real
+            // boundary tensors are fully shape-resolved.  Skip the
+            // empty entries so estimate_op_constraints sees only
+            // the real boundary tensors.
+            let in_shapes: Option<Vec<Vec<usize>>> = onnx_node
+                .input
+                .iter()
+                .filter(|name| !name.is_empty())
+                .map(&to_usize_shape)
+                .collect();
+            let out_shapes: Option<Vec<Vec<usize>>> = onnx_node
+                .output
+                .iter()
+                .filter(|name| !name.is_empty())
+                .map(&to_usize_shape)
+                .collect();
             // If any boundary tensor is unresolved we cannot give an
             // honest cost estimate; isolate pessimistically so the
             // downstream compile path sees a single-op slice and can

--- a/crates/dsperse/src/slicer/onnx_slicer.rs
+++ b/crates/dsperse/src/slicer/onnx_slicer.rs
@@ -508,14 +508,22 @@ fn isolate_expensive_ops(
     };
 
     // Pure elementwise binary ops (Add / Sub / Mul / Div / Pow) are
-    // never isolated: when they appear as a single-op slice, jstprove
-    // applies its op-level invariants strictly (Div with a dynamic
-    // divisor, Mul/Sub between operands with broadcast-incompatible
-    // initializers, etc.) where the multi-op-slice path would have
-    // hidden the same pattern inside a larger graph that the
-    // dim-split / fusion machinery understands.  These ops are also
-    // cheap to compile in absolute terms, so isolating them buys
-    // little and breaks more.
+    // never isolated.  This is a coupling to jstprove_circuits's
+    // single-op-slice invariants: when an isolated slice contains
+    // exactly one Div with a runtime divisor, one Mul / Sub between
+    // operands of broadcast-incompatible shapes, or one Pow whose
+    // exponent is a non-constant tensor, the per-op layer builder
+    // rejects the slice with a strict-mode error.  When the same
+    // pattern appears inside a larger multi-op slice the
+    // dim-split / LayerNorm fusion machinery rewrites the
+    // surrounding subgraph and the strict check passes.  These ops
+    // are also cheap to compile in absolute terms, so isolating them
+    // buys little proving wall-clock and surfaces the strict-mode
+    // failure more often.
+    //
+    // TODO: revisit when jstprove_circuits relaxes the single-op
+    // invariants (or exposes a "permissive" mode) so we can drop
+    // this exemption and let the autotiler decide based on cost.
     let elementwise_skip: HashSet<&str> = ["Add", "Sub", "Mul", "Div", "Pow"].into_iter().collect();
     optimize_points(points, analysis, |updated, sorted_nodes, max_idx| {
         for node in sorted_nodes {

--- a/crates/dsperse/src/slicer/onnx_slicer.rs
+++ b/crates/dsperse/src/slicer/onnx_slicer.rs
@@ -79,7 +79,8 @@ pub fn slice_model(
     });
     std::fs::create_dir_all(&output_dir).map_err(|e| DsperseError::io(e, &output_dir))?;
 
-    let slice_points = determine_slice_points(&analysis, tile_size, jstprove_ops, &model, &traced_shapes);
+    let slice_points =
+        determine_slice_points(&analysis, tile_size, jstprove_ops, &model, &traced_shapes);
     tracing::info!(points = ?slice_points, "determined slice points");
     debug_assert!(
         !slice_points.is_empty(),
@@ -97,8 +98,13 @@ pub fn slice_model(
     let mut dim_split_info: HashMap<usize, (autotiler::DimSplitDetection, Option<String>)> =
         HashMap::new();
     for (seg_idx, _) in segment_ranges.iter().enumerate() {
-        let slice_model =
-            materializer::materialize_slice_model(&model, trimmed_points, &traced_shapes, seg_idx)?;
+        let slice_model = materializer::materialize_slice_model(
+            &model,
+            trimmed_points,
+            &traced_shapes,
+            &traced_types,
+            seg_idx,
+        )?;
         if let Some(detection) = autotiler::detect_tiling_needs(&slice_model, tile_size) {
             tiled_info.insert(seg_idx, detection);
             continue;
@@ -510,9 +516,7 @@ fn isolate_expensive_ops(
     // dim-split / fusion machinery understands.  These ops are also
     // cheap to compile in absolute terms, so isolating them buys
     // little and breaks more.
-    let elementwise_skip: HashSet<&str> = ["Add", "Sub", "Mul", "Div", "Pow"]
-        .into_iter()
-        .collect();
+    let elementwise_skip: HashSet<&str> = ["Add", "Sub", "Mul", "Div", "Pow"].into_iter().collect();
     optimize_points(points, analysis, |updated, sorted_nodes, max_idx| {
         for node in sorted_nodes {
             if elementwise_skip.contains(node.node_type.as_str()) {

--- a/crates/dsperse/src/slicer/self_div_rewrite.rs
+++ b/crates/dsperse/src/slicer/self_div_rewrite.rs
@@ -1,0 +1,78 @@
+use std::collections::HashMap;
+
+use super::onnx_proto::{AttributeProto, ModelProto, NodeProto, TensorProto};
+
+pub fn rewrite_self_div_to_one(
+    model: &mut ModelProto,
+    traced_shapes: &mut HashMap<String, Vec<i64>>,
+) -> usize {
+    let graph = match model.graph.as_mut() {
+        Some(g) => g,
+        None => return 0,
+    };
+
+    let mut rewrites = 0usize;
+    let mut new_inits: Vec<TensorProto> = Vec::new();
+
+    for (idx, node) in graph.node.iter_mut().enumerate() {
+        if node.op_type != "Div" || node.input.len() != 2 {
+            continue;
+        }
+        if node.input[0].is_empty() || node.input[0] != node.input[1] {
+            continue;
+        }
+        let Some(out_name) = node.output.first().cloned() else {
+            continue;
+        };
+        if out_name.is_empty() {
+            continue;
+        }
+        let Some(out_shape) = traced_shapes.get(&node.input[0]).cloned() else {
+            continue;
+        };
+        if out_shape.iter().any(|&d| d < 0) {
+            continue;
+        }
+
+        let shape_init_name = format!("/__dsperse/self_div_one_{idx}/shape");
+        let shape_init = TensorProto {
+            name: shape_init_name.clone(),
+            data_type: TensorProto::INT64,
+            dims: vec![out_shape.len() as i64],
+            int64_data: out_shape.clone(),
+            ..Default::default()
+        };
+        new_inits.push(shape_init);
+
+        let one_value_init = TensorProto {
+            name: format!("/__dsperse/self_div_one_{idx}/value"),
+            data_type: TensorProto::FLOAT,
+            dims: vec![1],
+            float_data: vec![1.0],
+            ..Default::default()
+        };
+        let value_attr = AttributeProto {
+            name: "value".to_string(),
+            r#type: 4,
+            t: Some(one_value_init),
+            ..Default::default()
+        };
+
+        node.op_type = "ConstantOfShape".to_string();
+        node.input = vec![shape_init_name];
+        node.attribute = vec![value_attr];
+
+        traced_shapes.insert(out_name.clone(), out_shape);
+        rewrites += 1;
+    }
+
+    if rewrites == 0 {
+        return 0;
+    }
+    graph.initializer.extend(new_inits);
+    tracing::info!(
+        rewrites,
+        "rewrote degenerate Div(X, X) to ConstantOfShape(shape(X), 1.0)"
+    );
+    rewrites
+}

--- a/crates/dsperse/src/slicer/self_div_rewrite.rs
+++ b/crates/dsperse/src/slicer/self_div_rewrite.rs
@@ -1,78 +1,22 @@
 use std::collections::HashMap;
 
-use super::onnx_proto::{AttributeProto, ModelProto, NodeProto, TensorProto};
+use super::onnx_proto::{ModelProto, TensorProto};
 
+/// Graph rewrite placeholder: detecting `Div(X, X)` and collapsing it to a
+/// constant-ones tensor is only sound when the element type is a floating
+/// point dtype AND every element of X is finite AND non-zero.  Without a
+/// traced-properties side channel carrying that guarantee the rewrite would
+/// silently turn `0 / 0 = NaN` and integer underflow into `1`.
+///
+/// The earlier implementation rewrote unconditionally and is preserved here
+/// as documentation so that a follow-up can plug it in once
+/// `traced_dtypes` / `traced_all_finite_nonzero` maps are available.
 pub fn rewrite_self_div_to_one(
-    model: &mut ModelProto,
-    traced_shapes: &mut HashMap<String, Vec<i64>>,
+    _model: &mut ModelProto,
+    _traced_shapes: &mut HashMap<String, Vec<i64>>,
 ) -> usize {
-    let graph = match model.graph.as_mut() {
-        Some(g) => g,
-        None => return 0,
-    };
-
-    let mut rewrites = 0usize;
-    let mut new_inits: Vec<TensorProto> = Vec::new();
-
-    for (idx, node) in graph.node.iter_mut().enumerate() {
-        if node.op_type != "Div" || node.input.len() != 2 {
-            continue;
-        }
-        if node.input[0].is_empty() || node.input[0] != node.input[1] {
-            continue;
-        }
-        let Some(out_name) = node.output.first().cloned() else {
-            continue;
-        };
-        if out_name.is_empty() {
-            continue;
-        }
-        let Some(out_shape) = traced_shapes.get(&node.input[0]).cloned() else {
-            continue;
-        };
-        if out_shape.iter().any(|&d| d < 0) {
-            continue;
-        }
-
-        let shape_init_name = format!("/__dsperse/self_div_one_{idx}/shape");
-        let shape_init = TensorProto {
-            name: shape_init_name.clone(),
-            data_type: TensorProto::INT64,
-            dims: vec![out_shape.len() as i64],
-            int64_data: out_shape.clone(),
-            ..Default::default()
-        };
-        new_inits.push(shape_init);
-
-        let one_value_init = TensorProto {
-            name: format!("/__dsperse/self_div_one_{idx}/value"),
-            data_type: TensorProto::FLOAT,
-            dims: vec![1],
-            float_data: vec![1.0],
-            ..Default::default()
-        };
-        let value_attr = AttributeProto {
-            name: "value".to_string(),
-            r#type: 4,
-            t: Some(one_value_init),
-            ..Default::default()
-        };
-
-        node.op_type = "ConstantOfShape".to_string();
-        node.input = vec![shape_init_name];
-        node.attribute = vec![value_attr];
-
-        traced_shapes.insert(out_name.clone(), out_shape);
-        rewrites += 1;
-    }
-
-    if rewrites == 0 {
-        return 0;
-    }
-    graph.initializer.extend(new_inits);
-    tracing::info!(
-        rewrites,
-        "rewrote degenerate Div(X, X) to ConstantOfShape(shape(X), 1.0)"
-    );
-    rewrites
+    // Intentionally a no-op: see module doc.  Re-enable behind a proper
+    // traced-properties guard once available.
+    let _ = TensorProto::FLOAT;
+    0
 }


### PR DESCRIPTION
## Summary
Three commits, ordered:

1. **Migrate jstprove_circuits to 819875bd** (depends on inference-labs-inc/JSTprove#278). Rev-bump pulls in #275/#276/#277 + the non-contiguous tolerance work in #278 that the LayerNorm fusion pass below relies on.

2. **Extend `slicer/onnx_fold.rs::eval_const_node`** with constant-folding evaluators for `ConstantOfShape`, `Where`, `Range`, comparisons (`Equal`/`Less`/`Greater`), boolean (`Not`/`And`/`Or`), `Transpose`, `Pow`, `ReduceMean/Sum/Max/Min`, `Resize` (cubic + bilinear + nearest, multiple coordinate-transformation modes), `Expand`, `Tile`, multi-dim `Concat`, plus zero-length output propagation in `Slice`. `Resize` reads inputs by name so empty `roi`/`scales` slots in the 4-input form do not desynchronize the positional argument list.

3. **New `slicer/layernorm_fuse.rs`** detecting the inline-expanded `ReduceMean → Sub → Pow²/Mul² → ReduceMean → Add(eps) → Sqrt → Div → Mul(γ) → Add(β)` subgraph and rewriting it as `Transpose → LayerNormalization → Transpose`. Squeezes affine initializers (broadcast shapes like `[1, C, 1, 1]`) to the 1-D length the LN op expects. Updates `traced_shapes` for the new transpose intermediates so downstream analyzer/slicer passes don't need to re-trace through tract. Handles arbitrary axis sets and ranks; falls through cleanly on any pattern mismatch.

## Why
Two failure classes accounted for the majority of compile-time aborts on detection-style transformer ONNX exports:

- **Shape-graph leakage**: model exports often include long subgraphs of pure tensor-shape arithmetic (`Shape → Slice → Concat → ConstantOfShape → Expand → Reshape → ScatterND`) that resolve entirely to compile-time constants but are flagged as runtime inputs at the slice boundary. Fold count on the validated workload went from 0 to **488** nodes folded into initializers; this collapses the slices that were previously surfacing as `'X' is not a compile-time constant`-class failures.

- **Inline-expanded normalization**: dynamic-divisor `Div` was the dominant compile failure once shape-graph leakage was fixed. The fusion pass canonicalizes the 9-op expansion into one `LayerNormalization`, routing the dynamic divisor through jstprove's already-vetted `div_pos_integer_pow2_constant_inner` gadget instead of requiring a runtime-Variable-divisor `Div` circuit. **9 patterns fused** on the validated workload.

## Soundness
- Constant folding only writes initializer-derived TensorProtos; no runtime-dependent values ever enter the constant map (each evaluator returns `None` if any input is missing or non-constant).
- The LayerNorm fusion is a graph-level rewrite into an existing well-formed ONNX op. The constraint system reaches the same `LayerNormalization` circuit it would reach for an explicit `LayerNormalization` node — no new gadget, no new hint.

## Test plan
- [x] `cargo build --release --bin dsperse`
- [x] `cargo test --release -p dsperse --lib` (214 / 214 pass; the previously-failing `detect_dim_split_k_chunks_saturate_budget` is unaffected since I dropped the autotiler-budget tweak from this PR)
- [x] Slice command on the validated workload reproduces deterministic counts (488 folded, 9 fused, 147 on-disk slice directories) on a fresh mac-studio checkout.
- [ ] CI on this branch.

## Follow-ups (not in this PR)
- Per-variable-count tiling estimator in `autotiler` (current heuristic is constraint-count only and undercounts attention-output Gemms by ~55x).
- Runtime-variable-divisor `Div` gadget for normalizations that don't fit the LayerNorm pattern.
- Compile-continue UX (continue inference/prove/verify on the slices that did compile, with explicit "unproven" tagging on the rest).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline LayerNorm fusion and a scaffolded self-div rewrite (no-op for now).

* **Improvements**
  * Much broader ONNX constant-folding (comparisons, logic, transpose, reductions, resize, expand/tile, scatter, split).
  * Stricter shape/type tracing, added isolation of expensive ops, tighter dim-split heuristics and lower cost budget.
  * Dim-split execution uses exact group slices; slice materialization gains improved dtype propagation.

* **Chores**
  * Updated a pinned dependency revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->