### PR TITLE
Resolve publisher component existence-check against file presence

### DIFF
--- a/crates/dsperse/src/pipeline/publisher.rs
+++ b/crates/dsperse/src/pipeline/publisher.rs
@@ -87,22 +87,67 @@ async fn publish_async(dir: &Path, config: &PublishConfig) -> Result<PublishResu
             .filter_map(|v| v.as_str().map(String::from))
             .collect();
 
-        let check = client
-            .get(format!("{api}/components/{sha}"))
-            .send()
-            .await
-            .map_err(|e| DsperseError::Other(format!("check component {sha}: {e}")))?;
+        // Verify the component by probing each file the manifest
+        // expects to live in blob storage, not by asking for a
+        // metadata row.  The registry registers the component row
+        // as soon as POST /admin/components returns, but the
+        // per-file PUTs against the pre-signed upload URLs happen
+        // afterwards -- any failure there (timeout, network blip,
+        // interrupted publish process) leaves the row present with
+        // no backing files.  A plain GET /components/{sha} sees the
+        // row and reports "exists, skipping", so every subsequent
+        // publish run re-skips the broken component and the model
+        // stays permanently half-uploaded from downstream
+        // consumers' perspective.
+        //
+        // Mirror the byte-level presence check weight-blob uploads
+        // below already use: HEAD each expected file by issuing a
+        // single-byte ranged GET to the blob path.  If every file
+        // is present, the component is genuinely done and we skip.
+        // If every file is missing, proceed to the normal
+        // register + upload path.  If the set is partially present
+        // (registered but mid-upload), surface an actionable error
+        // instead of silently continuing, because re-registering
+        // via POST /admin/components will 409 and the current flow
+        // has no way to request fresh upload URLs for that sha.
+        let mut present = 0usize;
+        let mut missing: Vec<String> = Vec::new();
+        for filename in &files {
+            let file_url = format!("{api}/components/{sha}/files/{filename}");
+            let probe = client
+                .get(&file_url)
+                .header("Range", "bytes=0-0")
+                .send()
+                .await
+                .map_err(|e| DsperseError::Other(format!("probe {sha}/{filename}: {e}")))?;
+            let status = probe.status();
+            if status.is_success() || status.as_u16() == 206 {
+                present += 1;
+            } else if status.as_u16() == 404 {
+                missing.push(filename.clone());
+            } else {
+                let text = probe.text().await.unwrap_or_default();
+                return Err(DsperseError::Other(format!(
+                    "probe component {sha}/{filename} returned unexpected status ({status}): {text}"
+                )));
+            }
+        }
 
