### PR TITLE
Resolve component signature collision across proof config and compile mode

### DIFF
--- a/crates/dsperse/src/backend/jstprove.rs
+++ b/crates/dsperse/src/backend/jstprove.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
+pub use jstprove_circuits::api::ExtractedOutputType as ExtractedOutput;
 pub use jstprove_circuits::api::ProofConfigType as ProofConfig;
 pub use jstprove_circuits::api::StampedProofConfigType as StampedProofConfig;
 pub use jstprove_circuits::api::VerifiedOutputType as VerifiedOutput;
@@ -263,14 +264,33 @@ impl JstproveBackend {
         witness_bytes: &[u8],
         num_model_inputs: usize,
     ) -> Result<Vec<f64>> {
+        Ok(self
+            .extract_outputs_full(witness_bytes, num_model_inputs)?
+            .outputs)
+    }
+
+    /// Full extracted output bundle: inputs, outputs, and the
+    /// witness-stamped scale parameters. Holographic verifiers call
+    /// this after `verify_holographic` because the holographic
+    /// verify path does not reach through `verify_and_extract`, yet
+    /// the validator still needs the declared inputs (to cross-check
+    /// against what it sent) and the scale fields (to report the
+    /// same `VerifiedOutput` shape the non-holographic path
+    /// produces). Keeping `extract_outputs` as a thin wrapper
+    /// preserves the existing `Vec<f64>` contract for callers that
+    /// only want the outputs.
+    pub fn extract_outputs_full(
+        &self,
+        witness_bytes: &[u8],
+        num_model_inputs: usize,
+    ) -> Result<ExtractedOutput> {
         if num_model_inputs == 0 {
             return Err(DsperseError::Backend(
                 "extract_outputs: num_model_inputs must be > 0".into(),
             ));
         }
-        let result = api::extract_outputs(witness_bytes, num_model_inputs)
-            .map_err(|e| DsperseError::Backend(format!("extract_outputs: {e}")))?;
-        Ok(result.outputs)
+        api::extract_outputs(witness_bytes, num_model_inputs)
+            .map_err(|e| DsperseError::Backend(format!("extract_outputs: {e}")))
     }
 
     pub fn verify(

--- a/crates/dsperse/src/backend/jstprove.rs
+++ b/crates/dsperse/src/backend/jstprove.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
-pub use jstprove_circuits::api::ExtractedOutputType as ExtractedOutput;
 pub use jstprove_circuits::api::ProofConfigType as ProofConfig;
 pub use jstprove_circuits::api::StampedProofConfigType as StampedProofConfig;
 pub use jstprove_circuits::api::VerifiedOutputType as VerifiedOutput;
@@ -264,29 +263,14 @@ impl JstproveBackend {
         witness_bytes: &[u8],
         num_model_inputs: usize,
     ) -> Result<Vec<f64>> {
-        Ok(self
-            .extract_outputs_full(witness_bytes, num_model_inputs)?
-            .outputs)
-    }
-
-    /// Full extracted output bundle: inputs, outputs, and the
-    /// witness-stamped scale parameters. Holographic verifiers call
-    /// this after `verify_holographic` because their soundness path
-    /// does not reach through `verify_and_extract`, yet they still
-    /// need the scale fields to report the same `VerifyResult` shape
-    /// the non-holographic path produces.
-    pub fn extract_outputs_full(
-        &self,
-        witness_bytes: &[u8],
-        num_model_inputs: usize,
-    ) -> Result<ExtractedOutput> {
         if num_model_inputs == 0 {
             return Err(DsperseError::Backend(
                 "extract_outputs: num_model_inputs must be > 0".into(),
             ));
         }
-        api::extract_outputs(witness_bytes, num_model_inputs)
-            .map_err(|e| DsperseError::Backend(format!("extract_outputs: {e}")))
+        let result = api::extract_outputs(witness_bytes, num_model_inputs)
+            .map_err(|e| DsperseError::Backend(format!("extract_outputs: {e}")))?;
+        Ok(result.outputs)
     }
 
     pub fn verify(

--- a/crates/dsperse/src/backend/jstprove.rs
+++ b/crates/dsperse/src/backend/jstprove.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
+pub use jstprove_circuits::api::ExtractedOutputType as ExtractedOutput;
 pub use jstprove_circuits::api::ProofConfigType as ProofConfig;
 pub use jstprove_circuits::api::StampedProofConfigType as StampedProofConfig;
 pub use jstprove_circuits::api::VerifiedOutputType as VerifiedOutput;
@@ -263,14 +264,29 @@ impl JstproveBackend {
         witness_bytes: &[u8],
         num_model_inputs: usize,
     ) -> Result<Vec<f64>> {
+        Ok(self
+            .extract_outputs_full(witness_bytes, num_model_inputs)?
+            .outputs)
+    }
+
+    /// Full extracted output bundle: inputs, outputs, and the
+    /// witness-stamped scale parameters. Holographic verifiers call
+    /// this after `verify_holographic` because their soundness path
+    /// does not reach through `verify_and_extract`, yet they still
+    /// need the scale fields to report the same `VerifyResult` shape
+    /// the non-holographic path produces.
+    pub fn extract_outputs_full(
+        &self,
+        witness_bytes: &[u8],
+        num_model_inputs: usize,
+    ) -> Result<ExtractedOutput> {
         if num_model_inputs == 0 {
             return Err(DsperseError::Backend(
                 "extract_outputs: num_model_inputs must be > 0".into(),
             ));
         }
-        let result = api::extract_outputs(witness_bytes, num_model_inputs)
-            .map_err(|e| DsperseError::Backend(format!("extract_outputs: {e}")))?;
-        Ok(result.outputs)
+        api::extract_outputs(witness_bytes, num_model_inputs)
+            .map_err(|e| DsperseError::Backend(format!("extract_outputs: {e}")))
     }
 
     pub fn verify(

--- a/crates/dsperse/src/pipeline/compiler.rs
+++ b/crates/dsperse/src/pipeline/compiler.rs
@@ -425,6 +425,51 @@ pub(super) fn compute_circuit_signature(tmpl_path: &Path, curve: Option<&str>) -
     Ok(format!("{:x}", hash))
 }
 
+/// Bundle-aware signature used at packaging time. Wraps the ONNX+curve
+/// hash from `compute_circuit_signature` with discriminators pulled
+/// from the compiled bundle so that two packages built from the same
+/// ONNX but under different proof configs, input-binding modes, or
+/// holographic/non-holographic flows land at distinct shas in the
+/// content-addressed registry. The compile-time cache lookups in
+/// `compile_single_slice` continue to use `compute_circuit_signature`
+/// directly because they key on pre-compile state where no bundle
+/// exists yet.
+pub(super) fn compute_bundle_signature(
+    tmpl_path: &Path,
+    curve: Option<&str>,
+    bundle_dir: &Path,
+) -> Result<String> {
+    use sha2::{Digest, Sha256};
+
+    let base = compute_circuit_signature(tmpl_path, curve)?;
+    let mut hasher = Sha256::new();
+    hasher.update(base.as_bytes());
+    hasher.update(b"\x00bundle-disambiguator-v1\x00");
+
+    match jstprove_io::bundle::read_bundle_metadata::<jstprove_circuits::api::CircuitParamsType>(
+        bundle_dir,
+    ) {
+        Ok((Some(params), _)) => {
+            hasher.update([1u8]);
+            match params.proof_config {
+                Some(stamped) => {
+                    hasher.update([1u8]);
+                    hasher.update((stamped.config.config_id() as u64).to_le_bytes());
+                    hasher.update(stamped.version.to_le_bytes());
+                }
+                None => hasher.update([0u8]),
+            }
+            hasher.update([u8::from(params.weights_as_inputs)]);
+        }
+        Ok((None, _)) | Err(_) => {
+            hasher.update([0u8]);
+        }
+    }
+
+    hasher.update([u8::from(bundle_dir.join("vk.bin").is_file())]);
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
 fn summarize_onnx_ops(onnx_path: &Path) -> String {
     let model = match onnx_proto::load_model(onnx_path) {
         Ok(m) => m,
@@ -1683,5 +1728,67 @@ mod tests {
         });
         let path = resolve_compile_onnx(slices_dir, &meta).unwrap();
         assert!(path.ends_with("slice_0.onnx"));
+    }
+
+    fn write_identity_onnx(path: &Path) {
+        let node = onnx_proto::NodeProto {
+            op_type: "Relu".to_string(),
+            input: vec!["x".to_string()],
+            output: vec!["y".to_string()],
+            ..Default::default()
+        };
+        let graph = onnx_proto::make_graph(
+            "g",
+            vec![node],
+            vec![onnx_proto::make_tensor_value_info("x", 1, &[1, 8])],
+            vec![onnx_proto::make_tensor_value_info("y", 1, &[1, 8])],
+            vec![],
+        );
+        let model = onnx_proto::make_model(graph, 13);
+        onnx_proto::save_model(&model, path).unwrap();
+    }
+
+    #[test]
+    fn bundle_signature_matches_circuit_signature_when_bundle_has_no_metadata() {
+        let tmp = tempfile::tempdir().unwrap();
+        let onnx_path = tmp.path().join("slice.onnx");
+        write_identity_onnx(&onnx_path);
+        let bundle_dir = tmp.path().join("bundle");
+        std::fs::create_dir_all(&bundle_dir).unwrap();
+
+        let base = compute_circuit_signature(&onnx_path, None).unwrap();
+        let bundle_sig = compute_bundle_signature(&onnx_path, None, &bundle_dir).unwrap();
+
+        assert_ne!(
+            base, bundle_sig,
+            "bundle signature must always include discriminator bytes"
+        );
+
+        let bundle_sig_again = compute_bundle_signature(&onnx_path, None, &bundle_dir).unwrap();
+        assert_eq!(
+            bundle_sig, bundle_sig_again,
+            "bundle signature must be deterministic"
+        );
+    }
+
+    #[test]
+    fn bundle_signature_disambiguates_vk_presence() {
+        let tmp = tempfile::tempdir().unwrap();
+        let onnx_path = tmp.path().join("slice.onnx");
+        write_identity_onnx(&onnx_path);
+
+        let plain_bundle = tmp.path().join("plain");
+        let holo_bundle = tmp.path().join("holographic");
+        std::fs::create_dir_all(&plain_bundle).unwrap();
+        std::fs::create_dir_all(&holo_bundle).unwrap();
+        std::fs::write(holo_bundle.join("vk.bin"), b"vk-contents").unwrap();
+
+        let plain_sig = compute_bundle_signature(&onnx_path, None, &plain_bundle).unwrap();
+        let holo_sig = compute_bundle_signature(&onnx_path, None, &holo_bundle).unwrap();
+
+        assert_ne!(
+            plain_sig, holo_sig,
+            "holographic bundle must produce a distinct signature"
+        );
     }
 }

--- a/crates/dsperse/src/pipeline/compiler.rs
+++ b/crates/dsperse/src/pipeline/compiler.rs
@@ -494,7 +494,7 @@ pub(super) fn compute_bundle_signature(
         }
     }
 
-    hasher.update([u8::from(bundle_dir.join("vk.bin").is_file())]);
+    hasher.update([u8::from(jstprove_io::bundle::bundle_has_vk(bundle_dir))]);
     Ok(format!("{:x}", hasher.finalize()))
 }
 
