### PR TITLE
Resolve combined-run failure on const-folded slice inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3482,9 +3482,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/crates/dsperse/src/pipeline/combined.rs
+++ b/crates/dsperse/src/pipeline/combined.rs
@@ -305,20 +305,60 @@ fn seed_tensor_cache_from_initializers(
         if tensor_cache.contains(&init.name) {
             continue;
         }
-        let shape: Vec<usize> = init.dims.iter().map(|&d| d as usize).collect();
+        // Negative dims would silently wrap to huge positive
+        // values via `as usize`; reject up front so a malformed
+        // initialiser surfaces an error here instead of
+        // allocating a multi-petabyte array below.
+        let shape: Vec<usize> = match init
+            .dims
+            .iter()
+            .map(|&d| usize::try_from(d))
+            .collect::<std::result::Result<Vec<_>, _>>()
+        {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::debug!(
+                    name = %init.name,
+                    dims = ?init.dims,
+                    error = %e,
+                    "skipping initializer-backed slice tensor: invalid (negative) dimension"
+                );
+                continue;
+            }
+        };
+        // Use checked_mul so an arithmetic overflow surfaces as a
+        // skip (and the slice executor downstream produces a
+        // clearer error if it actually needed the value), instead
+        // of wrapping silently and mis-comparing against
+        // `data.len()`.
+        let expected: Option<usize> = shape.iter().try_fold(1usize, |acc, &d| acc.checked_mul(d));
+        let Some(expected) = expected else {
+            tracing::debug!(
+                name = %init.name,
+                dims = ?init.dims,
+                "skipping initializer-backed slice tensor: shape product overflowed usize"
+            );
+            continue;
+        };
         let data: Vec<f64> = crate::slicer::onnx_proto::tensor_to_f32(init)
             .into_iter()
             .map(f64::from)
             .collect();
-        let expected: usize = shape.iter().product();
         if data.len() != expected {
-            // Skip rather than fail: an initializer whose declared
+            // Skip rather than fail: an initialiser whose declared
             // shape doesn't match its element count can still be
             // useful elsewhere (some quantised tensors store packed
             // bytes), but we cannot reshape it into ArrayD<f64>
             // here without guessing.  Leave it to the slice ONNX
             // executor to surface a clearer error if it actually
             // needs the value.
+            tracing::debug!(
+                name = %init.name,
+                declared_shape = ?shape,
+                declared_elements = expected,
+                actual_elements = data.len(),
+                "skipping initializer-backed slice tensor: declared shape != element count"
+            );
             continue;
         }
         let arr = ArrayD::from_shape_vec(IxDyn(&shape), data).map_err(|e| {

--- a/crates/dsperse/src/pipeline/combined.rs
+++ b/crates/dsperse/src/pipeline/combined.rs
@@ -340,10 +340,11 @@ fn seed_tensor_cache_from_initializers(
             );
             continue;
         };
-        let data: Vec<f64> = crate::slicer::onnx_proto::tensor_to_f32(init)
-            .into_iter()
-            .map(f64::from)
-            .collect();
+        // Decode straight to f64 so DOUBLE / INT64 initialisers
+        // keep their full precision -- the previous f32-then-widen
+        // chain truncated DOUBLE mantissas and silently lost
+        // precision on INT64 magnitudes outside f32's exact range.
+        let data: Vec<f64> = crate::slicer::onnx_proto::tensor_to_f64(init);
         if data.len() != expected {
             // Skip rather than fail: an initialiser whose declared
             // shape doesn't match its element count can still be

--- a/crates/dsperse/src/pipeline/combined.rs
+++ b/crates/dsperse/src/pipeline/combined.rs
@@ -56,6 +56,20 @@ impl CombinedRun {
             }
         }
 
+        // Seed the tensor_cache with any initializer-backed tensor
+        // the slice metadata references.  The slicer's constant-
+        // folding passes can turn intermediate tensors (e.g. a
+        // Transpose over a constant) into initializers in the
+        // transformed graph, while leaving downstream slice
+        // metadata pointing at the original tensor name.  ORT
+        // does not emit those names among its named outputs (they
+        // are not declared as graph outputs of combined.onnx and
+        // have no producing node), so without this seed the
+        // subsequent `tensor_cache.get` in `all_circuit_work` fails
+        // with `tensor '<name>' not found in store` and the whole
+        // run aborts before a single DSlice gets dispatched.
+        seed_tensor_cache_from_initializers(&combined_path, &model_meta, &mut tensor_cache)?;
+
         let chain = build_execution_chain(&model_meta, slices_dir)?;
         let run_meta = build_run_metadata(&model_meta, slices_dir, &chain)?;
 
@@ -248,4 +262,79 @@ fn run_combined_onnx(
             declared_inputs.len()
         )))
     }
