### PR TITLE
Resolve multi-input tiled wire dispatch dropping non-primary inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3483,9 +3483,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/crates/dsperse/src/pipeline/combined.rs
+++ b/crates/dsperse/src/pipeline/combined.rs
@@ -130,8 +130,24 @@ impl CombinedRun {
                     (t, Vec::new())
                 }
                 ExecutionStrategy::Tiled(tiling) => {
-                    let t = self.tensor_cache.get(&tiling.input_name)?.clone();
-                    (t, Vec::new())
+                    let names = tiling.all_input_names();
+                    if names.len() > 1 {
+                        let mut named: Vec<(String, ArrayD<f64>)> = Vec::with_capacity(names.len());
+                        let mut flat: Vec<f64> = Vec::new();
+                        for name in &names {
+                            let arr = self.tensor_cache.get(name)?;
+                            named.push(((*name).to_string(), arr.clone()));
+                            flat.extend(arr.iter());
+                        }
+                        let concatenated = ArrayD::from_shape_vec(IxDyn(&[flat.len()]), flat)
+                            .map_err(|e| {
+                                DsperseError::Pipeline(format!("tiled multi-input concat: {e}"))
+                            })?;
+                        (concatenated, named)
+                    } else {
+                        let t = self.tensor_cache.get(&tiling.input_name)?.clone();
+                        (t, Vec::new())
+                    }
                 }
                 ExecutionStrategy::Single { .. } => {
                     let filtered = &meta.dependencies.filtered_inputs;

--- a/crates/dsperse/src/pipeline/mod.rs
+++ b/crates/dsperse/src/pipeline/mod.rs
@@ -26,5 +26,7 @@ pub use runner::{RunConfig, extract_onnx_initializers, run_inference};
 pub use slice_cache::SliceAssets;
 pub use strategy::ExecutionStrategy;
 pub use tensor_store::TensorStore;
-pub use tiled::{reconstruct_from_tiles, split_for_tiling, split_into_tiles};
+pub use tiled::{
+    reconstruct_from_tiles, split_for_multi_input_dispatch, split_for_tiling, split_into_tiles,
+};
 pub use verifier::verify_run;

--- a/crates/dsperse/src/pipeline/tiled.rs
+++ b/crates/dsperse/src/pipeline/tiled.rs
@@ -619,6 +619,19 @@ pub fn split_for_multi_input_dispatch(
             "split_for_multi_input_dispatch: named_inputs is empty".into(),
         ));
     }
+    let expected_names = tiling.all_input_names();
+    let provided: std::collections::HashSet<&str> =
+        named_inputs.iter().map(|(n, _)| n.as_str()).collect();
+    let missing: Vec<&str> = expected_names
+        .iter()
+        .copied()
+        .filter(|n| !provided.contains(n))
+        .collect();
+    if !missing.is_empty() {
+        return Err(DsperseError::Pipeline(format!(
+            "split_for_multi_input_dispatch: missing input tensors required by tiling.all_input_names(): {missing:?}"
+        )));
+    }
     let mut cache = TensorStore::new();
     for (name, arr) in named_inputs {
         cache.put(name.clone(), arr.clone());

--- a/crates/dsperse/src/pipeline/tiled.rs
+++ b/crates/dsperse/src/pipeline/tiled.rs
@@ -649,6 +649,11 @@ pub fn split_for_multi_input_dispatch(
         ));
     }
     let num_tiles = all_tiles[0].len();
