### PR TITLE
Develop per-slice activation snapshot writer for combined inference runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -971,6 +971,7 @@ version = "0.0.0"
 dependencies = [
  "clap",
  "criterion",
+ "half",
  "jstprove-io",
  "jstprove_circuits",
  "libc",
@@ -994,6 +995,7 @@ dependencies = [
  "uuid",
  "walkdir",
  "zip",
+ "zstd",
 ]
 
 [[package]]

--- a/crates/dsperse/Cargo.toml
+++ b/crates/dsperse/Cargo.toml
@@ -30,6 +30,8 @@ jstprove_circuits.workspace = true
 jstprove_io.workspace = true
 reqwest.workspace = true
 tokio.workspace = true
+half = "2"
+zstd = "0.13"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/dsperse/src/cli/mod.rs
+++ b/crates/dsperse/src/cli/mod.rs
@@ -589,6 +589,13 @@ pub fn cmd_full_run(args: FullRunArgs) -> Result<()> {
         ));
     }
 
+    if args.activations_dir.is_some() && !args.combined {
+        return Err(DsperseError::Other(
+            "--activations-dir requires --combined true (snapshots are written only on the combined inference path)"
+                .into(),
+        ));
+    }
+
     let layers = args
         .layers
         .as_ref()
@@ -614,13 +621,6 @@ pub fn cmd_full_run(args: FullRunArgs) -> Result<()> {
     }
 
     let run_dir = args.model_dir.join("run").join(format!("run_{}", run_id()));
-
-    if args.activations_dir.is_some() && !args.combined {
-        return Err(DsperseError::Other(
-            "--activations-dir requires --combined true (snapshots are written only on the combined inference path)"
-                .into(),
-        ));
-    }
 
     let config = RunConfig {
         parallel: args.parallel.get(),

--- a/crates/dsperse/src/cli/mod.rs
+++ b/crates/dsperse/src/cli/mod.rs
@@ -176,6 +176,11 @@ pub struct RunArgs {
         help = "Run inference on combined monolithic ONNX instead of per-slice execution"
     )]
     pub combined: bool,
+    #[arg(
+        long,
+        help = "Directory to write per-slice activation snapshots (slice_<N>.bin, fp16 + zstd) for every slice in the combined run"
+    )]
+    pub activations_dir: Option<PathBuf>,
 }
 
 #[derive(Args)]
@@ -293,6 +298,11 @@ pub struct FullRunArgs {
         help = "Run inference on combined monolithic ONNX instead of per-slice execution"
     )]
     pub combined: bool,
+    #[arg(
+        long,
+        help = "Directory to write per-slice activation snapshots (slice_<N>.bin, fp16 + zstd) for every slice in the combined run"
+    )]
+    pub activations_dir: Option<PathBuf>,
     #[arg(
         long = "proof-config",
         visible_alias = "curve",
@@ -465,6 +475,7 @@ pub fn cmd_run(args: RunArgs) -> Result<()> {
         batch: args.batch,
         weights_onnx: args.weights,
         combined: args.combined,
+        activations_dir: args.activations_dir,
     };
 
     pipeline::run_inference(&slices_dir, &args.input_file, &run_dir, &backend, &config)?;
@@ -602,6 +613,7 @@ pub fn cmd_full_run(args: FullRunArgs) -> Result<()> {
         batch: args.batch,
         weights_onnx: args.weights,
         combined: args.combined,
+        activations_dir: args.activations_dir,
     };
 
     tracing::info!("running inference");

--- a/crates/dsperse/src/cli/mod.rs
+++ b/crates/dsperse/src/cli/mod.rs
@@ -463,6 +463,13 @@ pub fn cmd_run(args: RunArgs) -> Result<()> {
         )));
     }
 
