### PR TITLE
Introduce holographic GKR pipeline integration through JstproveBackend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -971,6 +971,7 @@ version = "0.0.0"
 dependencies = [
  "clap",
  "criterion",
+ "jstprove-io",
  "jstprove_circuits",
  "libc",
  "ndarray 0.17.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,6 @@ tempfile = "3"
 prost = "0.13"
 pyo3 = { version = "0.24" }
 jstprove_circuits = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "87a1859f3487cf0fb9a463dbfd713b1df4827afc" }
+jstprove_io = { git = "https://github.com/inference-labs-inc/JSTprove.git", rev = "87a1859f3487cf0fb9a463dbfd713b1df4827afc", package = "jstprove-io" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/crates/dsperse/Cargo.toml
+++ b/crates/dsperse/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = "1"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 walkdir = "2"
 jstprove_circuits.workspace = true
+jstprove_io.workspace = true
 reqwest.workspace = true
 tokio.workspace = true
 

--- a/crates/dsperse/src/backend/jstprove.rs
+++ b/crates/dsperse/src/backend/jstprove.rs
@@ -265,6 +265,64 @@ impl JstproveBackend {
         )
         .map_err(|e| DsperseError::Backend(format!("verify_and_extract: {e}")))
     }
+
+    /// Run holographic GKR setup against the compiled circuit at
+    /// `circuit_path` and persist the resulting verifying key as
+    /// `vk.bin` inside the bundle directory. The bundle is read from
+    /// the cache, so callers that just compiled the bundle through
+    /// [`Self::compile`] pay only the holographic setup cost on top.
+    ///
+    /// `setup_holographic_vk` only succeeds when the bundle was
+    /// compiled with `ProofConfig::GoldilocksExt4Whir`; the underlying
+    /// jstprove API rejects every other config.
+    ///
+    /// The vk blob is written using the same compression mode as the
+    /// rest of the bundle (`Self::compress`) so
+    /// `jstprove_io::bundle::read_vk_only` can decode it via the
+    /// shared auto-detecting reader.
+    pub fn setup_holographic_vk(&self, circuit_path: &Path) -> Result<()> {
+        let bundle = self.load_bundle_cached(circuit_path)?;
+        let config = Self::resolve_proof_config(&bundle)?;
+
+        let vk_bytes = api::setup_holographic_vk(config, &bundle.circuit)
+            .map_err(|e| DsperseError::Backend(format!("setup_holographic_vk: {e}")))?;
+
+        let vk_path = circuit_path.join("vk.bin");
+        let payload = if self.compress {
+            jstprove_io::compress_bytes(&vk_bytes)
+                .map_err(|e| DsperseError::Backend(format!("compress vk: {e}")))?
+        } else {
+            vk_bytes
+        };
+        std::fs::write(&vk_path, &payload).map_err(|e| DsperseError::io(e, &vk_path))?;
+        Ok(())
+    }
+
+    /// Generate a holographic GKR proof for an existing bundle and
+    /// witness. Like [`Self::setup_holographic_vk`] this requires the
+    /// bundle to have been compiled with
+    /// `ProofConfig::GoldilocksExt4Whir`.
+    pub fn prove_holographic(&self, circuit_path: &Path, witness_bytes: &[u8]) -> Result<Vec<u8>> {
+        let bundle = self.load_bundle_cached(circuit_path)?;
+        let config = Self::resolve_proof_config(&bundle)?;
+
+        api::prove_holographic(config, &bundle.circuit, witness_bytes)
+            .map_err(|e| DsperseError::Backend(format!("prove_holographic: {e}")))
+    }
+
+    /// Verify a holographic GKR proof against the bundle's vk.bin.
+    /// The vk is read independently of the (much larger) circuit
+    /// blob, mirroring the validator-side flow where the verifying
+    /// party only ever ships the vk.
+    pub fn verify_holographic(&self, circuit_path: &Path, proof_bytes: &[u8]) -> Result<bool> {
+        let bundle = self.load_bundle_cached(circuit_path)?;
+        let config = Self::resolve_proof_config(&bundle)?;
+        let vk_bytes = jstprove_io::bundle::read_vk_only(circuit_path)
+            .map_err(|e| DsperseError::Backend(format!("read vk: {e}")))?;
+
+        api::verify_holographic(config, &vk_bytes, proof_bytes)
+            .map_err(|e| DsperseError::Backend(format!("verify_holographic: {e}")))
+    }
 }
 
 impl ProofBackend for JstproveBackend {

--- a/crates/dsperse/src/backend/jstprove.rs
+++ b/crates/dsperse/src/backend/jstprove.rs
@@ -119,6 +119,35 @@ impl JstproveBackend {
         Ok(stamped.config)
     }
 
+    /// Resolve the proof config without touching the circuit or
+    /// witness-solver blobs. Reads only `manifest.msgpack`, which is
+    /// kilobytes versus the tens of megabytes a full bundle load
+    /// pulls in. Falls back to `resolve_proof_config` on a full
+    /// bundle load if the manifest is missing the stamp so callers
+    /// still get the same "no stamped proof_config" error path for
+    /// legacy bundles rather than a confusing deserialization
+    /// failure.
+    fn resolve_proof_config_from_manifest(&self, circuit_path: &Path) -> Result<ProofConfig> {
+        match jstprove_io::bundle::read_bundle_metadata::<CircuitParams>(circuit_path) {
+            Ok((Some(params), _)) => {
+                let stamped = params.proof_config.ok_or_else(|| {
+                    DsperseError::Backend(
+                        "circuit bundle has no stamped proof_config; recompile with a stamping prover"
+                            .into(),
+                    )
+                })?;
+                stamped
+                    .ensure_current()
+                    .map_err(|e| DsperseError::Backend(format!("incompatible bundle: {e}")))?;
+                Ok(stamped.config)
+            }
+            Ok((None, _)) | Err(_) => {
+                let bundle = self.load_bundle_cached(circuit_path)?;
+                Self::resolve_proof_config(&bundle)
+            }
+        }
+    }
+
     pub fn compile(
         &self,
         circuit_path: &Path,
@@ -315,8 +344,13 @@ impl JstproveBackend {
     /// blob, mirroring the validator-side flow where the verifying
     /// party only ever ships the vk.
     pub fn verify_holographic(&self, circuit_path: &Path, proof_bytes: &[u8]) -> Result<bool> {
-        let bundle = self.load_bundle_cached(circuit_path)?;
-        let config = Self::resolve_proof_config(&bundle)?;
+        // Verifiers only need the vk and the proof config — the
+        // circuit and witness solver blobs are not used downstream.
+        // Skip load_bundle_cached here so validators that only ever
+        // hold vk.bin + manifest.msgpack (the intended light-weight
+        // deployment shape) don't fail with a missing circuit.bin
+        // and don't pay the tens-of-megabytes read cost.
+        let config = self.resolve_proof_config_from_manifest(circuit_path)?;
         let vk_bytes = jstprove_io::bundle::read_vk_only(circuit_path)
             .map_err(|e| DsperseError::Backend(format!("read vk: {e}")))?;
 

--- a/crates/dsperse/src/backend/jstprove.rs
+++ b/crates/dsperse/src/backend/jstprove.rs
@@ -141,7 +141,20 @@ impl JstproveBackend {
                     .map_err(|e| DsperseError::Backend(format!("incompatible bundle: {e}")))?;
                 Ok(stamped.config)
             }
-            Ok((None, _)) | Err(_) => {
+            Ok((None, _)) => {
+                let bundle = self.load_bundle_cached(circuit_path)?;
+                Self::resolve_proof_config(&bundle)
+            }
+            Err(e) => {
+                // Surface the manifest-read failure so operators
+                // investigating a slow verify path or a legacy
+                // bundle layout can tell the fast path missed
+                // rather than silently eating a parse / IO error.
+                tracing::debug!(
+                    path = %circuit_path.display(),
+                    error = %e,
+                    "manifest-only proof_config read failed; falling back to full bundle load"
+                );
                 let bundle = self.load_bundle_cached(circuit_path)?;
                 Self::resolve_proof_config(&bundle)
             }

--- a/crates/dsperse/src/cli/mod.rs
+++ b/crates/dsperse/src/cli/mod.rs
@@ -39,6 +39,8 @@ pub enum Commands {
     #[command(name = "full-run")]
     FullRun(FullRunArgs),
     Analyze(AnalyzeArgs),
+    #[command(name = "setup-holographic")]
+    SetupHolographic(SetupHolographicArgs),
 }
 
 pub fn dispatch(command: Commands) -> Result<()> {
@@ -53,6 +55,7 @@ pub fn dispatch(command: Commands) -> Result<()> {
         Commands::Publish(args) => cmd_publish(args),
         Commands::FullRun(args) => cmd_full_run(args),
         Commands::Analyze(args) => cmd_analyze(args),
+        Commands::SetupHolographic(args) => cmd_setup_holographic(args),
     }
 }
 
@@ -138,6 +141,13 @@ pub struct CompileArgs {
         help = "Allow the command to exit 0 when individual slices fail to compile.  Failed slices fall back to ONNX execution at run / prove time, producing a partial-coverage proof.  Off by default so CI surfaces real compile regressions."
     )]
     pub allow_onnx_fallback: bool,
+    #[arg(
+        long,
+        default_value_t = false,
+        action = clap::ArgAction::Set,
+        help = "After compiling each slice, run holographic GKR setup and persist the verifying key as vk.bin in the bundle directory. Requires --proof-config goldilocks_ext4_whir."
+    )]
+    pub holographic: bool,
 }
 
 #[derive(Args)]
@@ -302,6 +312,30 @@ pub struct FullRunArgs {
         help = "Allow full-run to proceed when individual slices fail to compile.  Failed slices fall back to ONNX execution, producing a partial-coverage proof.  Off by default so CI surfaces real compile regressions."
     )]
     pub allow_onnx_fallback: bool,