+    if num_tiles == 0 {
+        return Err(DsperseError::Pipeline(
+            "split_for_multi_input_dispatch: tiling produced zero tiles".into(),
+        ));
+    }
     for (idx, per_input) in all_tiles.iter().enumerate() {
         if per_input.len() != num_tiles {
             return Err(DsperseError::Pipeline(format!(

--- a/crates/dsperse/src/pipeline/tiled.rs
+++ b/crates/dsperse/src/pipeline/tiled.rs
@@ -604,6 +604,53 @@ pub(crate) fn prepare_tiles_from_cache(
     Ok(all_tiles)
 }
 
+/// Build per-tile dispatch payloads for a tiled slice that consumes multiple
+/// upstream activation tensors per witness. Returns one entry per tile; each
+/// entry is the concatenation, in `tiling.all_input_names()` order, of that
+/// tile's segment from each input tensor. The element count of every returned
+/// entry equals `N * per_input_tile_size`, matching what the slice's compiled
+/// witness solver consumes per request.
+pub fn split_for_multi_input_dispatch(
+    named_inputs: &[(String, ArrayD<f64>)],
+    tiling: &TilingInfo,
+) -> Result<Vec<Vec<f64>>> {
+    if named_inputs.is_empty() {
+        return Err(DsperseError::Pipeline(
+            "split_for_multi_input_dispatch: named_inputs is empty".into(),
+        ));
+    }
+    let mut cache = TensorStore::new();
+    for (name, arr) in named_inputs {
+        cache.put(name.clone(), arr.clone());
+    }
+    let is_fixed_segment = tiling.ndim == 1;
+    let is_1d = tiling.ndim == 3;
+    let all_tiles = if is_fixed_segment {
+        prepare_fixed_segments_from_cache(tiling, &cache)?
+    } else {
+        prepare_tiles_from_cache(tiling, &cache, is_1d)?
+    };
+    if all_tiles.is_empty() {
+        return Err(DsperseError::Pipeline(
+            "split_for_multi_input_dispatch: empty tile set".into(),
+        ));
+    }
+    let num_tiles = all_tiles[0].len();
+    for (idx, per_input) in all_tiles.iter().enumerate() {
+        if per_input.len() != num_tiles {
+            return Err(DsperseError::Pipeline(format!(
+                "split_for_multi_input_dispatch: input {idx} produced {} tiles, expected {num_tiles}",
+                per_input.len()
+            )));
+        }
+    }
+    let mut per_tile = Vec::with_capacity(num_tiles);
+    for tile_idx in 0..num_tiles {
+        per_tile.push(flatten_tile_inputs(&all_tiles, tile_idx));
+    }
+    Ok(per_tile)
+}
+
 pub fn split_for_tiling(input: &ArrayD<f64>, tiling: &TilingInfo) -> Result<Vec<ArrayD<f64>>> {
     let is_fixed_segment = tiling.ndim == 1;
     if is_fixed_segment {

--- a/crates/dsperse/src/pipeline/tiled.rs
+++ b/crates/dsperse/src/pipeline/tiled.rs
@@ -620,12 +620,24 @@ pub fn split_for_multi_input_dispatch(
         ));
     }
     let expected_names = tiling.all_input_names();
-    let provided: std::collections::HashSet<&str> =
-        named_inputs.iter().map(|(n, _)| n.as_str()).collect();
+    let mut seen = std::collections::HashSet::with_capacity(named_inputs.len());
+    let mut duplicates: Vec<&str> = Vec::new();
+    for (name, _) in named_inputs {
+        if !seen.insert(name.as_str()) {
+            duplicates.push(name.as_str());
+        }
+    }
+    if !duplicates.is_empty() {
+        duplicates.sort_unstable();
+        duplicates.dedup();
+        return Err(DsperseError::Pipeline(format!(
+            "split_for_multi_input_dispatch: named_inputs contains duplicate input tensor names (would silently overwrite via TensorStore::put): {duplicates:?}"
+        )));
+    }
     let missing: Vec<&str> = expected_names
         .iter()
         .copied()
-        .filter(|n| !provided.contains(n))
+        .filter(|n| !seen.contains(n))
         .collect();
     if !missing.is_empty() {
         return Err(DsperseError::Pipeline(format!(


### PR DESCRIPTION
## Summary

The wire-dispatch path through `CombinedRun::all_circuit_work` (combined.rs:122-152) Tiled branch reads only `tiling.input_name` (the single primary tensor) while the witness solver compiled into the bundle for that slice expects N concatenated input segments per tile, where N = `tiling.all_input_names().len()`.

For slices with `input_names.len() > 1` the resulting per-request payload is `segment_size` elements arriving where the witness solver expects `N * segment_size`. Downstream this surfaces as `Witness generation failed: activation length mismatch: expected N*segment_size, got segment_size` at the consuming miner. The local-prove path in `tiled.rs` (lines 33, 125-130, 942) was already correct because it iterates `all_input_names` and produces `tile_in_0..tile_in_N` per-tile inputs — only the wire/dispatch path was incomplete.

## Changes

- `combined.rs::all_circuit_work` Tiled branch — when `tiling.all_input_names().len() > 1`, gather every named tensor, record them in `SliceWork.named_inputs`, and set `SliceWork.input` to the concatenation. Aggregate-size preflight on the consumer (validator) remains satisfied because `work.input.len()` now equals the model-level total. Single-input tilings retain the historical single-tensor path.
- `tiled.rs::split_for_multi_input_dispatch` — new public helper that takes `named_inputs: &[(String, ArrayD<f64>)]` plus `&TilingInfo` and returns `Vec<Vec<f64>>` (one entry per tile, each entry is the in-order concatenation of that tile's segment from each named input). Reuses `prepare_fixed_segments_from_cache`, `prepare_tiles_from_cache`, and `flatten_tile_inputs` so 1D fixed-segment and 4D/3D spatial tilings are both covered.
- `pipeline/mod.rs` — re-export `split_for_multi_input_dispatch` so consumers (subnet-2 validator) can build per-tile dispatch payloads without re-implementing tile geometry.

## Why

The slicer emits `tiling.input_names` (plural) when a tiled circuit consumes multiple upstream activations per witness — attention QKV concat, residual+sublayer combinations, etc. The compiled circuit bundle's `manifest.msgpack` declares `params.inputs` totalling `N * tile_size` elements per witness; the witness solver enforces it (`jstprove_circuits/src/onnx.rs:426`). The `tiling.input_name` (singular) field is the primary/output-naming hint, not the full input set; using only it on dispatch silently drops the other N-1 tensors and produces an undersized payload that the bundle correctly rejects. This change makes the wire path symmetric with the local-prove path that already handles multi-input tilings via `all_input_names()`.

## Test plan

- [x] `cargo build -p dsperse`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --check`
- [ ] Coordinated validator change in subnet-2 will drive `split_for_multi_input_dispatch` from `stage_tiled_work` and verify that requests for slice_48 / slice_56 in rfdetr-nano (3 and 2 input names respectively) now carry `3 * 384 = 1152` and `2 * 384 = 768` element payloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tiled execution now supports multiple input tensors and produces combined per-tile payloads.
  * Preserves previous behavior when only a single input is provided.

* **Bug Fixes / Validation**
  * Adds stricter validation and clear errors for empty, duplicate, missing, or mismatched inputs during tiled dispatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->