+    if args.activations_dir.is_some() && !args.combined {
+        return Err(DsperseError::Other(
+            "--activations-dir requires --combined true (snapshots are written only on the combined inference path)"
+                .into(),
+        ));
+    }
+
     let backend = JstproveBackend::new();
     let slices_dir = resolve_slices_dir(args.slices_dir, &args.model_dir);
 
@@ -607,6 +614,13 @@ pub fn cmd_full_run(args: FullRunArgs) -> Result<()> {
     }
 
     let run_dir = args.model_dir.join("run").join(format!("run_{}", run_id()));
+
+    if args.activations_dir.is_some() && !args.combined {
+        return Err(DsperseError::Other(
+            "--activations-dir requires --combined true (snapshots are written only on the combined inference path)"
+                .into(),
+        ));
+    }
 
     let config = RunConfig {
         parallel: args.parallel.get(),

--- a/crates/dsperse/src/pipeline/activations.rs
+++ b/crates/dsperse/src/pipeline/activations.rs
@@ -1,0 +1,127 @@
+//! Per-slice activation snapshot writer.
+//!
+//! After a combined inference run the `TensorStore` holds every slice's
+//! output tensor keyed by ONNX tensor name. This module serializes each
+//! slice's output tensor to disk under `<dir>/slice_<index>.bin` as a
+//! self-describing fp16 + zstd payload so downstream consumers can render
+//! activation maps for every slice including non-circuit ones.
+
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::Path;
+
+use half::f16;
+use ndarray::ArrayD;
+use zstd::stream::write::Encoder;
+
+use crate::error::{DsperseError, Result};
+use crate::pipeline::tensor_store::TensorStore;
+use crate::schema::metadata::ModelMetadata;
+
+/// File magic for `slice_<N>.bin` activation snapshots: "DAST" (Dsperse
+/// Activation Snapshot Tensor). Little-endian u32 = 0x54534144.
+pub const ACTIVATION_MAGIC: [u8; 4] = *b"DAST";
+pub const ACTIVATION_VERSION: u8 = 1;
+const DTYPE_FP16: u8 = 1;
+const ZSTD_LEVEL: i32 = 3;
+const MAX_RANK: usize = 8;
+
+/// Writes one `slice_<index>.bin` per slice into `dir`. Slices whose
+/// output tensor is not present in the cache are skipped (logged at debug).
+pub fn write_slice_activations(
+    dir: &Path,
+    model_meta: &ModelMetadata,
+    cache: &TensorStore,
+) -> Result<()> {
+    fs::create_dir_all(dir).map_err(|e| DsperseError::io(e, dir))?;
+
+    let mut written = 0usize;
+    let mut skipped = 0usize;
+
+    for slice in &model_meta.slices {
+        let candidate_names: Vec<&String> = slice.dependencies.output.iter().collect();
+        let tensor = candidate_names
+            .iter()
+            .find_map(|name| cache.try_get(name.as_str()));
+
+        let Some(tensor) = tensor else {
+            tracing::debug!(
+                slice_index = slice.index,
+                "slice activation snapshot skipped (no cached output tensor)"
+            );
+            skipped += 1;
+            continue;
+        };
+
+        let target = dir.join(format!("slice_{}.bin", slice.index));
+        write_one(&target, tensor)?;
+        written += 1;
+    }
+
+    tracing::info!(
+        dir = %dir.display(),
+        written,
+        skipped,
+        total = model_meta.slices.len(),
+        "wrote per-slice activation snapshots"
+    );
+
+    Ok(())
+}
+
+fn write_one(target: &Path, tensor: &ArrayD<f64>) -> Result<()> {
+    let rank = tensor.ndim();
+    if rank > MAX_RANK {
+        return Err(DsperseError::Pipeline(format!(
+            "activation tensor rank {rank} exceeds max {MAX_RANK}"
+        )));
+    }
+    let total: usize = tensor.shape().iter().product();
+    if total > u32::MAX as usize {
+        return Err(DsperseError::Pipeline(format!(
+            "activation tensor too large for u32 element count: {total}"
+        )));
+    }
+
+    let file = File::create(target).map_err(|e| DsperseError::io(e, target))?;
+    let mut enc = Encoder::new(file, ZSTD_LEVEL).map_err(|e| DsperseError::io(e, target))?;
+
+    // Header (12 + rank*4 bytes), all little-endian.
+    enc.write_all(&ACTIVATION_MAGIC)
+        .map_err(|e| DsperseError::io(e, target))?;
+    enc.write_all(&[ACTIVATION_VERSION, DTYPE_FP16, rank as u8, 0])
+        .map_err(|e| DsperseError::io(e, target))?;
+    enc.write_all(&(total as u32).to_le_bytes())
+        .map_err(|e| DsperseError::io(e, target))?;
+    for dim in tensor.shape() {
+        let d = *dim as u32;
+        enc.write_all(&d.to_le_bytes())
+            .map_err(|e| DsperseError::io(e, target))?;
+    }
+
+    // Body: contiguous fp16 values in row-major order.
+    let contiguous = tensor.as_standard_layout();
+    let slice = contiguous
+        .as_slice()
+        .ok_or_else(|| DsperseError::Pipeline("activation tensor not contiguous".into()))?;
+    let mut chunk = [0u8; 8192];
+    let mut buf_i = 0usize;
+    for &v in slice {
+        let h = f16::from_f64(v).to_le_bytes();
+        chunk[buf_i] = h[0];
+        chunk[buf_i + 1] = h[1];
+        buf_i += 2;
+        if buf_i == chunk.len() {
+            enc.write_all(&chunk)
+                .map_err(|e| DsperseError::io(e, target))?;
+            buf_i = 0;
+        }
+    }
+    if buf_i > 0 {
+        enc.write_all(&chunk[..buf_i])
+            .map_err(|e| DsperseError::io(e, target))?;
+    }
+
+    enc.finish().map_err(|e| DsperseError::io(e, target))?;
+    Ok(())
+}

--- a/crates/dsperse/src/pipeline/activations.rs
+++ b/crates/dsperse/src/pipeline/activations.rs
@@ -77,11 +77,14 @@ fn write_one(target: &Path, tensor: &ArrayD<f64>) -> Result<()> {
         )));
     }
     let total: usize = tensor.shape().iter().product();