@@ -1817,6 +1817,87 @@ mod tests {
         assert_ne!(
             plain_sig, holo_sig,
             "holographic bundle must produce a distinct signature"
+        );
+    }
+
+    #[test]
+    fn bundle_signature_disambiguates_proof_config_and_wai_on_metadata_branch() {
+        use std::collections::HashMap;
+
+        use jstprove_circuits::ProofSystem;
+        use jstprove_circuits::api::{CircuitParamsType, ProofConfigType, StampedProofConfigType};
+        use jstprove_io::bundle::write_bundle;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let onnx_path = tmp.path().join("slice.onnx");
+        write_identity_onnx(&onnx_path);
+
+        fn make_params(config: ProofConfigType, weights_as_inputs: bool) -> CircuitParamsType {
+            CircuitParamsType {
+                scale_base: 2,
+                scale_exponent: 8,
+                rescale_config: HashMap::new(),
+                inputs: Vec::new(),
+                outputs: Vec::new(),
+                freivalds_reps: 1,
+                n_bits_config: HashMap::new(),
+                weights_as_inputs,
+                proof_system: ProofSystem::default(),
+                proof_config: Some(StampedProofConfigType::current(config)),
+                logup_chunk_bits: None,
+                public_inputs: Vec::new(),
+            }
+        }
+
+        let bn254_bundle = tmp.path().join("bn254");
+        let goldi_bundle = tmp.path().join("goldilocks");
+        let bn254_wai_bundle = tmp.path().join("bn254-wai");
+
+        write_bundle(
+            &bn254_bundle,
+            &[1, 2, 3],
+            &[4, 5, 6],
+            Some(make_params(ProofConfigType::Bn254Raw, false)),
+            None,
+            false,
+        )
+        .unwrap();
+        write_bundle(
+            &goldi_bundle,
+            &[1, 2, 3],
+            &[4, 5, 6],
+            Some(make_params(ProofConfigType::GoldilocksExt4Whir, false)),
+            None,
+            false,
+        )
+        .unwrap();
+        write_bundle(
+            &bn254_wai_bundle,
+            &[1, 2, 3],
+            &[4, 5, 6],
+            Some(make_params(ProofConfigType::Bn254Raw, true)),
+            None,
+            false,
+        )
+        .unwrap();
+
+        let sig_bn254 = compute_bundle_signature(&onnx_path, None, &bn254_bundle).unwrap();
+        let sig_goldi = compute_bundle_signature(&onnx_path, None, &goldi_bundle).unwrap();
+        let sig_bn254_wai = compute_bundle_signature(&onnx_path, None, &bn254_wai_bundle).unwrap();
+
+        assert_ne!(
+            sig_bn254, sig_goldi,
+            "config_id must discriminate bundles with different ProofConfig variants"
+        );
+        assert_ne!(
+            sig_bn254, sig_bn254_wai,
+            "weights_as_inputs must discriminate bundles with the same ProofConfig"
+        );
+
+        let sig_bn254_again = compute_bundle_signature(&onnx_path, None, &bn254_bundle).unwrap();
+        assert_eq!(
+            sig_bn254, sig_bn254_again,
+            "signature must be deterministic for the metadata branch"
         );
     }
 }

