### PR TITLE
Introduce model-declared input dtype handling in ONNX backend

### DIFF
--- a/crates/dsperse/src/backend/onnx.rs
+++ b/crates/dsperse/src/backend/onnx.rs
@@ -63,12 +63,15 @@ fn resolve_concrete_shape(model: &InferenceModel, input_shape: &[usize]) -> Resu
     Ok(input_shape.to_vec())
 }
 
-fn resolve_input_datum_type(model: &InferenceModel, idx: usize) -> DatumType {
-    model
+fn resolve_input_datum_type(model: &InferenceModel, idx: usize) -> Result<DatumType> {
+    let fact = model
         .input_fact(idx)
-        .ok()
-        .and_then(|f| f.datum_type.concretize())
-        .unwrap_or_else(f32::datum_type)
+        .map_err(|e| DsperseError::Onnx(format!("input fact at index {idx}: {e}")))?;
+    fact.datum_type.concretize().ok_or_else(|| {
+        DsperseError::Onnx(format!(
+            "input fact at index {idx} has no concrete datum type; the model must declare a concrete element type for this input"
+        ))
+    })
 }
 
 fn optimize_to_runnable(
@@ -92,7 +95,7 @@ pub fn run_inference_with_coercion(
 ) -> Result<NamedOutputs> {
     let model = load_onnx_model(onnx_path)?;
     let concrete_shape = resolve_concrete_shape(&model, input_shape)?;
-    let input_dt = resolve_input_datum_type(&model, 0);
+    let input_dt = resolve_input_datum_type(&model, 0)?;
 
     if let Ok(plan) = optimize_to_runnable(model, &concrete_shape, input_dt) {
         let input = build_input_tvalue(input_data, &concrete_shape, input_dt)?;
@@ -157,42 +160,118 @@ fn load_runnable(
 ) -> Result<(Arc<TypedRunnableModel>, Vec<usize>, DatumType)> {
     let model = load_onnx_model(onnx_path)?;
     let concrete_shape = resolve_concrete_shape(&model, input_shape)?;
-    let input_dt = resolve_input_datum_type(&model, 0);
+    let input_dt = resolve_input_datum_type(&model, 0)?;
     let plan = optimize_to_runnable(model, &concrete_shape, input_dt)?;
     Ok((plan, concrete_shape, input_dt))
 }
 
+const I64_SAFE_BOUND_F64: f64 = I64_SAFE_BOUND as f64;
+
+fn reject_non_finite(v: f64, idx: usize, type_name: &str) -> Result<()> {
+    if !v.is_finite() {
+        return Err(DsperseError::Onnx(format!(
+            "input[{idx}] = {v}: non-finite values are not accepted for {type_name} inputs"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_integer_input(
+    v: f64,
+    idx: usize,
+    type_name: &str,
+    type_min: f64,
+    type_max: f64,
+) -> Result<()> {
+    reject_non_finite(v, idx, type_name)?;
+    if v.trunc() != v {
+        return Err(DsperseError::Onnx(format!(
+            "input[{idx}] = {v}: fractional component cannot be represented as {type_name}"
+        )));
+    }
+    if v.abs() >= I64_SAFE_BOUND_F64 {
+        return Err(DsperseError::Onnx(format!(
+            "input[{idx}] = {v}: magnitude exceeds IEEE-754 safe integer bound {I64_SAFE_BOUND}"
+        )));
+    }
+    if v < type_min || v > type_max {
+        return Err(DsperseError::Onnx(format!(
+            "input[{idx}] = {v}: outside representable range [{type_min}, {type_max}] for {type_name}"
+        )));
+    }
+    Ok(())
+}
+
 fn build_input_tvalue(input_data: &[f64], shape: &[usize], dt: DatumType) -> Result<TValue> {
-    macro_rules! build_numeric {
-        ($t:ty) => {{
-            let data: Vec<$t> = input_data.iter().map(|&v| v as $t).collect();
+    macro_rules! build_float {
+        ($t:ty, $name:expr) => {{
+            let mut data: Vec<$t> = Vec::with_capacity(input_data.len());
+            for (i, &v) in input_data.iter().enumerate() {
+                reject_non_finite(v, i, $name)?;
+                data.push(v as $t);
+            }
+            tract_ndarray::ArrayD::from_shape_vec(IxDyn(shape), data)
+                .map(|a| a.into_tvalue())
+                .map_err(|e| DsperseError::Onnx(format!("input tensor: {e}")))
+        }};
+    }
+    macro_rules! build_bounded_int {
+        ($t:ty, $name:expr, $min:expr, $max:expr) => {{
+            let mut data: Vec<$t> = Vec::with_capacity(input_data.len());
+            for (i, &v) in input_data.iter().enumerate() {
+                validate_integer_input(v, i, $name, $min as f64, $max as f64)?;
+                data.push(v as $t);
+            }
             tract_ndarray::ArrayD::from_shape_vec(IxDyn(shape), data)
                 .map(|a| a.into_tvalue())
                 .map_err(|e| DsperseError::Onnx(format!("input tensor: {e}")))
         }};
     }
     if dt == f32::datum_type() {
-        build_numeric!(f32)
+        build_float!(f32, "f32")
     } else if dt == f64::datum_type() {
-        build_numeric!(f64)
+        build_float!(f64, "f64")
     } else if dt == u8::datum_type() {
-        build_numeric!(u8)
+        build_bounded_int!(u8, "u8", u8::MIN, u8::MAX)
     } else if dt == i8::datum_type() {
-        build_numeric!(i8)
+        build_bounded_int!(i8, "i8", i8::MIN, i8::MAX)
     } else if dt == u16::datum_type() {
-        build_numeric!(u16)
+        build_bounded_int!(u16, "u16", u16::MIN, u16::MAX)
     } else if dt == i16::datum_type() {
-        build_numeric!(i16)
+        build_bounded_int!(i16, "i16", i16::MIN, i16::MAX)
     } else if dt == u32::datum_type() {
-        build_numeric!(u32)
+        build_bounded_int!(u32, "u32", u32::MIN, u32::MAX)
     } else if dt == i32::datum_type() {
-        build_numeric!(i32)
+        build_bounded_int!(i32, "i32", i32::MIN, i32::MAX)
     } else if dt == u64::datum_type() {
-        build_numeric!(u64)
+        let mut data: Vec<u64> = Vec::with_capacity(input_data.len());
+        for (i, &v) in input_data.iter().enumerate() {
+            validate_integer_input(v, i, "u64", 0.0, I64_SAFE_BOUND_F64)?;
+            data.push(v as u64);
+        }
+        tract_ndarray::ArrayD::from_shape_vec(IxDyn(shape), data)
+            .map(|a| a.into_tvalue())
+            .map_err(|e| DsperseError::Onnx(format!("input tensor: {e}")))
     } else if dt == i64::datum_type() {
-        build_numeric!(i64)
+        let mut data: Vec<i64> = Vec::with_capacity(input_data.len());
+        for (i, &v) in input_data.iter().enumerate() {
+            validate_integer_input(v, i, "i64", -I64_SAFE_BOUND_F64, I64_SAFE_BOUND_F64)?;
+            data.push(v as i64);
+        }
+        tract_ndarray::ArrayD::from_shape_vec(IxDyn(shape), data)
+            .map(|a| a.into_tvalue())
+            .map_err(|e| DsperseError::Onnx(format!("input tensor: {e}")))
     } else if dt == bool::datum_type() {
-        let data: Vec<bool> = input_data.iter().map(|&v| v != 0.0).collect();
+        let mut data: Vec<bool> = Vec::with_capacity(input_data.len());
+        for (i, &v) in input_data.iter().enumerate() {
+            reject_non_finite(v, i, "bool")?;
+            if v != 0.0 && v != 1.0 {
+                return Err(DsperseError::Onnx(format!(
+                    "input[{i}] = {v}: bool inputs must be exactly 0 or 1"
+                )));
+            }
+            data.push(v != 0.0);
+        }
         tract_ndarray::ArrayD::from_shape_vec(IxDyn(shape), data)
             .map(|a| a.into_tvalue())
             .map_err(|e| DsperseError::Onnx(format!("input tensor: {e}")))
@@ -254,7 +333,7 @@ pub fn run_inference_named(
     let model = load_onnx_model(onnx_path)?;
     let output_names = collect_output_names(&model);
     let concrete_shape = resolve_concrete_shape(&model, input_shape)?;
-    let input_dt = resolve_input_datum_type(&model, 0);
+    let input_dt = resolve_input_datum_type(&model, 0)?;
     match optimize_to_runnable(model, &concrete_shape, input_dt) {
         Ok(plan) => {
             let result = run_single(&plan, input_data, &concrete_shape, input_dt)?;
@@ -319,7 +398,7 @@ fn run_multi_inner(
     let mut input_dts: Vec<DatumType> = vec![f32::datum_type(); model_input_count];
     for (i, name) in &model_input_names {
         if let Some(&provided_idx) = input_by_name.get(name.as_str()) {
-            let dt = resolve_input_datum_type(&model, *i);
+            let dt = resolve_input_datum_type(&model, *i)?;
             model = model
                 .with_input_fact(*i, InferenceFact::dt_shape(dt, &inputs[provided_idx].2))
                 .map_err(|e| DsperseError::Onnx(format!("set input {i} ({name}) shape: {e}")))?;
@@ -603,7 +682,7 @@ mod tests {
         let tv_i64 = build_input_tvalue(&values, &shape, i64::datum_type()).unwrap();
         assert_eq!(tv_i64.datum_type(), i64::datum_type());
 
-        let bool_vals = vec![0.0, 1.0, 0.0, 2.0, 0.0, 1.0];
+        let bool_vals = vec![0.0, 1.0, 0.0, 1.0, 0.0, 1.0];
         let tv_bool = build_input_tvalue(&bool_vals, &shape, bool::datum_type()).unwrap();
         assert_eq!(tv_bool.datum_type(), bool::datum_type());
         let view = tv_bool.to_plain_array_view::<bool>().unwrap();
@@ -614,5 +693,149 @@ mod tests {
 
         let unsupported = build_input_tvalue(&values, &shape, DatumType::String);
         assert!(unsupported.is_err());
+    }
+
+    #[test]
+    fn build_input_tvalue_rejects_non_finite() {
+        let shape = [3usize];
+        for dt in [
+            f32::datum_type(),
+            f64::datum_type(),
+            u8::datum_type(),
+            i64::datum_type(),
+            bool::datum_type(),
+        ] {
+            for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+                let err = build_input_tvalue(&[0.0, bad, 1.0], &shape, dt).unwrap_err();
+                let msg = format!("{err:?}");
+                assert!(
+                    msg.contains("non-finite"),
+                    "expected non-finite error for dt={dt:?} val={bad}, got {msg}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn build_input_tvalue_rejects_fractional_for_integer_dtypes() {
+        let shape = [2usize];
+        for dt in [
+            u8::datum_type(),
+            i8::datum_type(),
+            u32::datum_type(),
+            i32::datum_type(),
+            i64::datum_type(),
+            u64::datum_type(),
+        ] {
+            let err = build_input_tvalue(&[0.0, 1.5], &shape, dt).unwrap_err();
+            let msg = format!("{err:?}");
+            assert!(
+                msg.contains("fractional"),
+                "expected fractional error for dt={dt:?}, got {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn build_input_tvalue_rejects_out_of_range_for_integer_dtypes() {
+        let shape = [2usize];
+        let cases: &[(DatumType, f64)] = &[
+            (u8::datum_type(), 256.0),
+            (u8::datum_type(), -1.0),
+            (i8::datum_type(), 128.0),
+            (i8::datum_type(), -129.0),
+            (u16::datum_type(), -1.0),
+            (i16::datum_type(), 32_768.0),
+            (u32::datum_type(), -1.0),
+        ];
+        for (dt, bad) in cases.iter().copied() {
+            let err = build_input_tvalue(&[0.0, bad], &shape, dt).unwrap_err();
+            let msg = format!("{err:?}");
+            assert!(
+                msg.contains("outside"),
+                "expected range error for dt={dt:?} val={bad}, got {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn build_input_tvalue_rejects_i64_above_safe_integer_bound() {
+        let shape = [2usize];
+        let unsafe_hi = (I64_SAFE_BOUND as f64) + 1024.0;
+        let err = build_input_tvalue(&[0.0, unsafe_hi], &shape, i64::datum_type()).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("safe integer bound"),
+            "expected safe-integer-bound error, got {msg}"
+        );
+    }
+
+    #[test]
+    fn build_input_tvalue_rejects_non_boolean_for_bool_dtype() {
+        let shape = [2usize];
+        let err = build_input_tvalue(&[0.0, 2.0], &shape, bool::datum_type()).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("bool inputs must be exactly 0 or 1"),
+            "expected strict bool error, got {msg}"
+        );
+    }
+
+    fn write_uint8_cast_to_float_model(path: &Path) {
+        use crate::slicer::onnx_proto;
+        let input = onnx_proto::make_tensor_value_info("x", 2, &[3]); // 2 = UINT8
+        let output = onnx_proto::make_tensor_value_info("y", 1, &[3]); // 1 = FLOAT
+        let cast_to = onnx_proto::make_attribute_int("to", 1);
+        let node = onnx_proto::make_node(
+            "Cast",
+            vec!["x".to_string()],
+            vec!["y".to_string()],
+            vec![cast_to],
+        );
+        let graph = onnx_proto::make_graph("g", vec![node], vec![input], vec![output], vec![]);
+        let model = onnx_proto::make_model(graph, 13);
+        onnx_proto::save_model(&model, path).unwrap();
+    }
+
+    #[test]
+    fn warm_model_runs_non_f32_input_through_planner() {
+        let tmp = tempfile::tempdir().unwrap();
+        let onnx_path = tmp.path().join("u8_cast.onnx");
+        write_uint8_cast_to_float_model(&onnx_path);
+
+        let shape = [3usize];
+        let warm = WarmModel::load(&onnx_path, &shape).expect("WarmModel::load");
+        assert_eq!(warm.input_dt, u8::datum_type());
+        let (data, out_shape) = warm.run(&[0.0, 42.0, 255.0]).unwrap();
+        assert_eq!(out_shape, shape.to_vec());
+        assert_eq!(data, vec![0.0, 42.0, 255.0]);
+
+        // A second call with a value that can't round-trip through u8 must error
+        // from build_input_tvalue before the planner is invoked.
+        let err = warm.run(&[0.0, 256.0, 0.0]).unwrap_err();
+        assert!(format!("{err:?}").contains("outside"));
+    }
+
+    #[test]
+    fn run_inference_multi_honors_per_input_dtype() {
+        let tmp = tempfile::tempdir().unwrap();
+        let onnx_path = tmp.path().join("u8_cast.onnx");
+        write_uint8_cast_to_float_model(&onnx_path);
+
+        let inputs: Vec<(&str, Vec<f64>, Vec<usize>)> = vec![("x", vec![1.0, 2.0, 3.0], vec![3])];
+        let out = run_inference_multi_named(&onnx_path, &inputs).unwrap();
+        let (data, shape) = out.values().next().expect("at least one output");
+        assert_eq!(shape, &vec![3]);
+        assert_eq!(data, &vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn resolve_input_datum_type_reads_concrete_model_dtype() {
+        let tmp = tempfile::tempdir().unwrap();
+        let onnx_path = tmp.path().join("u8_cast.onnx");
+        write_uint8_cast_to_float_model(&onnx_path);
+        let model = load_onnx_model(&onnx_path).unwrap();
+        let dt = resolve_input_datum_type(&model, 0).unwrap();
+        assert_eq!(dt, u8::datum_type());
     }
 }

--- a/crates/dsperse/src/backend/onnx.rs
+++ b/crates/dsperse/src/backend/onnx.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use ndarray::IxDyn;
 use tract_onnx::prelude::*;
+use tract_onnx::tract_hir::infer::Factoid;
 
 use crate::error::{DsperseError, Result};
 
@@ -62,15 +63,21 @@ fn resolve_concrete_shape(model: &InferenceModel, input_shape: &[usize]) -> Resu
     Ok(input_shape.to_vec())
 }
 
+fn resolve_input_datum_type(model: &InferenceModel, idx: usize) -> DatumType {
+    model
+        .input_fact(idx)
+        .ok()
+        .and_then(|f| f.datum_type.concretize())
+        .unwrap_or_else(f32::datum_type)
+}
+
 fn optimize_to_runnable(
     model: InferenceModel,
     concrete_shape: &[usize],
+    input_dt: DatumType,
 ) -> Result<Arc<TypedRunnableModel>> {
     model
-        .with_input_fact(
-            0,
-            InferenceFact::dt_shape(f32::datum_type(), concrete_shape),
-        )
+        .with_input_fact(0, InferenceFact::dt_shape(input_dt, concrete_shape))
         .map_err(|e| DsperseError::Onnx(format!("set input shape: {e}")))?
         .into_optimized()
         .map_err(|e| DsperseError::Onnx(format!("optimize: {e:#}")))?
@@ -85,9 +92,10 @@ pub fn run_inference_with_coercion(
 ) -> Result<NamedOutputs> {
     let model = load_onnx_model(onnx_path)?;
     let concrete_shape = resolve_concrete_shape(&model, input_shape)?;
+    let input_dt = resolve_input_datum_type(&model, 0);
 
-    if let Ok(plan) = optimize_to_runnable(model, &concrete_shape) {
-        let input = build_input_tvalue(input_data, &concrete_shape)?;
+    if let Ok(plan) = optimize_to_runnable(model, &concrete_shape, input_dt) {
+        let input = build_input_tvalue(input_data, &concrete_shape, input_dt)?;
         let result = plan
             .run(tvec![input])
             .map_err(|e| DsperseError::Onnx(format!("run: {e:#}")))?;
@@ -97,10 +105,7 @@ pub fn run_inference_with_coercion(
     tracing::warn!("standard optimization failed; using inference plan with TDim coercion");
     let model2 = load_onnx_model(onnx_path)?;
     let with_shape = model2
-        .with_input_fact(
-            0,
-            InferenceFact::dt_shape(f32::datum_type(), &concrete_shape),
-        )
+        .with_input_fact(0, InferenceFact::dt_shape(input_dt, &concrete_shape))
         .map_err(|e| DsperseError::Onnx(format!("set input: {e}")))?;
 
     let plan =
@@ -109,7 +114,7 @@ pub fn run_inference_with_coercion(
     let mut state = tract_onnx::tract_core::plan::SimpleState::new(&plan)
         .map_err(|e| DsperseError::Onnx(format!("state: {e}")))?;
 
-    let input = build_input_tvalue(input_data, &concrete_shape)?;
+    let input = build_input_tvalue(input_data, &concrete_shape, input_dt)?;
     let result = state
         .run_plan_with_eval(tvec![input], |session, op_state, node, inputs| {
             let coerced = coerce_tdim_inputs(&inputs);
@@ -149,26 +154,62 @@ fn extract_all_outputs(result: &[TValue]) -> Result<NamedOutputs> {
 fn load_runnable(
     onnx_path: &Path,
     input_shape: &[usize],
-) -> Result<(Arc<TypedRunnableModel>, Vec<usize>)> {
+) -> Result<(Arc<TypedRunnableModel>, Vec<usize>, DatumType)> {
     let model = load_onnx_model(onnx_path)?;
     let concrete_shape = resolve_concrete_shape(&model, input_shape)?;
-    let plan = optimize_to_runnable(model, &concrete_shape)?;
-    Ok((plan, concrete_shape))
+    let input_dt = resolve_input_datum_type(&model, 0);
+    let plan = optimize_to_runnable(model, &concrete_shape, input_dt)?;
+    Ok((plan, concrete_shape, input_dt))
 }
 
-fn build_input_tvalue(input_data: &[f64], shape: &[usize]) -> Result<TValue> {
-    let input_f32: Vec<f32> = input_data.iter().map(|&v| v as f32).collect();
-    let tensor = tract_ndarray::ArrayD::from_shape_vec(IxDyn(shape), input_f32)
-        .map_err(|e| DsperseError::Onnx(format!("input tensor: {e}")))?;
-    Ok(tensor.into_tvalue())
+fn build_input_tvalue(input_data: &[f64], shape: &[usize], dt: DatumType) -> Result<TValue> {
+    macro_rules! build_numeric {
+        ($t:ty) => {{
+            let data: Vec<$t> = input_data.iter().map(|&v| v as $t).collect();
+            tract_ndarray::ArrayD::from_shape_vec(IxDyn(shape), data)
+                .map(|a| a.into_tvalue())
+                .map_err(|e| DsperseError::Onnx(format!("input tensor: {e}")))
+        }};
+    }
+    if dt == f32::datum_type() {
+        build_numeric!(f32)
+    } else if dt == f64::datum_type() {
+        build_numeric!(f64)
+    } else if dt == u8::datum_type() {
+        build_numeric!(u8)
+    } else if dt == i8::datum_type() {
+        build_numeric!(i8)
+    } else if dt == u16::datum_type() {
+        build_numeric!(u16)
+    } else if dt == i16::datum_type() {
+        build_numeric!(i16)
+    } else if dt == u32::datum_type() {
+        build_numeric!(u32)
+    } else if dt == i32::datum_type() {
+        build_numeric!(i32)
+    } else if dt == u64::datum_type() {
+        build_numeric!(u64)
+    } else if dt == i64::datum_type() {
+        build_numeric!(i64)
+    } else if dt == bool::datum_type() {
+        let data: Vec<bool> = input_data.iter().map(|&v| v != 0.0).collect();
+        tract_ndarray::ArrayD::from_shape_vec(IxDyn(shape), data)
+            .map(|a| a.into_tvalue())
+            .map_err(|e| DsperseError::Onnx(format!("input tensor: {e}")))
+    } else {
+        Err(DsperseError::Onnx(format!(
+            "unsupported input datum type {dt:?}"
+        )))
+    }
 }
 
 fn run_single(
     plan: &Arc<TypedRunnableModel>,
     input_data: &[f64],
     shape: &[usize],
+    dt: DatumType,
 ) -> Result<TVec<TValue>> {
-    let tv = build_input_tvalue(input_data, shape)?;
+    let tv = build_input_tvalue(input_data, shape, dt)?;
     plan.run(tvec!(tv))
         .map_err(|e| DsperseError::Onnx(format!("inference: {e}")))
 }
@@ -176,16 +217,21 @@ fn run_single(
 pub struct WarmModel {
     plan: Arc<TypedRunnableModel>,
     input_shape: Vec<usize>,
+    input_dt: DatumType,
 }
 
 impl WarmModel {
     pub fn load(onnx_path: &Path, input_shape: &[usize]) -> Result<Self> {
-        let (plan, input_shape) = load_runnable(onnx_path, input_shape)?;
-        Ok(Self { plan, input_shape })
+        let (plan, input_shape, input_dt) = load_runnable(onnx_path, input_shape)?;
+        Ok(Self {
+            plan,
+            input_shape,
+            input_dt,
+        })
     }
 
     pub fn run(&self, input_data: &[f64]) -> Result<(Vec<f64>, Vec<usize>)> {
-        let result = run_single(&self.plan, input_data, &self.input_shape)?;
+        let result = run_single(&self.plan, input_data, &self.input_shape, self.input_dt)?;
         extract_first_output(&result)
     }
 }
@@ -195,8 +241,8 @@ pub fn run_inference(
     input_data: &[f64],
     input_shape: &[usize],
 ) -> Result<(Vec<f64>, Vec<usize>)> {
-    let (plan, concrete_shape) = load_runnable(onnx_path, input_shape)?;
-    let result = run_single(&plan, input_data, &concrete_shape)?;
+    let (plan, concrete_shape, input_dt) = load_runnable(onnx_path, input_shape)?;
+    let result = run_single(&plan, input_data, &concrete_shape, input_dt)?;
     extract_first_output(&result)
 }
 
@@ -208,9 +254,10 @@ pub fn run_inference_named(
     let model = load_onnx_model(onnx_path)?;
     let output_names = collect_output_names(&model);
     let concrete_shape = resolve_concrete_shape(&model, input_shape)?;
-    match optimize_to_runnable(model, &concrete_shape) {
+    let input_dt = resolve_input_datum_type(&model, 0);
+    match optimize_to_runnable(model, &concrete_shape, input_dt) {
         Ok(plan) => {
-            let result = run_single(&plan, input_data, &concrete_shape)?;
+            let result = run_single(&plan, input_data, &concrete_shape, input_dt)?;
             zip_named_outputs(&output_names, &result)
         }
         Err(_) => {
@@ -269,15 +316,15 @@ fn run_multi_inner(
         .collect();
 
     let mut input_order: Vec<Option<usize>> = vec![None; model_input_count];
+    let mut input_dts: Vec<DatumType> = vec![f32::datum_type(); model_input_count];
     for (i, name) in &model_input_names {
         if let Some(&provided_idx) = input_by_name.get(name.as_str()) {
+            let dt = resolve_input_datum_type(&model, *i);
             model = model
-                .with_input_fact(
-                    *i,
-                    InferenceFact::dt_shape(f32::datum_type(), &inputs[provided_idx].2),
-                )
+                .with_input_fact(*i, InferenceFact::dt_shape(dt, &inputs[provided_idx].2))
                 .map_err(|e| DsperseError::Onnx(format!("set input {i} ({name}) shape: {e}")))?;
             input_order[*i] = Some(provided_idx);
+            input_dts[*i] = dt;
         }
     }
 
@@ -317,7 +364,7 @@ fn run_multi_inner(
             ))
         })?;
         let (_, ref data, ref shape) = inputs[provided_idx];
-        input_tvs.push(build_input_tvalue(data, shape)?);
+        input_tvs.push(build_input_tvalue(data, shape, input_dts[model_idx])?);
     }
 
     let result = model
@@ -539,5 +586,33 @@ mod tests {
     fn extract_first_output_empty() {
         let result = extract_first_output(&[]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn build_input_tvalue_respects_declared_dtypes() {
+        let shape = [2usize, 3];
+        let values: Vec<f64> = (0..6).map(|v| v as f64).collect();
+
+        let tv_f32 = build_input_tvalue(&values, &shape, f32::datum_type()).unwrap();
+        assert_eq!(tv_f32.datum_type(), f32::datum_type());
+        assert_eq!(tv_f32.shape(), &shape);
+
+        let tv_u8 = build_input_tvalue(&values, &shape, u8::datum_type()).unwrap();
+        assert_eq!(tv_u8.datum_type(), u8::datum_type());
+
+        let tv_i64 = build_input_tvalue(&values, &shape, i64::datum_type()).unwrap();
+        assert_eq!(tv_i64.datum_type(), i64::datum_type());
+
+        let bool_vals = vec![0.0, 1.0, 0.0, 2.0, 0.0, 1.0];
+        let tv_bool = build_input_tvalue(&bool_vals, &shape, bool::datum_type()).unwrap();
+        assert_eq!(tv_bool.datum_type(), bool::datum_type());
+        let view = tv_bool.to_plain_array_view::<bool>().unwrap();
+        assert_eq!(
+            view.iter().copied().collect::<Vec<_>>(),
+            vec![false, true, false, true, false, true]
+        );
+
+        let unsupported = build_input_tvalue(&values, &shape, DatumType::String);
+        assert!(unsupported.is_err());
     }
 }

--- a/crates/dsperse/src/backend/onnx.rs
+++ b/crates/dsperse/src/backend/onnx.rs
@@ -493,6 +493,15 @@ fn i64_to_f64_checked(v: i64, label: &str) -> Result<f64> {
     Ok(v as f64)
 }
 
+fn u64_to_f64_checked(v: u64, label: &str) -> Result<f64> {
+    if v >= I64_SAFE_BOUND as u64 {
+        return Err(DsperseError::Onnx(format!(
+            "{label}: u64 value {v} exceeds IEEE-754 safe integer bound"
+        )));
+    }
+    Ok(v as f64)
+}
+
 fn tvalue_to_f64(tv: &TValue, label: &str) -> Result<(Vec<f64>, Vec<usize>)> {
     let shape = tv.shape().to_vec();
     let dt = tv.datum_type();
@@ -518,6 +527,38 @@ fn tvalue_to_f64(tv: &TValue, label: &str) -> Result<(Vec<f64>, Vec<usize>)> {
             .to_plain_array_view::<i32>()
             .map_err(|e| DsperseError::Onnx(format!("{label}: {e}")))?;
         arr.iter().map(|&v| f64::from(v)).collect()
+    } else if dt == u32::datum_type() {
+        let arr = tv
+            .to_plain_array_view::<u32>()
+            .map_err(|e| DsperseError::Onnx(format!("{label}: {e}")))?;
+        arr.iter().map(|&v| f64::from(v)).collect()
+    } else if dt == i16::datum_type() {
+        let arr = tv
+            .to_plain_array_view::<i16>()
+            .map_err(|e| DsperseError::Onnx(format!("{label}: {e}")))?;
+        arr.iter().map(|&v| f64::from(v)).collect()
+    } else if dt == u16::datum_type() {
+        let arr = tv
+            .to_plain_array_view::<u16>()
+            .map_err(|e| DsperseError::Onnx(format!("{label}: {e}")))?;
+        arr.iter().map(|&v| f64::from(v)).collect()
+    } else if dt == i8::datum_type() {
+        let arr = tv
+            .to_plain_array_view::<i8>()
+            .map_err(|e| DsperseError::Onnx(format!("{label}: {e}")))?;
+        arr.iter().map(|&v| f64::from(v)).collect()
+    } else if dt == u8::datum_type() {
+        let arr = tv
+            .to_plain_array_view::<u8>()
+            .map_err(|e| DsperseError::Onnx(format!("{label}: {e}")))?;
+        arr.iter().map(|&v| f64::from(v)).collect()
+    } else if dt == u64::datum_type() {
+        let arr = tv
+            .to_plain_array_view::<u64>()
+            .map_err(|e| DsperseError::Onnx(format!("{label}: {e}")))?;
+        arr.iter()
+            .map(|&v| u64_to_f64_checked(v, label))
+            .collect::<Result<Vec<_>>>()?
     } else if dt == bool::datum_type() {
         let arr = tv
             .to_plain_array_view::<bool>()
@@ -831,6 +872,64 @@ mod tests {
         let graph = onnx_proto::make_graph("g", vec![node], vec![input], vec![output], vec![]);
         let model = onnx_proto::make_model(graph, 13);
         onnx_proto::save_model(&model, path).unwrap();
+    }
+
+    fn write_uint8_identity_model(path: &Path) {
+        use crate::slicer::onnx_proto;
+        let input = onnx_proto::make_tensor_value_info("x", 2, &[3]); // UINT8
+        let output = onnx_proto::make_tensor_value_info("y", 2, &[3]); // UINT8
+        let node = onnx_proto::make_node(
+            "Identity",
+            vec!["x".to_string()],
+            vec!["y".to_string()],
+            vec![],
+        );
+        let graph = onnx_proto::make_graph("g", vec![node], vec![input], vec![output], vec![]);
+        let model = onnx_proto::make_model(graph, 13);
+        onnx_proto::save_model(&model, path).unwrap();
+    }
+
+    #[test]
+    fn warm_model_decodes_uint8_output() {
+        let tmp = tempfile::tempdir().unwrap();
+        let onnx_path = tmp.path().join("u8_identity.onnx");
+        write_uint8_identity_model(&onnx_path);
+
+        let shape = [3usize];
+        let warm = WarmModel::load(&onnx_path, &shape).expect("WarmModel::load");
+        assert_eq!(warm.input_dt, u8::datum_type());
+        let (data, out_shape) = warm.run(&[0.0, 128.0, 255.0]).unwrap();
+        assert_eq!(out_shape, shape.to_vec());
+        assert_eq!(data, vec![0.0, 128.0, 255.0]);
+    }
+
+    #[test]
+    fn tvalue_to_f64_covers_added_integer_dtypes() {
+        fn tv_of<T: Datum>(values: &[T]) -> TValue {
+            let arr =
+                tract_ndarray::ArrayD::from_shape_vec(IxDyn(&[values.len()]), values.to_vec())
+                    .unwrap();
+            arr.into_tvalue()
+        }
+        let (d, s) = tvalue_to_f64(&tv_of::<u8>(&[0, 255]), "u8").unwrap();
+        assert_eq!((d, s), (vec![0.0, 255.0], vec![2]));
+        let (d, _) = tvalue_to_f64(&tv_of::<i8>(&[-128, 127]), "i8").unwrap();
+        assert_eq!(d, vec![-128.0, 127.0]);
+        let (d, _) = tvalue_to_f64(&tv_of::<u16>(&[0, 65_535]), "u16").unwrap();
+        assert_eq!(d, vec![0.0, 65_535.0]);
+        let (d, _) = tvalue_to_f64(&tv_of::<i16>(&[-32_768, 32_767]), "i16").unwrap();
+        assert_eq!(d, vec![-32_768.0, 32_767.0]);
+        let (d, _) = tvalue_to_f64(&tv_of::<u32>(&[0, u32::MAX]), "u32").unwrap();
+        assert_eq!(d, vec![0.0, u32::MAX as f64]);
+        let (d, _) = tvalue_to_f64(&tv_of::<u64>(&[0, 1_000_000]), "u64").unwrap();
+        assert_eq!(d, vec![0.0, 1_000_000.0]);
+
+        let unsafe_hi = (I64_SAFE_BOUND as u64) + 7;
+        let err = tvalue_to_f64(&tv_of::<u64>(&[unsafe_hi]), "u64").unwrap_err();
+        assert!(
+            format!("{err:?}").contains("safe integer bound"),
+            "expected u64 safe-bound error"
+        );
     }
 
     #[test]

--- a/crates/dsperse/src/backend/onnx.rs
+++ b/crates/dsperse/src/backend/onnx.rs
@@ -203,18 +203,7 @@ fn validate_integer_input(
 }
 
 fn build_input_tvalue(input_data: &[f64], shape: &[usize], dt: DatumType) -> Result<TValue> {
-    macro_rules! build_float {
-        ($t:ty, $name:expr) => {{
-            let mut data: Vec<$t> = Vec::with_capacity(input_data.len());
-            for (i, &v) in input_data.iter().enumerate() {
-                reject_non_finite(v, i, $name)?;
-                data.push(v as $t);
-            }
-            tract_ndarray::ArrayD::from_shape_vec(IxDyn(shape), data)
-                .map(|a| a.into_tvalue())
-                .map_err(|e| DsperseError::Onnx(format!("input tensor: {e}")))
-        }};
-    }
+    let f32_max_f64: f64 = f32::MAX as f64;
     macro_rules! build_bounded_int {
         ($t:ty, $name:expr, $min:expr, $max:expr) => {{
             let mut data: Vec<$t> = Vec::with_capacity(input_data.len());
@@ -228,9 +217,28 @@ fn build_input_tvalue(input_data: &[f64], shape: &[usize], dt: DatumType) -> Res
         }};
     }
     if dt == f32::datum_type() {
-        build_float!(f32, "f32")
+        let mut data: Vec<f32> = Vec::with_capacity(input_data.len());
+        for (i, &v) in input_data.iter().enumerate() {
+            reject_non_finite(v, i, "f32")?;
+            if v < -f32_max_f64 || v > f32_max_f64 {
+                return Err(DsperseError::Onnx(format!(
+                    "input[{i}] = {v}: magnitude exceeds representable f32 range [-{f32_max_f64}, {f32_max_f64}]"
+                )));
+            }
+            data.push(v as f32);
+        }
+        tract_ndarray::ArrayD::from_shape_vec(IxDyn(shape), data)
+            .map(|a| a.into_tvalue())
+            .map_err(|e| DsperseError::Onnx(format!("input tensor: {e}")))
     } else if dt == f64::datum_type() {
-        build_float!(f64, "f64")
+        let mut data: Vec<f64> = Vec::with_capacity(input_data.len());
+        for (i, &v) in input_data.iter().enumerate() {
+            reject_non_finite(v, i, "f64")?;
+            data.push(v);
+        }
+        tract_ndarray::ArrayD::from_shape_vec(IxDyn(shape), data)
+            .map(|a| a.into_tvalue())
+            .map_err(|e| DsperseError::Onnx(format!("input tensor: {e}")))
     } else if dt == u8::datum_type() {
         build_bounded_int!(u8, "u8", u8::MIN, u8::MAX)
     } else if dt == i8::datum_type() {
@@ -768,6 +776,28 @@ mod tests {
             msg.contains("safe integer bound"),
             "expected safe-integer-bound error, got {msg}"
         );
+    }
+
+    #[test]
+    fn build_input_tvalue_rejects_finite_f64_outside_f32_range() {
+        let shape = [2usize];
+        for bad in [1.0e40_f64, -1.0e40_f64] {
+            assert!(bad.is_finite());
+            let err = build_input_tvalue(&[0.0, bad], &shape, f32::datum_type()).unwrap_err();
+            let msg = format!("{err:?}");
+            assert!(
+                msg.contains("representable f32 range"),
+                "expected f32-range error for val={bad}, got {msg}"
+            );
+        }
+        let ok = build_input_tvalue(
+            &[0.0, f32::MAX as f64, -(f32::MAX as f64)],
+            &[3],
+            f32::datum_type(),
+        )
+        .unwrap();
+        let view = ok.to_plain_array_view::<f32>().unwrap();
+        assert!(view.iter().all(|v| v.is_finite()));
     }
 
     #[test]

--- a/crates/dsperse/src/backend/onnx.rs
+++ b/crates/dsperse/src/backend/onnx.rs
@@ -129,11 +129,19 @@ pub fn run_inference_with_coercion(
             match eval_result {
                 Ok(o) => Ok::<_, TractError>(o),
                 Err(e) => {
+                    let Some(first) = inputs.first() else {
+                        return Err(e);
+                    };
                     tracing::warn!(node = %node.name, error = %e, "eval failed, using fallback");
-                    let fallback = inputs
-                        .first()
-                        .cloned()
-                        .unwrap_or_else(|| Tensor::zero::<f32>(&[1]).unwrap().into_tvalue());
+                    let dt = first.datum_type();
+                    let fallback = Tensor::zero_dt(dt, &[1])
+                        .map_err(|alloc_err| {
+                            TractError::msg(format!(
+                                "node {}: eval failed ({e}); fallback allocation for dtype {dt:?} failed: {alloc_err}",
+                                node.name
+                            ))
+                        })?
+                        .into_tvalue();
                     let n = node.outputs.len().max(1);
                     Ok((0..n).map(|_| fallback.clone()).collect())
                 }
@@ -189,7 +197,7 @@ fn validate_integer_input(
             "input[{idx}] = {v}: fractional component cannot be represented as {type_name}"
         )));
     }
-    if v.abs() >= I64_SAFE_BOUND_F64 {
+    if v.abs() > I64_SAFE_BOUND_F64 {
         return Err(DsperseError::Onnx(format!(
             "input[{idx}] = {v}: magnitude exceeds IEEE-754 safe integer bound {I64_SAFE_BOUND}"
         )));
@@ -485,7 +493,7 @@ fn collect_output_names(model: &InferenceModel) -> Vec<String> {
 const I64_SAFE_BOUND: i64 = 9_007_199_254_740_992;
 
 fn i64_to_f64_checked(v: i64, label: &str) -> Result<f64> {
-    if v.abs() >= I64_SAFE_BOUND {
+    if v.abs() > I64_SAFE_BOUND {
         return Err(DsperseError::Onnx(format!(
             "{label}: i64 value {v} exceeds IEEE-754 safe integer bound"
         )));
@@ -494,7 +502,7 @@ fn i64_to_f64_checked(v: i64, label: &str) -> Result<f64> {
 }
 
 fn u64_to_f64_checked(v: u64, label: &str) -> Result<f64> {
-    if v >= I64_SAFE_BOUND as u64 {
+    if v > I64_SAFE_BOUND as u64 {
         return Err(DsperseError::Onnx(format!(
             "{label}: u64 value {v} exceeds IEEE-754 safe integer bound"
         )));
@@ -811,6 +819,26 @@ mod tests {
                 "expected range error for dt={dt:?} val={bad}, got {msg}"
             );
         }
+    }
+
+    #[test]
+    fn safe_integer_bound_is_inclusive_on_both_sides() {
+        let shape = [3usize];
+        let bound = I64_SAFE_BOUND as f64;
+        build_input_tvalue(&[0.0, bound, -bound], &shape, i64::datum_type())
+            .expect("i64 accepts +/- I64_SAFE_BOUND");
+        build_input_tvalue(&[0.0, bound, 1.0], &shape, u64::datum_type())
+            .expect("u64 accepts I64_SAFE_BOUND");
+
+        i64_to_f64_checked(I64_SAFE_BOUND, "i64")
+            .expect("i64_to_f64_checked accepts I64_SAFE_BOUND");
+        i64_to_f64_checked(-I64_SAFE_BOUND, "i64")
+            .expect("i64_to_f64_checked accepts -I64_SAFE_BOUND");
+        u64_to_f64_checked(I64_SAFE_BOUND as u64, "u64")
+            .expect("u64_to_f64_checked accepts I64_SAFE_BOUND");
+
+        assert!(i64_to_f64_checked(I64_SAFE_BOUND + 1, "i64").is_err());
+        assert!(u64_to_f64_checked(I64_SAFE_BOUND as u64 + 1, "u64").is_err());
     }
 
     #[test]

--- a/crates/dsperse/src/backend/onnx.rs
+++ b/crates/dsperse/src/backend/onnx.rs
@@ -403,7 +403,7 @@ fn run_multi_inner(
         .collect();
 
     let mut input_order: Vec<Option<usize>> = vec![None; model_input_count];
-    let mut input_dts: Vec<DatumType> = vec![f32::datum_type(); model_input_count];
+    let mut input_dts: Vec<Option<DatumType>> = vec![None; model_input_count];
     for (i, name) in &model_input_names {
         if let Some(&provided_idx) = input_by_name.get(name.as_str()) {
             let dt = resolve_input_datum_type(&model, *i)?;
@@ -411,7 +411,7 @@ fn run_multi_inner(
                 .with_input_fact(*i, InferenceFact::dt_shape(dt, &inputs[provided_idx].2))
                 .map_err(|e| DsperseError::Onnx(format!("set input {i} ({name}) shape: {e}")))?;
             input_order[*i] = Some(provided_idx);
-            input_dts[*i] = dt;
+            input_dts[*i] = Some(dt);
         }
     }
 
@@ -450,8 +450,14 @@ fn run_multi_inner(
                 "model input {model_idx} ('{name}') not matched to provided tensors"
             ))
         })?;
+        let dt = input_dts[model_idx].ok_or_else(|| {
+            let name = &model_input_names[model_idx].1;
+            DsperseError::Onnx(format!(
+                "model input {model_idx} ('{name}') has no resolved datum type"
+            ))
+        })?;
         let (_, ref data, ref shape) = inputs[provided_idx];
-        input_tvs.push(build_input_tvalue(data, shape, input_dts[model_idx])?);
+        input_tvs.push(build_input_tvalue(data, shape, dt)?);
     }
 
     let result = model


### PR DESCRIPTION
## Summary
- Replace the hard-coded `f32::datum_type()` input fact in the ONNX backend with a resolver that reads each model input's declared concrete dtype and plumbs it through tensor construction.
- Generalize `build_input_tvalue` to emit `u8`, `i8`, `u16`, `i16`, `u32`, `i32`, `u64`, `i64`, `f32`, `f64`, and `bool` tensors from the existing `f64` input payload, with an explicit error path for unsupported element types.
- Apply the same resolution to the coerced fallback plan and the multi-input runner so per-input dtypes are honored independently.

## Investigation
The prior backend forced every input to `f32`, which caused tract optimization to reject graphs whose first op consumed a non-`f32` tensor (e.g. a leading `Cast` from an integer input). Tracing the three call sites (`optimize_to_runnable`, `run_inference_with_coercion`, `run_multi_inner`) confirmed the override was consistent across all run paths. The model's `InferenceFact` already carries the concrete `DatumType` via the `Factoid` trait, so no new ONNX parsing was required.

## Test plan
- [x] `cargo check -p dsperse`
- [x] `cargo clippy -p dsperse --tests -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test -p dsperse --lib backend::onnx` — 7 passed including new `build_input_tvalue_respects_declared_dtypes`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full support for non-f32 model inputs (ints, doubles, bools); runtime preserves and uses each model-declared input type.

* **Bug Fixes**
  * Single- and multi-input ONNX models no longer assume f32 inputs; tensors are built and executed with correct dtypes.

* **Improvements**
  * Stricter input validation with clear errors for non-finite floats, fractional/out-of-range/unsafe integers, and strict boolean encodings.
  * Output conversion extended to additional integer dtypes with safety checks.

* **Tests**
  * Added tests covering dtype-respecting inputs, strict bools, invalid numeric rejection, dtype propagation, and end-to-end execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->