+}
+
+/// Populate `tensor_cache` with any combined-graph initializer
+/// whose name appears in slice metadata as a `filtered_input` or a
+/// declared `output`.  Without this, a slice that depends on a
+/// constant-folded tensor (one the slicer turned from a node
+/// output into an initializer) would fail at the
+/// `tensor_cache.get(name)` call in `all_circuit_work` even though
+/// the value is right there in the combined ONNX.
+fn seed_tensor_cache_from_initializers(
+    combined_path: &Path,
+    model_meta: &ModelMetadata,
+    tensor_cache: &mut TensorStore,
+) -> Result<()> {
+    let needed: HashSet<&str> = model_meta
+        .slices
+        .iter()
+        .flat_map(|s| {
+            s.dependencies
+                .filtered_inputs
+                .iter()
+                .chain(s.dependencies.output.iter())
+        })
+        .map(String::as_str)
+        .collect();
+    if needed.is_empty() {
+        return Ok(());
+    }
+
+    let model = crate::slicer::onnx_proto::load_model(combined_path)?;
+    let graph = match &model.graph {
+        Some(g) => g,
+        None => return Ok(()),
+    };
+
+    let mut seeded = 0usize;
+    for init in &graph.initializer {
+        if !needed.contains(init.name.as_str()) {
+            continue;
+        }
+        if tensor_cache.contains(&init.name) {
+            continue;
+        }
+        let shape: Vec<usize> = init.dims.iter().map(|&d| d as usize).collect();
+        let data: Vec<f64> = crate::slicer::onnx_proto::tensor_to_f32(init)
+            .into_iter()
+            .map(f64::from)
+            .collect();
+        let expected: usize = shape.iter().product();
+        if data.len() != expected {
+            // Skip rather than fail: an initializer whose declared
+            // shape doesn't match its element count can still be
+            // useful elsewhere (some quantised tensors store packed
+            // bytes), but we cannot reshape it into ArrayD<f64>
+            // here without guessing.  Leave it to the slice ONNX
+            // executor to surface a clearer error if it actually
+            // needs the value.
+            continue;
+        }
+        let arr = ArrayD::from_shape_vec(IxDyn(&shape), data).map_err(|e| {
+            DsperseError::Pipeline(format!(
+                "seed initializer-backed tensor '{}' from combined.onnx: {e}",
+                init.name
+            ))
+        })?;
+        tensor_cache.put(init.name.clone(), arr);
+        seeded += 1;
+    }
+    if seeded > 0 {
+        tracing::info!(
+            seeded,
+            "seeded tensor_cache with constant-folded slice-input initializers"
+        );
+    }
+    Ok(())
 }

--- a/crates/dsperse/src/slicer/onnx_proto.rs
+++ b/crates/dsperse/src/slicer/onnx_proto.rs
@@ -269,6 +269,79 @@ pub fn tensor_to_f32(tensor: &TensorProto) -> Vec<f32> {
     Vec::new()
 }
 