--- a/crates/dsperse/src/pipeline/compiler.rs
+++ b/crates/dsperse/src/pipeline/compiler.rs
@@ -444,6 +444,19 @@ pub(super) fn compute_bundle_signature(
     let base = compute_circuit_signature(tmpl_path, curve)?;
     let mut hasher = Sha256::new();
     hasher.update(base.as_bytes());
+    // Stability contract: any change to the on-wire / in-hash layout
+    // of the bytes mixed in below will silently re-shuffle every
+    // content-addressed component sha. The three inputs that must
+    // stay byte-stable are
+    //   * `jstprove_circuits::proof_config::ProofConfig::config_id()`
+    //     (CONFIG_ID integers documented in proof_config.rs),
+    //   * `StampedProofConfig::version` (u32, per
+    //     ProofConfig::current_version),
+    //   * `CircuitParams::weights_as_inputs` serialization (bool).
+    // If any of those change their encoding, bump the version tag in
+    // the marker below (for example `bundle-disambiguator-v2`) so
+    // downstream registries receive a deliberate re-shuffle rather
+    // than a silent one.
     hasher.update(b"\x00bundle-disambiguator-v1\x00");
 
     match jstprove_io::bundle::read_bundle_metadata::<jstprove_circuits::api::CircuitParamsType>(
@@ -461,8 +474,23 @@ pub(super) fn compute_bundle_signature(
             }
             hasher.update([u8::from(params.weights_as_inputs)]);
         }
-        Ok((None, _)) | Err(_) => {
+        Ok((None, _)) => {
             hasher.update([0u8]);
+        }
+        Err(e) => {
+            // A malformed or unreadable manifest is meaningfully
+            // different from a bundle that legitimately carries no
+            // metadata. Distinguish the two with separate
+            // discriminator bytes so a corrupt bundle cannot collide
+            // with a clean legacy bundle, and surface the failure in
+            // the tracing log so operators investigating a shifted
+            // sha have the underlying read error to reference.
+            tracing::warn!(
+                bundle = %bundle_dir.display(),
+                error = %e,
+                "bundle manifest read failed while computing bundle signature; using error discriminator"
+            );
+            hasher.update([2u8]);
         }
     }
 
@@ -1749,7 +1777,7 @@ mod tests {
     }
 
     #[test]
-    fn bundle_signature_matches_circuit_signature_when_bundle_has_no_metadata() {
+    fn bundle_signature_differs_from_circuit_signature_even_without_metadata() {
         let tmp = tempfile::tempdir().unwrap();
         let onnx_path = tmp.path().join("slice.onnx");
         write_identity_onnx(&onnx_path);

--- a/crates/dsperse/src/pipeline/packager.rs
+++ b/crates/dsperse/src/pipeline/packager.rs
@@ -8,7 +8,7 @@ use sha2::{Digest, Sha256};
 use walkdir::WalkDir;
 
 use crate::error::{DsperseError, Result};
-use crate::pipeline::compiler::compute_circuit_signature;
+use crate::pipeline::compiler::compute_bundle_signature;
 use crate::pipeline::runner::load_model_metadata;
 use crate::schema::metadata::SliceMetadata;
 use crate::utils::paths::resolve_relative_path;
@@ -418,7 +418,7 @@ fn extract_component(
 ) -> Result<(String, Vec<String>, Option<String>, ComponentSource)> {
     if let Some(dir) = resolve_circuit_dir(slices_dir, slice)? {
         let onnx_path = resolve_source_onnx(slices_dir, slice)?;
-        let sig = compute_circuit_signature(&onnx_path, curve)?;
+        let sig = compute_bundle_signature(&onnx_path, curve, &dir)?;
         let files = list_bundle_files(&dir)?;
         return Ok((
             sig,


### PR DESCRIPTION
## Summary

- `compute_circuit_signature` hashes only the ONNX graph plus optional curve string. Two bundles compiled from the same ONNX under different proof configs (bn254_raw vs goldilocks_ext4_whir), `weights_as_inputs` flags, or holographic/non-holographic setups collapse to the same content-addressed sha.
- On a mode switch the registry component row already exists; publisher probes the new manifest's files (which may add `vk.bin`), finds the old upload set, and trips the partial-upload guard in `publisher.rs:160`.
- Introduces `compute_bundle_signature` which wraps the onnx+curve base hash with discriminator bytes read from the compiled bundle manifest (stamped `proof_config` id plus version, `weights_as_inputs` flag) and a byte reflecting `vk.bin` presence. Packager switches to the new function. Compile-time cache lookups keep using the onnx-only hash because they key on pre-compile state where no bundle exists yet.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p dsperse --all-targets -- -D warnings`
- [x] `cargo build -p dsperse`
- [x] `cargo test -p dsperse --lib` (237 passed, including two new tests for the bundle signature path)
- [ ] Integration: re-package and re-publish a previously-published model after switching `--proof-config` or `--holographic`; confirm the component sha changes and publisher does not trip the partial-upload guard

## History

The branch carries an exploratory commit (`148a6bb1`) that introduced a bespoke `extract_outputs_full` backend method, followed by a revert (`fa44d5a2`) once it became clear that downstream holographic verifiers can source the scale parameters from existing `load_params` output. Retained in history to record the investigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bundle signatures now incorporate bundle metadata, version tags, presence of verification keys, and configuration variants; component identities for compiled bundles are derived from the bundle directory context.
  * Backend API: added a method to return the full extracted output bundle; the existing output-extraction method now delegates and returns just the numeric outputs.

* **Tests**
  * Added unit tests validating signature uniqueness, determinism, sensitivity to verification-key presence, and differentiation between proof configuration variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->