-        if check.status().is_success() {
-            tracing::info!(sha = %sha, "component exists, skipping");
+        if missing.is_empty() && present == files.len() {
+            tracing::info!(sha = %sha, "component files present, skipping");
             components_skipped += 1;
             continue;
         }
-        if check.status().as_u16() != 404 {
-            let status = check.status();
-            let text = check.text().await.unwrap_or_default();
+        if present > 0 {
             return Err(DsperseError::Other(format!(
-                "probe component {sha} returned unexpected status ({status}): {text}"
+                "component {sha} is partially uploaded: {present}/{} files present, \
+                 missing: {:?}.  A previous publish registered the component row but \
+                 some PUTs did not complete.  Run \
+                 `curl -X DELETE -H 'Authorization: Bearer $REGISTRY_AUTH_TOKEN' \
+                 {api}/admin/components/{sha}` to drop the stale row, then re-run \
+                 publish so the full register + upload flow can replay for this sha.",
+                files.len(),
+                missing
             )));
         }
 

--- a/crates/dsperse/src/pipeline/publisher.rs
+++ b/crates/dsperse/src/pipeline/publisher.rs
@@ -110,6 +110,17 @@ async fn publish_async(dir: &Path, config: &PublishConfig) -> Result<PublishResu
         // instead of silently continuing, because re-registering
         // via POST /admin/components will 409 and the current flow
         // has no way to request fresh upload URLs for that sha.
+        // A manifest entry with zero files is malformed -- the
+        // empty-list case would otherwise make both
+        // `missing.is_empty()` and `present == files.len()` true
+        // below, silently classifying the component as present
+        // without any actual bytes verified.  Fail loud.
+        if files.is_empty() {
+            return Err(DsperseError::Other(format!(
+                "component {sha} has no files listed in the manifest; refusing to treat as present"
+            )));
+        }
+
         let mut present = 0usize;
         let mut missing: Vec<String> = Vec::new();
         for filename in &files {
@@ -120,16 +131,24 @@ async fn publish_async(dir: &Path, config: &PublishConfig) -> Result<PublishResu
                 .send()
                 .await
                 .map_err(|e| DsperseError::Other(format!("probe {sha}/{filename}: {e}")))?;
+            // A Range: bytes=0-0 GET against a blob path has two
+            // legitimate success replies: 206 (partial content,
+            // what the blob store returns when it honours the
+            // range) and 200 (full content, what it returns when
+            // it ignores the range for an empty body or tiny file).
+            // Any other 2xx (201 Created, 202 Accepted, 204 No
+            // Content) is ambiguous for a GET on a CAS path and
+            // should not be interpreted as "file present".
             let status = probe.status();
-            if status.is_success() || status.as_u16() == 206 {
-                present += 1;
-            } else if status.as_u16() == 404 {
-                missing.push(filename.clone());
-            } else {
-                let text = probe.text().await.unwrap_or_default();
-                return Err(DsperseError::Other(format!(
-                    "probe component {sha}/{filename} returned unexpected status ({status}): {text}"
-                )));
+            match status.as_u16() {
+                200 | 206 => present += 1,
+                404 => missing.push(filename.clone()),
+                _ => {
+                    let text = probe.text().await.unwrap_or_default();
+                    return Err(DsperseError::Other(format!(
+                        "probe component {sha}/{filename} returned unexpected status ({status}): {text}"
+                    )));
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- `publisher.rs:90` probes `GET /components/{sha}` to decide whether a component is already uploaded. That endpoint returns the metadata row, which the registry creates as soon as `POST /admin/components` returns the pre-signed upload URLs — **before** the per-file PUTs run. Any failure during the PUT stage (timeout, network blip, interrupted publish) leaves the row present with no backing files, and every subsequent `dsperse publish` run logs `component exists, skipping` and moves on, so the model stays permanently half-uploaded from the downstream consumer's perspective.
- The weight-blob path (`:208-215`) already does this correctly: a single-byte `Range: bytes=0-0` GET against the blob URL. Align the component path with that pattern.

## Concrete failure we ran into
- Model `33894054...` published via `dsperse publish --activate`. All but one of its 460 components uploaded cleanly; `slice_41` registered but its three files (`circuit.bin`, `manifest.msgpack`, `witness_solver.bin`) never landed in blob storage.
- Testnet validator's circuit refresh kept failing:
  ```
  WARN sn2_circuit_store: failed to load new circuit id="33894054..." error=downloading composable model
    0: downloading slice_41/circuit.bin
    1: download returned 404 Not Found
  ```
- `curl /components/{slice41_sha}` → 200 (row exists).
- `curl /components/{slice41_sha}/files/circuit.bin` → 404 (blob missing).
- Re-running `dsperse publish` re-logged "component exists, skipping" for slice_41 on every retry. No path to self-heal.

## Change
- Replace the single `GET /components/{sha}` probe with a per-file byte-level probe under `/components/{sha}/files/{filename}` — one `Range: bytes=0-0` GET per file in the manifest's `files` list. Three branches:
  - **All 200/206** → component genuinely complete, skip (same end state as before).
  - **All 404** → missing entirely, proceed to register + upload (same end state as before, but now keyed off actual file absence).
  - **Partial** (metadata row exists, some files uploaded, some missing) → return `DsperseError` naming the sha, the missing files, and the exact `curl -X DELETE -H 'Authorization: Bearer $REGISTRY_AUTH_TOKEN' {api}/admin/components/{sha}` to drop the stale row so the next publish can replay cleanly.
- Unexpected non-`(200|206|404)` statuses abort with the status + response body so transport-layer problems surface immediately instead of being misclassified as "present".

## Compatibility
- No behaviour change when every component is fully present or fully absent.
- The new "partial" arm is strictly additive — the old code hid that state; new code surfaces it with an actionable recovery step.
- Works with any registry that serves `/components/{sha}/files/{filename}` with standard Range support (what the validator's download path `sn2-circuit-store/src/lib.rs:793` already assumes).

## Test plan
- [x] `cargo fmt -p dsperse` clean.
- [x] `cargo clippy -p dsperse --no-deps -- -D warnings` clean.
- [ ] Manual: delete the broken `slice_41` registration on the testnet registry (`/admin/components/10436214421159217b57d4e3cdb85471323a320b37ef544d103cd362c414f0d7`), rerun `dsperse publish`, confirm the three missing files now upload and the validator's next refresh tick caches `33894054...` successfully.
- [ ] Manual regression: run `dsperse publish` against a fresh model, then re-run it — expect all components to log `component files present, skipping`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pre-upload presence checks to detect partial component uploads; now returns an explicit error for partially uploaded components with instructions to remove the stale record and retry.
  * Rejects manifests that list no files.
  * Skips upload only when all expected files are present; proceeds with register+upload when none are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->