-    if total > u32::MAX as usize {
-        return Err(DsperseError::Pipeline(format!(
+    let total_u32 = u32::try_from(total).map_err(|_| {
+        DsperseError::Pipeline(format!(
             "activation tensor too large for u32 element count: {total}"
-        )));
-    }
+        ))
+    })?;
+    let rank_u8 = u8::try_from(rank).map_err(|_| {
+        DsperseError::Pipeline(format!("activation tensor rank {rank} exceeds u8::MAX"))
+    })?;
 
     let file = File::create(target).map_err(|e| DsperseError::io(e, target))?;
     let mut enc = Encoder::new(file, ZSTD_LEVEL).map_err(|e| DsperseError::io(e, target))?;
@@ -89,12 +92,17 @@ fn write_one(target: &Path, tensor: &ArrayD<f64>) -> Result<()> {
     // Header (12 + rank*4 bytes), all little-endian.
     enc.write_all(&ACTIVATION_MAGIC)
         .map_err(|e| DsperseError::io(e, target))?;
-    enc.write_all(&[ACTIVATION_VERSION, DTYPE_FP16, rank as u8, 0])
+    enc.write_all(&[ACTIVATION_VERSION, DTYPE_FP16, rank_u8, 0])
         .map_err(|e| DsperseError::io(e, target))?;
-    enc.write_all(&(total as u32).to_le_bytes())
+    enc.write_all(&total_u32.to_le_bytes())
         .map_err(|e| DsperseError::io(e, target))?;
     for dim in tensor.shape() {
-        let d = *dim as u32;
+        let d = u32::try_from(*dim).map_err(|_| {
+            DsperseError::Pipeline(format!(
+                "activation tensor dimension {dim} exceeds u32::MAX in {}",
+                target.display()
+            ))
+        })?;
         enc.write_all(&d.to_le_bytes())
             .map_err(|e| DsperseError::io(e, target))?;
     }

--- a/crates/dsperse/src/pipeline/mod.rs
+++ b/crates/dsperse/src/pipeline/mod.rs
@@ -1,3 +1,4 @@
+pub mod activations;
 mod channel_split;
 mod combined;
 mod compiler;

--- a/crates/dsperse/src/pipeline/runner.rs
+++ b/crates/dsperse/src/pipeline/runner.rs
@@ -28,6 +28,7 @@ pub struct RunConfig {
     pub batch: bool,
     pub weights_onnx: Option<PathBuf>,
     pub combined: bool,
+    pub activations_dir: Option<PathBuf>,
 }
 
 impl Default for RunConfig {
@@ -37,6 +38,7 @@ impl Default for RunConfig {
             batch: false,
             weights_onnx: None,
             combined: true,
+            activations_dir: None,
         }
     }
 }