+    #[arg(
+        long,
+        default_value_t = false,
+        action = clap::ArgAction::Set,
+        help = "After compiling each slice, run holographic GKR setup and persist the verifying key as vk.bin in the bundle directory. Requires --proof-config goldilocks_ext4_whir."
+    )]
+    pub holographic: bool,
+}
+
+#[derive(Args)]
+pub struct SetupHolographicArgs {
+    #[arg(long)]
+    pub model_dir: PathBuf,
+    #[arg(long)]
+    pub slices_dir: Option<PathBuf>,
+    #[arg(long, default_value = "1")]
+    pub parallel: NonZeroUsize,
+    #[arg(
+        long,
+        default_value_t = false,
+        action = clap::ArgAction::Set,
+        help = "Re-run setup and overwrite vk.bin even when the bundle already has one"
+    )]
+    pub overwrite: bool,
 }
 
 struct CircuitOps(Vec<String>);
@@ -402,6 +436,7 @@ pub fn cmd_compile(args: CompileArgs) -> Result<()> {
         layers.as_deref(),
         &ops.as_refs(),
         args.skip_compile_over_size,
+        args.holographic,
     )?;
     if args.allow_onnx_fallback {
         Ok(())
@@ -554,6 +589,7 @@ pub fn cmd_full_run(args: FullRunArgs) -> Result<()> {
         layers.as_deref(),
         &ops.as_refs(),
         args.skip_compile_over_size,
+        args.holographic,
     )?;
     if !args.allow_onnx_fallback {
         report.ok_if_no_failures()?;
@@ -579,6 +615,27 @@ pub fn cmd_full_run(args: FullRunArgs) -> Result<()> {
 
     tracing::info!(run_dir = %run_dir.display(), "full run complete");
     Ok(())
+}
+
+pub fn cmd_setup_holographic(args: SetupHolographicArgs) -> Result<()> {
+    let backend = JstproveBackend::new();
+    let slices_dir = resolve_slices_dir(args.slices_dir, &args.model_dir);
+
+    let report = pipeline::setup_holographic_for_slices(
+        &slices_dir,
+        &backend,
+        args.parallel.get(),
+        args.overwrite,
+    )?;
+
+    tracing::info!(
+        processed = report.processed,
+        skipped = report.skipped_already_present,
+        failed = report.failed.len(),
+        "holographic setup complete"
+    );
+
+    report.ok_if_no_failures().map(|_| ())
 }
 
 #[derive(Args)]
@@ -985,6 +1042,85 @@ mod tests {
             assert!(!args.combined);
         } else {
             panic!("expected Run");
+        }
+    }
+
+    #[test]
+    fn cli_compile_holographic_default_false() {
+        let cli = Cli::parse_from(["dsperse", "compile", "--model-dir", "/tmp"]);
+        if let Commands::Compile(args) = cli.command {
+            assert!(!args.holographic);
+        } else {
+            panic!("expected Compile");
+        }
+    }
+
+    #[test]
+    fn cli_compile_holographic_explicit_true() {
+        let cli = Cli::parse_from([
+            "dsperse",
+            "compile",
+            "--model-dir",
+            "/tmp",
+            "--holographic",
+            "true",
+        ]);
+        if let Commands::Compile(args) = cli.command {
+            assert!(args.holographic);
+        } else {
+            panic!("expected Compile");
+        }
+    }
+
+    #[test]
+    fn cli_full_run_holographic_explicit_true() {
+        let cli = Cli::parse_from([
+            "dsperse",
+            "full-run",
+            "--model-dir",
+            "/tmp",
+            "--holographic",
+            "true",
+        ]);
+        if let Commands::FullRun(args) = cli.command {
+            assert!(args.holographic);
+        } else {
+            panic!("expected FullRun");
+        }
+    }
+
+    #[test]
+    fn cli_setup_holographic_command() {
+        let cli = Cli::parse_from([
+            "dsperse",
+            "setup-holographic",
+            "--model-dir",
+            "/tmp",
+            "--parallel",
+            "4",
+        ]);
+        if let Commands::SetupHolographic(args) = cli.command {
+            assert_eq!(args.parallel.get(), 4);
+            assert!(!args.overwrite);
+        } else {
+            panic!("expected SetupHolographic");
+        }
+    }
+
+    #[test]
+    fn cli_setup_holographic_overwrite() {
+        let cli = Cli::parse_from([
+            "dsperse",
+            "setup-holographic",
+            "--model-dir",
+            "/tmp",
+            "--overwrite",
+            "true",
+        ]);
+        if let Commands::SetupHolographic(args) = cli.command {
+            assert!(args.overwrite);
+        } else {
+            panic!("expected SetupHolographic");
         }
     }
 

--- a/crates/dsperse/src/pipeline/compiler.rs
+++ b/crates/dsperse/src/pipeline/compiler.rs
@@ -133,7 +133,13 @@ pub fn compile_slices(
     layers: Option<&[usize]>,
     jstprove_ops: &[&str],
     skip_compile_over_size: Option<u64>,
+    holographic: bool,
 ) -> Result<CompileReport> {
+    if holographic && proof_config != jstprove_circuits::api::ProofConfigType::GoldilocksExt4Whir {
+        return Err(DsperseError::Pipeline(format!(
+            "--holographic requires --proof-config goldilocks_ext4_whir; got {proof_config}"
+        )));
+    }
     let meta_path = find_metadata_path(slices_dir).ok_or_else(|| {
         DsperseError::Metadata(format!(
             "no {} found in slices directory",
@@ -181,6 +187,7 @@ pub fn compile_slices(
                 skip_compile_over_size,
                 &circuit_cache,
                 traced_ref,
+                holographic,
             );
             match r {
                 Ok(CompileOutcome::Compiled) => {
@@ -734,6 +741,7 @@ fn compile_single_slice(
     skip_compile_over_size: Option<u64>,
     circuit_cache: &CircuitCache,
     traced_shapes: Option<&std::collections::HashMap<String, Vec<i64>>>,
+    holographic: bool,
 ) -> Result<CompileOutcome> {
     let slice_dir = slice_dir_path(slices_dir, slice.index);
     if !slice_dir.exists() {
@@ -757,6 +765,7 @@ fn compile_single_slice(
             skip_compile_over_size,
             circuit_cache,
             traced_shapes,
+            holographic,
         );
     }
 
@@ -776,6 +785,7 @@ fn compile_single_slice(
                 skip_compile_over_size,
                 circuit_cache,
                 traced_shapes,
+                holographic,
             );
         }
     }
@@ -822,6 +832,9 @@ fn compile_single_slice(
         match backend.load_params(&circuit_path) {
             Ok(_) => {
                 tracing::info!(slice = slice.index, "already compiled, skipping");
+                if holographic && !jstprove_io::bundle::bundle_has_vk(&circuit_path) {
+                    run_holographic_setup(backend, &circuit_path, slice.index, "slice")?;
+                }
                 return Ok(CompileOutcome::Compiled);
             }
             Err(e) => {
@@ -879,7 +892,163 @@ fn compile_single_slice(
         DsperseError::Backend(format!("jstprove panicked: {msg}"))
     })??;
 
+    if holographic {
+        run_holographic_setup(backend, &circuit_path, slice.index, "slice")?;
+    }
+
     Ok(CompileOutcome::Compiled)
+}
+
+/// Result of a [`setup_holographic_for_slices`] invocation. Mirrors
+/// the structure of [`CompileReport`] so callers can surface
+/// per-slice failures with the same handling.
+#[derive(Debug, Default)]
+pub struct HolographicSetupReport {
+    pub processed: usize,
+    pub skipped_already_present: usize,
+    pub failed: Vec<(usize, DsperseError)>,
+}
+
+impl HolographicSetupReport {
+    pub fn ok_if_no_failures(self) -> Result<Self> {
+        if self.failed.is_empty() {
+            Ok(self)
+        } else {
+            Err(DsperseError::Pipeline(format!(
+                "setup_holographic_for_slices: {} slice bundle(s) failed",
+                self.failed.len()
+            )))
+        }
+    }
+}
+
+/// Run holographic GKR setup over every compiled bundle under
+/// `slices_dir`. Walks the slice metadata and, for each slice,
+/// processes the conventional bundle paths produced by
+/// [`compile_slices`]: standard (`jstprove/circuit.bundle`),
+/// channel-split (`jstprove/shared/circuit.bundle`), and dim-split
+/// template (`jstprove/dim_split/circuit.bundle`).
+///
+/// Bundles that already carry a `vk.bin` are skipped unless
+/// `overwrite` is set, so this function is idempotent and cheap to
+/// re-run after a partial failure.
+pub fn setup_holographic_for_slices(
+    slices_dir: &Path,
+    backend: &JstproveBackend,
+    parallel: usize,
+    overwrite: bool,
+) -> Result<HolographicSetupReport> {
+    let meta_path = find_metadata_path(slices_dir).ok_or_else(|| {
+        DsperseError::Metadata(format!(
+            "no {} found in slices directory",
+            crate::utils::paths::METADATA_FILE
+        ))
+    })?;
+    let metadata = ModelMetadata::load(&meta_path)?;
+
+    let mut targets: Vec<(usize, &'static str, PathBuf)> = Vec::new();
+    for slice in &metadata.slices {
+        let slice_dir = slice_dir_path(slices_dir, slice.index);
+        let candidates: [(&'static str, PathBuf); 3] = [
+            ("slice", slice_dir.join("jstprove").join("circuit.bundle")),
+            (
+                "channel-split-shared",
+                slice_dir
+                    .join("jstprove")
+                    .join("shared")
+                    .join("circuit.bundle"),
+            ),
+            (
+                "dim-split-template",
+                slice_dir
+                    .join("jstprove")
+                    .join("dim_split")
+                    .join("circuit.bundle"),
+            ),
+        ];
+        for (kind, path) in candidates {
+            if path.is_dir() {
+                targets.push((slice.index, kind, path));
+            }
+        }
+    }
+
+    tracing::info!(
+        bundles = targets.len(),
+        parallel,
+        overwrite,
+        "running holographic GKR setup over compiled bundles"
+    );
+
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(parallel)
+        .build()
+        .map_err(|e| DsperseError::Pipeline(format!("thread pool: {e}")))?;
+
+    let processed = std::sync::atomic::AtomicUsize::new(0);
+    let skipped = std::sync::atomic::AtomicUsize::new(0);
+    let errors: std::sync::Mutex<Vec<(usize, DsperseError)>> = std::sync::Mutex::new(Vec::new());
+
+    pool.install(|| {
+        targets
+            .par_iter()
+            .for_each(|(slice_idx, kind, bundle_path)| {
+                if !overwrite && jstprove_io::bundle::bundle_has_vk(bundle_path) {
+                    skipped.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    tracing::info!(
+                        slice = *slice_idx,
+                        kind,
+                        path = %bundle_path.display(),
+                        "vk.bin already present, skipping (pass --overwrite to regenerate)"
+                    );
+                    return;
+                }
+                match run_holographic_setup(backend, bundle_path, *slice_idx, kind) {
+                    Ok(()) => {
+                        processed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    }
+                    Err(e) => {
+                        tracing::warn!(slice = *slice_idx, kind, error = %e, "holographic setup failed");
+                        errors.lock().unwrap().push((*slice_idx, e));
+                    }
+                }
+            });
+    });
+
+    Ok(HolographicSetupReport {
+        processed: processed.load(std::sync::atomic::Ordering::Relaxed),
+        skipped_already_present: skipped.load(std::sync::atomic::Ordering::Relaxed),
+        failed: errors.into_inner().unwrap(),
+    })
+}
+
+fn run_holographic_setup(
+    backend: &JstproveBackend,
+    circuit_path: &Path,
+    slice_idx: usize,
+    kind: &'static str,
+) -> Result<()> {
+    tracing::info!(
+        slice = slice_idx,
+        kind,
+        path = %circuit_path.display(),
+        "running holographic GKR setup"
+    );
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        backend.setup_holographic_vk(circuit_path)
+    }))
+    .map_err(|p| {
+        let msg = p
+            .downcast_ref::<&str>()
+            .copied()
+            .or_else(|| p.downcast_ref::<String>().map(String::as_str))
+            .unwrap_or("unknown panic");
+        DsperseError::Backend(format!(
+            "jstprove panicked during holographic setup on slice {slice_idx} ({kind}): {msg}"
+        ))
+    })??;
+    tracing::info!(slice = slice_idx, kind, "holographic vk persisted");
+    Ok(())
 }
 
 fn populate_channel_split_groups(
@@ -953,6 +1122,7 @@ fn compile_channel_split_slice(
     skip_compile_over_size: Option<u64>,
     circuit_cache: &CircuitCache,
     traced_shapes: Option<&std::collections::HashMap<String, Vec<i64>>>,
+    holographic: bool,
 ) -> Result<CompileOutcome> {
     let slice_dir = slice_dir_path(slices_dir, slice.index);
     let jst_dir = slice_dir.join("jstprove");
@@ -1096,6 +1266,25 @@ fn compile_channel_split_slice(
                 slice.index
             ))
         })?;
+
+        if holographic {
+            run_holographic_setup(
+                backend,
+                &shared_circuit_path,
+                slice.index,
+                "channel-split-shared",
+            )?;
+        }
+    } else if holographic && !jstprove_io::bundle::bundle_has_vk(&shared_circuit_path) {
+        // Cached bundle predates the holographic plumbing: backfill
+        // the vk so reused circuits stay in sync with freshly-built
+        // ones.
+        run_holographic_setup(
+            backend,
+            &shared_circuit_path,
+            slice.index,
+            "channel-split-shared",
+        )?;
     }
 
     let group_circuits: Vec<(usize, String)> = cs
@@ -1119,6 +1308,7 @@ fn compile_dim_split_template(
     skip_compile_over_size: Option<u64>,
     circuit_cache: &CircuitCache,
     _traced_shapes: Option<&std::collections::HashMap<String, Vec<i64>>>,
+    holographic: bool,
 ) -> Result<CompileOutcome> {
     let slice_dir = slice_dir_path(slices_dir, slice.index);
     let jst_dir = slice_dir.join("jstprove");
@@ -1133,6 +1323,16 @@ fn compile_dim_split_template(
                     slice = slice.index,
                     "dim-split template already compiled, reusing"
                 );
+                if holographic && !jstprove_io::bundle::bundle_has_vk(&circuit_path) {
+                    // Backfill vk on cached bundles; see channel-
+                    // split branch above for the same rationale.
+                    run_holographic_setup(
+                        backend,
+                        &circuit_path,
+                        slice.index,
+                        "dim-split-template",
+                    )?;
+                }
                 return Ok(CompileOutcome::CompiledDimSplit);
             }
             Err(e) => {
@@ -1238,6 +1438,11 @@ fn compile_dim_split_template(
         .unwrap()
         .insert(sig.clone(), circuit_path.clone());
     tracing::info!(slice = slice.index, sig = %sig, "dim-split template compiled");
+
+    if holographic {
+        run_holographic_setup(backend, &circuit_path, slice.index, "dim-split-template")?;
+    }
+
     Ok(CompileOutcome::CompiledDimSplit)
 }
 

--- a/crates/dsperse/src/pipeline/compiler.rs
+++ b/crates/dsperse/src/pipeline/compiler.rs
@@ -1267,7 +1267,14 @@ fn compile_channel_split_slice(
             ))
         })?;
 
-        if holographic {
+        if holographic && !jstprove_io::bundle::bundle_has_vk(&shared_circuit_path) {
+            // When the needs_build branch took the memcache-reuse
+            // sub-path, copy_dir_recursive may already have brought
+            // vk.bin across from the source bundle; skip the
+            // expensive re-setup in that case and only run it when
+            // the shared bundle genuinely lacks a vk (the
+            // fresh-compile sub-path, or a source that raced us
+            // before its own setup persisted).
             run_holographic_setup(
                 backend,
                 &shared_circuit_path,

--- a/crates/dsperse/src/pipeline/compiler.rs
+++ b/crates/dsperse/src/pipeline/compiler.rs
@@ -1396,6 +1396,17 @@ fn compile_dim_split_template(
             sig = %sig,
             "reused cached dim-split circuit"
         );
+        // circuit_cache can hand back a source bundle that was
+        // inserted before its own run_holographic_setup finished
+        // (the fresh-build branch below inserts the sig before it
+        // persists vk.bin), so a parallel racer can snapshot a
+        // pre-vk source and copy_dir_recursive a bundle missing
+        // vk.bin.  Mirror the channel-split reuse branch and
+        // backfill on the copy so every reused dim-split bundle
+        // ends up in the same shape as a freshly-compiled one.
+        if holographic && !jstprove_io::bundle::bundle_has_vk(&circuit_path) {
+            run_holographic_setup(backend, &circuit_path, slice.index, "dim-split-template")?;
+        }
         return Ok(CompileOutcome::CompiledDimSplit);
     }
 

--- a/crates/dsperse/src/pipeline/mod.rs
+++ b/crates/dsperse/src/pipeline/mod.rs
@@ -16,7 +16,10 @@ mod tiled;
 mod verifier;
 
 pub use combined::CombinedRun;
-pub use compiler::{CompileReport, SliceAnalysisReport, analyze_slices, compile_slices};
+pub use compiler::{
+    CompileReport, HolographicSetupReport, SliceAnalysisReport, analyze_slices, compile_slices,
+    setup_holographic_for_slices,
+};
 pub use incremental::{IncrementalRun, SliceExecutionResult, SliceWork};
 pub use prover::prove_run;
 pub use runner::{RunConfig, extract_onnx_initializers, run_inference};

--- a/crates/dsperse/src/python.rs
+++ b/crates/dsperse/src/python.rs
@@ -95,7 +95,7 @@ fn slice_model(
 
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
-#[pyo3(signature = (slices_dir, proof_config="bn254_raw", parallel=1, weights_as_inputs=true, layers=None, proof_system="expander", circuit_ops=None, skip_compile_over_size=None))]
+#[pyo3(signature = (slices_dir, proof_config="bn254_raw", parallel=1, weights_as_inputs=true, layers=None, proof_system="expander", circuit_ops=None, skip_compile_over_size=None, holographic=false))]
 fn compile_slices(
     py: Python<'_>,
     slices_dir: &str,
@@ -106,6 +106,7 @@ fn compile_slices(
     proof_system: &str,
     circuit_ops: Option<Vec<String>>,
     skip_compile_over_size: Option<u64>,
+    holographic: bool,
 ) -> PyResult<()> {
     require_nonzero(parallel)?;
     let backend = JstproveBackend::default();
@@ -129,6 +130,7 @@ fn compile_slices(
                 layers.as_deref(),
                 &ops_refs,
                 skip_compile_over_size,
+                holographic,
             )
         })
         .map_err(to_py_err)?;
@@ -236,6 +238,31 @@ fn cli_main(py: Python<'_>, argv: Option<Vec<String>>) -> PyResult<()> {
     result.map_err(to_py_err)
 }
 
+#[pyfunction]
+#[pyo3(signature = (slices_dir, parallel=1, overwrite=false))]
+fn setup_holographic(
+    py: Python<'_>,
+    slices_dir: &str,
+    parallel: usize,
+    overwrite: bool,
+) -> PyResult<()> {
+    require_nonzero(parallel)?;
+    let backend = JstproveBackend::default();
+    let dir = PathBuf::from(slices_dir);
+    let report = py
+        .allow_threads(|| {
+            pipeline::setup_holographic_for_slices(&dir, &backend, parallel, overwrite)
+        })
+        .map_err(to_py_err)?;
+    if !report.failed.is_empty() {
+        return Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
+            "{} bundle(s) failed holographic setup",
+            report.failed.len()
+        )));
+    }
+    Ok(())
+}
+
 #[pymodule]
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(slice_model, m)?)?;
@@ -243,6 +270,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(run_inference, m)?)?;
     m.add_function(wrap_pyfunction!(prove_run, m)?)?;
     m.add_function(wrap_pyfunction!(verify_run, m)?)?;
+    m.add_function(wrap_pyfunction!(setup_holographic, m)?)?;
     m.add_function(wrap_pyfunction!(cli_main, m)?)?;
     Ok(())
 }