+/// Decode a TensorProto into `Vec<f64>` directly, without going
+/// through `f32`.  FLOAT / DOUBLE / INT32 / INT64 payloads — in
+/// either the typed `*_data` fields or the little-endian
+/// `raw_data` byte stream — round-trip through the widest
+/// numeric carrier the consumer holds, preserving bits that the
+/// `tensor_to_f32` -> `f64::from(f32)` chain would otherwise
+/// truncate (notably DOUBLE mantissas and INT64 magnitudes
+/// outside the f32 exact range).
+///
+/// Returns an empty `Vec` on unsupported / unrecognised dtypes
+/// or malformed `raw_data` length so callers can use the
+/// existing `data.is_empty()` skip path.
+pub fn tensor_to_f64(tensor: &TensorProto) -> Vec<f64> {
+    if !tensor.double_data.is_empty() {
+        return tensor.double_data.clone();
+    }
+    if !tensor.float_data.is_empty() {
+        return tensor.float_data.iter().map(|&v| f64::from(v)).collect();
+    }
+    if !tensor.int64_data.is_empty() {
+        #[allow(clippy::cast_precision_loss)]
+        return tensor.int64_data.iter().map(|&v| v as f64).collect();
+    }
+    if !tensor.int32_data.is_empty() {
+        return tensor.int32_data.iter().map(|&v| f64::from(v)).collect();
+    }
+    if tensor.raw_data.is_empty() {
+        return Vec::new();
+    }
+    match tensor.data_type {
+        TensorProto::DOUBLE => {
+            let chunks = tensor.raw_data.chunks_exact(8);
+            if !chunks.remainder().is_empty() {
+                return Vec::new();
+            }
+            chunks
+                .map(|c| f64::from_le_bytes([c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7]]))
+                .collect()
+        }
+        TensorProto::FLOAT => {
+            let chunks = tensor.raw_data.chunks_exact(4);
+            if !chunks.remainder().is_empty() {
+                return Vec::new();
+            }
+            chunks
+                .map(|c| f64::from(f32::from_le_bytes([c[0], c[1], c[2], c[3]])))
+                .collect()
+        }
+        TensorProto::INT64 => {
+            let chunks = tensor.raw_data.chunks_exact(8);
+            if !chunks.remainder().is_empty() {
+                return Vec::new();
+            }
+            #[allow(clippy::cast_precision_loss)]
+            chunks
+                .map(|c| {
+                    i64::from_le_bytes([c[0], c[1], c[2], c[3], c[4], c[5], c[6], c[7]]) as f64
+                })
+                .collect()
+        }
+        TensorProto::INT32 => {
+            let chunks = tensor.raw_data.chunks_exact(4);
+            if !chunks.remainder().is_empty() {
+                return Vec::new();
+            }
+            chunks
+                .map(|c| f64::from(i32::from_le_bytes([c[0], c[1], c[2], c[3]])))
+                .collect()
+        }
+        _ => Vec::new(),
+    }
+}
+
 pub fn build_initializer_map(graph: &GraphProto) -> HashMap<String, &TensorProto> {
     graph
         .initializer

--- a/crates/dsperse/src/slicer/onnx_proto.rs
+++ b/crates/dsperse/src/slicer/onnx_proto.rs
@@ -270,13 +270,19 @@ pub fn tensor_to_f32(tensor: &TensorProto) -> Vec<f32> {
 }
 
 /// Decode a TensorProto into `Vec<f64>` directly, without going
-/// through `f32`.  FLOAT / DOUBLE / INT32 / INT64 payloads — in
-/// either the typed `*_data` fields or the little-endian
-/// `raw_data` byte stream — round-trip through the widest
-/// numeric carrier the consumer holds, preserving bits that the
-/// `tensor_to_f32` -> `f64::from(f32)` chain would otherwise
-/// truncate (notably DOUBLE mantissas and INT64 magnitudes
-/// outside the f32 exact range).
+/// through `f32`.  FLOAT / DOUBLE / INT32 payloads — in either
+/// the typed `*_data` fields or the little-endian `raw_data`
+/// byte stream — round-trip exactly: DOUBLE keeps its full 52-
+/// bit mantissa, FLOAT widens losslessly, and INT32 is always
+/// within f64's exact-integer range.
+///
+/// INT64 is a partial exception.  f64 exactly represents every
+/// integer in `[-2^53, 2^53]`; INT64 magnitudes beyond 2^53 are
+/// rounded to the nearest representable f64 and are not
+/// preserved bit-for-bit.  This still beats the previous
+/// `tensor_to_f32 -> f64::from(f32)` chain (which truncated at
+/// 2^24) but callers that need full INT64 fidelity must not use
+/// this decoder.
 ///
 /// Returns an empty `Vec` on unsupported / unrecognised dtypes
 /// or malformed `raw_data` length so callers can use the


### PR DESCRIPTION
## Summary
- `CombinedRun::new` populated `tensor_cache` only from ORT named outputs and the user's input. The slicer's constant-folding can move an intermediate tensor from `graph.node[].output` into `graph.initializer[]` of the combined ONNX while leaving downstream slice metadata pointing at the original name. ORT does not expose initialisers among named outputs, so the cache misses, and the first slice that depends on a const-folded tensor aborts the whole run at `tensor_cache.get` inside `all_circuit_work`.
- Seed `tensor_cache` from `combined.onnx`'s initialisers for any name referenced by a slice's `filtered_inputs` or declared `output`. No slicer / combiner / packaging changes — works for models already on the registry.

## Concrete failure this fixes
- Validator on sn2-testnet-1 with rfdetr-nano (`33894054...`):
  ```
  WARN sn2_validator::validator_loop::dslice: failed to enumerate circuit work
       run_uid=a2f071ec... 
       error=pipeline error: tensor '/transformer/decoder/layers.0/self_attn/Transpose_1_output_0' not found in store
  ```
- Every benchmark pick of the model aborted in <1 s; miner saw 0 DSlices for it across 6+ hours.
- Diagnosis: that tensor lives in `slices/combined.onnx`'s `graph.initializer` with shape `[300, 1, 256]` FLOAT — the slicer's const-fold pass collapsed a Transpose-over-constant down to its computed value, but slice 316 still references it as a `filtered_input`.

## Behaviour
- **All ORT named outputs match every slice dep** → unchanged.
- **A slice dep is in the combined model's initialisers** → seed it from there (was: hard error).
- **A slice dep is missing from both ORT outputs AND initialisers** → still surfaces the existing `tensor_cache.get` error, with the original message preserved.
- **Initialiser shape × dtype mismatch** (e.g. quantised packed-byte) → skip silently and let the slice executor produce a clearer error if it actually needs the value, rather than crashing the whole run during seeding.

## Test plan
- [x] `cargo fmt -p dsperse` clean.
- [x] `cargo clippy -p dsperse --no-deps -- -D warnings` clean.
- [ ] Manual: bump subnet-2 `dsperse` pin to this branch, redeploy validator, confirm `failed to enumerate circuit work` disappears for `33894054...`, miner starts servicing `circuit_id="33894054..."` DSlices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public tensor-decoding utility that converts model initializer data to 64-bit floats, handling typed and raw payloads and safely skipping malformed or unsupported data.

* **Bug Fixes**
  * Preloads referenced constant tensors from combined models into the runtime cache with shape and size validation to prevent lookup failures and runtime errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->