@@ -753,6 +755,14 @@ fn run_combined_inference(
         &output_path,
         &build_msgpack_map(vec![("output_data", output_val)]),
     )?;
+
+    if let Some(activations_dir) = config.activations_dir.as_ref() {
+        crate::pipeline::activations::write_slice_activations(
+            activations_dir,
+            model_meta,
+            &tensor_cache,
+        )?;
+    }
 
     tracing::info!(
         run_dir = %run_dir.display(),

--- a/crates/dsperse/src/python.rs
+++ b/crates/dsperse/src/python.rs
@@ -168,6 +168,7 @@ fn run_inference(
         batch,
         weights_onnx: weights_onnx.map(PathBuf::from),
         combined,
+        activations_dir: None,
     };
     let sd = PathBuf::from(slices_dir);
     let inf = PathBuf::from(input_file);


### PR DESCRIPTION
## Summary

- Adds `--activations-dir <path>` to `dsperse run` and `dsperse full-run`.
- After `run_combined_inference` finishes, iterates `model_meta.slices` and looks up each slice's output tensor in the populated `TensorStore`. Each is written as `<dir>/slice_<index>.bin` so downstream consumers can render activation maps for **every** slice in the model — including non-circuit / bypass slices that produce no witness or proof artifact.
- New module `crates/dsperse/src/pipeline/activations.rs`. Format is a self-describing fp16 + zstd payload with header:
  ```
  [4B  magic = 'DAST']
  [1B  version = 1]
  [1B  dtype  = 1 (fp16)]
  [1B  rank]
  [1B  reserved]
  [4B  u32 LE total element count]
  [rank × 4B u32 LE dim extents]
  [body: rank-many * Π dims * fp16 LE elements]
  ```
- Wired through the python binding constructor (`activations_dir: None` by default) so the existing PyO3 surface is unchanged.

## Test plan

- [ ] `cargo build -p dsperse --bin dsperse` (clean)
- [ ] `cargo clippy -p dsperse --bin dsperse -- -D warnings` (clean)
- [ ] `cargo fmt --check` (clean)
- [ ] On a real aim-track combined run, confirm `<activations-dir>/slice_<N>.bin` is produced for every slice in `metadata.msgpack`, header magic/version/rank match the runtime tensor shape, and the fp16 round-trip stays within 1e-3 of the source f64
- [ ] Confirm Python `_native.run(..., activations_dir=None)` keeps existing behaviour (no extra writes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional --activations-dir flag to run and full-run to export per-slice activation snapshots as compressed, versioned binary files (fp16, zstd).
* **Chores**
  * Added runtime libraries to support fp16 conversion and zstd compression.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/inference-labs-inc/dsperse/pull/202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->