--- a/python/dsperse/__init__.py
+++ b/python/dsperse/__init__.py
@@ -4,6 +4,7 @@ from dsperse._native import (
     run_inference,
     prove_run,
     verify_run,
+    setup_holographic,
 )
 
 __all__ = [
@@ -12,4 +13,5 @@ __all__ = [
     "run_inference",
     "prove_run",
     "verify_run",
+    "setup_holographic",
 ]


### PR DESCRIPTION
## Summary

- Bumps `jstprove_circuits` to a rev that exposes `setup_holographic_vk`, `prove_holographic`, and `verify_holographic`.
- Adds matching methods on `JstproveBackend` that read the cached bundle, dispatch to the jstprove holographic API for `GoldilocksExt4Whir`, and persist `vk.bin` into the bundle directory through `jstprove_io::compress_bytes` so the existing auto-detecting reader picks it up.
- Threads a `--holographic` flag through `dsperse compile` and `dsperse full-run`. When set, every freshly compiled bundle (standard slice, channel-split shared, dim-split template) gets a setup-vk pass; cached bundles missing a `vk.bin` are backfilled in place.
- Adds a dedicated `dsperse setup-holographic` subcommand that walks an existing slice tree, finds the conventional bundle paths, and runs setup in parallel. Idempotent unless `--overwrite true` is passed.
- Validates that holographic compilation only proceeds against `--proof-config goldilocks_ext4_whir` at the pipeline boundary so callers fail fast on the wrong field.
- Mirrors the CLI surface in the Python binding: new `holographic` kwarg on `compile_slices`, new `setup_holographic` function exposed from `dsperse._native`.

## Test plan

- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --workspace --tests` (230 unit + 7+10+12 integration, all green)
- [x] New CLI tests cover `--holographic` parsing on `compile` / `full-run` and the `setup-holographic` subcommand
- [ ] End-to-end run on rf-detr-nano with `--proof-config goldilocks_ext4_whir --holographic --weights-as-inputs` on M3 Ultra (in progress on the pull-and-build follow-up)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Holographic proof: generate, verify, and set up verification keys via backend.
  * New CLI command: setup-holographic (supports parallelism and overwrite).
  * New --holographic flag for compile and full-run to enable holographic workflows.
  * Automatic setup/backfill of holographic verification keys for existing bundles (skips present keys unless overwritten).
  * Python API: added setup_holographic() and holographic parameter for compile_slices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->