### PR TITLE
Develop per-chunk activation-weight dispatch for dim-split matmul slice circuits

### DIFF
--- a/crates/dsperse/src/pipeline/combined.rs
+++ b/crates/dsperse/src/pipeline/combined.rs
@@ -175,6 +175,7 @@ impl CombinedRun {
                 use_circuit: node.use_circuit,
                 tiling: meta.tiling.clone(),
                 channel_split: meta.channel_split.clone(),
+                dim_split: meta.dim_split.clone(),
                 circuit_path: node.circuit_path.clone(),
                 onnx_path: node.onnx_path.clone(),
                 slice_meta: meta.clone(),

--- a/crates/dsperse/src/pipeline/dim_split.rs
+++ b/crates/dsperse/src/pipeline/dim_split.rs
@@ -527,7 +527,7 @@ pub fn dim_split_weight_and_transb(
             ))
         })?;
     let expected_weight_len = ds.k_dim.saturating_mul(ds.n_dim);
-    if expected_weight_len > 0 && full_weight.len() != expected_weight_len {
+    if full_weight.len() != expected_weight_len {
         return Err(DsperseError::Pipeline(format!(
             "dim-split slice {}: weight {weight_name:?} length {} does not match k_dim*n_dim = {}*{} = {}",
             ds.slice_idx,
@@ -624,7 +624,7 @@ mod tests {
     fn weight_chunk_partitions_full_weight_along_k() {
         let ds = slice_148_meta();
         let full: Vec<f32> = (0..ds.k_dim)
-            .flat_map(|k| std::iter::repeat(k as f32).take(ds.n_dim))
+            .flat_map(|k| std::iter::repeat_n(k as f32, ds.n_dim))
             .collect();
         let c0 = dim_split_weight_chunk(&full, &ds, 0, false);
         let c1 = dim_split_weight_chunk(&full, &ds, 1, false);
@@ -634,6 +634,24 @@ mod tests {
         assert_eq!(*c0.last().unwrap(), 191.0);
         assert_eq!(c1[0], 192.0);
         assert_eq!(*c1.last().unwrap(), 383.0);
+    }
+
+    #[test]
+    fn weight_chunk_transposed_gemm_band_ordering() {
+        let ds = DimSplitInfo {
+            slice_idx: 7,
+            k_dim: 4,
+            n_dim: 3,
+            k_chunks: 2,
+            ..Default::default()
+        };
+        let full: Vec<f32> = (0..ds.n_dim)
+            .flat_map(|r| (0..ds.k_dim).map(move |c| (r * 10 + c) as f32))
+            .collect();
+        let c0 = dim_split_weight_chunk(&full, &ds, 0, true);
+        let c1 = dim_split_weight_chunk(&full, &ds, 1, true);
+        assert_eq!(c0, vec![0.0, 1.0, 10.0, 11.0, 20.0, 21.0]);
+        assert_eq!(c1, vec![2.0, 3.0, 12.0, 13.0, 22.0, 23.0]);
     }
 
     #[test]

--- a/crates/dsperse/src/pipeline/dim_split.rs
+++ b/crates/dsperse/src/pipeline/dim_split.rs
@@ -526,6 +526,17 @@ pub fn dim_split_weight_and_transb(
                 ds.slice_idx
             ))
         })?;
+    let expected_weight_len = ds.k_dim.saturating_mul(ds.n_dim);
+    if expected_weight_len > 0 && full_weight.len() != expected_weight_len {
+        return Err(DsperseError::Pipeline(format!(
+            "dim-split slice {}: weight {weight_name:?} length {} does not match k_dim*n_dim = {}*{} = {}",
+            ds.slice_idx,
+            full_weight.len(),
+            ds.k_dim,
+            ds.n_dim,
+            expected_weight_len
+        )));
+    }
     Ok((full_weight, trans_b))
 }
 

--- a/crates/dsperse/src/pipeline/dim_split.rs
+++ b/crates/dsperse/src/pipeline/dim_split.rs
@@ -164,37 +164,7 @@ fn execute_matmul_dim_split(
 
     let mut patched_paths: Vec<std::path::PathBuf> = Vec::with_capacity(k_chunks);
     for kc in 0..k_chunks {
-        let k_start = kc * k_chunk_size;
-        let k_end = (k_start + k_chunk_size).min(k_dim);
-        let actual_k = k_end.saturating_sub(k_start);
-
-        let weight_chunk: Vec<f32> = if trans_b {
-            let mut w = Vec::with_capacity(n_dim * k_chunk_size);
-            for row_idx in 0..n_dim {
-                let row_start = row_idx * k_dim + k_start;
-                let avail = actual_k.min(full_weight.len().saturating_sub(row_start));
-                w.extend_from_slice(&full_weight[row_start..row_start + avail]);
-                if avail < k_chunk_size {
-                    w.resize(w.len() + k_chunk_size - avail, 0.0);
-                }
-            }
-            w
-        } else {
-            let mut w = Vec::with_capacity(k_chunk_size * n_dim);
-            for ki in k_start..k_start + actual_k {
-                let start = ki * n_dim;
-                let end = start + n_dim;
-                if end <= full_weight.len() {
-                    w.extend_from_slice(&full_weight[start..end]);
-                } else {
-                    w.resize(w.len() + n_dim, 0.0);
-                }
-            }
-            if actual_k < k_chunk_size {
-                w.resize(k_chunk_size * n_dim, 0.0);
-            }
-            w
-        };
+        let weight_chunk = dim_split_weight_chunk(&full_weight, ds, kc, trans_b);
 
         let mut patched = tmpl_model.clone();
         let graph = patched.graph.as_mut().ok_or_else(|| {
@@ -233,14 +203,7 @@ fn execute_matmul_dim_split(
         let mut row_accum = vec![0.0f64; n_dim];
 
         for (kc, patched_path) in patched_paths.iter().enumerate() {
-            let k_start = kc * k_chunk_size;
-            let k_end = (k_start + k_chunk_size).min(k_dim);
-            let actual_k = k_end.saturating_sub(k_start);
-
-            let mut input_chunk = vec![0.0f64; k_chunk_size];
-            if actual_k > 0 {
-                input_chunk[..actual_k].copy_from_slice(&full_row[k_start..k_end]);
-            }
+            let input_chunk = dim_split_row_chunk(&full_row, kc, k_dim, k_chunk_size);
 
             let input_arr =
                 ndarray::ArrayD::from_shape_vec(ndarray::IxDyn(&[1, k_chunk_size]), input_chunk)
@@ -417,6 +380,179 @@ fn execute_generic_dim_split(
     Ok(final_result)
 }
 
+pub fn dim_split_unit_count(total_rows: usize, ds: &crate::schema::tiling::DimSplitInfo) -> usize {
+    total_rows.saturating_mul(ds.k_chunks.max(1))
+}
+
+fn dim_split_row_chunk(row: &[f64], kc: usize, k_dim: usize, k_chunk_size: usize) -> Vec<f64> {
+    let k_start = kc * k_chunk_size;
+    let k_end = (k_start + k_chunk_size).min(k_dim);
+    let actual_k = k_end.saturating_sub(k_start);
+    let mut chunk = vec![0.0f64; k_chunk_size];
+    if actual_k > 0 {
+        chunk[..actual_k].copy_from_slice(&row[k_start..k_end]);
+    }
+    chunk
+}
+
+pub fn dim_split_weight_chunk(
+    full_weight: &[f32],
+    ds: &crate::schema::tiling::DimSplitInfo,
+    kc: usize,
+    trans_b: bool,
+) -> Vec<f32> {
+    let k_dim = ds.k_dim;
+    let n_dim = ds.n_dim;
+    let k_chunks = ds.k_chunks.max(1);
+    let k_chunk_size = k_dim.div_ceil(k_chunks);
+    let k_start = kc * k_chunk_size;
+    let k_end = (k_start + k_chunk_size).min(k_dim);
+    let actual_k = k_end.saturating_sub(k_start);
+    if trans_b {
+        let mut w = Vec::with_capacity(n_dim * k_chunk_size);
+        for row_idx in 0..n_dim {
+            let row_start = row_idx * k_dim + k_start;
+            let avail = actual_k.min(full_weight.len().saturating_sub(row_start));
+            w.extend_from_slice(&full_weight[row_start..row_start + avail]);
+            if avail < k_chunk_size {
+                w.resize(w.len() + k_chunk_size - avail, 0.0);
+            }
+        }
+        w
+    } else {
+        let mut w = Vec::with_capacity(k_chunk_size * n_dim);
+        for ki in k_start..k_start + actual_k {
+            let start = ki * n_dim;
+            let end = start + n_dim;
+            if end <= full_weight.len() {
+                w.extend_from_slice(&full_weight[start..end]);
+            } else {
+                w.resize(w.len() + n_dim, 0.0);
+            }
+        }
+        if actual_k < k_chunk_size {
+            w.resize(k_chunk_size * n_dim, 0.0);
+        }
+        w
+    }
+}
+
+pub fn split_for_dim_split_dispatch(
+    input: &ndarray::ArrayD<f64>,
+    ds: &crate::schema::tiling::DimSplitInfo,
+) -> Result<Vec<Vec<f64>>> {
+    let input_shape = input.shape().to_vec();
+    let k_dim = *input_shape.last().unwrap_or(&0);
+    if k_dim == 0 {
+        return Err(DsperseError::Pipeline(format!(
+            "dim-split slice {}: input {:?} has zero-width last dim",
+            ds.slice_idx, ds.input_name
+        )));
+    }
+    if ds.k_dim != 0 && k_dim != ds.k_dim {
+        return Err(DsperseError::Pipeline(format!(
+            "dim-split slice {}: runtime k_dim {k_dim} does not match metadata k_dim {}",
+            ds.slice_idx, ds.k_dim
+        )));
+    }
+    let k_chunks = ds.k_chunks.max(1);
+    let k_chunk_size = k_dim.div_ceil(k_chunks);
+    let total_rows: usize = input_shape
+        .iter()
+        .take(input_shape.len().saturating_sub(1))
+        .product();
+    let flat = input
+        .as_standard_layout()
+        .into_owned()
+        .into_shape_with_order(ndarray::IxDyn(&[total_rows, k_dim]))
+        .map_err(|e| {
+            DsperseError::Pipeline(format!(
+                "dim-split slice {}: flatten input: {e}",
+                ds.slice_idx
+            ))
+        })?;
+    let mut units = Vec::with_capacity(dim_split_unit_count(total_rows, ds));
+    for r in 0..total_rows {
+        let row: Vec<f64> = flat.slice(ndarray::s![r, ..]).iter().copied().collect();
+        for kc in 0..k_chunks {
+            units.push(dim_split_row_chunk(&row, kc, k_dim, k_chunk_size));
+        }
+    }
+    Ok(units)
+}
+
+pub fn dim_split_weight_and_transb(
+    slice_onnx_path: &Path,
+    ds: &crate::schema::tiling::DimSplitInfo,
+) -> Result<(Vec<f32>, bool)> {
+    let weight_name = ds.weight_name.as_ref().ok_or_else(|| {
+        DsperseError::Pipeline(format!(
+            "dim-split slice {}: missing weight_name in metadata",
+            ds.slice_idx
+        ))
+    })?;
+    let model = crate::slicer::onnx_proto::load_model(slice_onnx_path)?;
+    let graph = model.graph.as_ref().ok_or_else(|| {
+        DsperseError::Pipeline(format!(
+            "dim-split slice {}: ONNX has no graph",
+            ds.slice_idx
+        ))
+    })?;
+    let matmul_node = graph
+        .node
+        .iter()
+        .find(|n| {
+            matches!(n.op_type.as_str(), "MatMul" | "Gemm")
+                && n.input.iter().any(|i| i == weight_name)
+                && n.input.iter().any(|i| i == &ds.input_name)
+                && n.output.iter().any(|o| o == &ds.output_name)
+        })
+        .ok_or_else(|| {
+            DsperseError::Pipeline(format!(
+                "dim-split slice {}: no MatMul/Gemm node matches weight={weight_name:?}",
+                ds.slice_idx
+            ))
+        })?;
+    let trans_b = matmul_node.op_type == "Gemm"
+        && crate::slicer::onnx_proto::get_attribute_int(matmul_node, "transB").unwrap_or(0) == 1;
+    let full_weight = graph
+        .initializer
+        .iter()
+        .find(|i| i.name == *weight_name)
+        .map(crate::slicer::onnx_proto::tensor_to_f32)
+        .ok_or_else(|| {
+            DsperseError::Pipeline(format!(
+                "dim-split slice {}: weight {weight_name:?} not in ONNX initializers",
+                ds.slice_idx
+            ))
+        })?;
+    Ok((full_weight, trans_b))
+}
+
+pub fn dim_split_bound_inputs(
+    input: &ndarray::ArrayD<f64>,
+    slice_onnx_path: &Path,
+    ds: &crate::schema::tiling::DimSplitInfo,
+) -> Result<Vec<Vec<f64>>> {
+    let activations = split_for_dim_split_dispatch(input, ds)?;
+    let (full_weight, trans_b) = dim_split_weight_and_transb(slice_onnx_path, ds)?;
+    let k_chunks = ds.k_chunks.max(1);
+    let weight_chunks: Vec<Vec<f64>> = (0..k_chunks)
+        .map(|kc| {
+            dim_split_weight_chunk(&full_weight, ds, kc, trans_b)
+                .into_iter()
+                .map(f64::from)
+                .collect()
+        })
+        .collect();
+    let mut bound = Vec::with_capacity(activations.len());
+    for (unit_idx, mut payload) in activations.into_iter().enumerate() {
+        payload.extend_from_slice(&weight_chunks[unit_idx % k_chunks]);
+        bound.push(payload);
+    }
+    Ok(bound)
+}
+
 fn resolve_output_shape(
     slice_id: &str,
     input_shape: &[usize],
@@ -440,5 +576,59 @@ fn resolve_output_shape(
             *last = n_dim;
         }
         Ok(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::tiling::DimSplitInfo;
+    use ndarray::{ArrayD, IxDyn};
+
+    fn slice_148_meta() -> DimSplitInfo {
+        DimSplitInfo {
+            slice_idx: 148,
+            k_dim: 384,
+            n_dim: 1536,
+            k_chunks: 2,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn dispatch_split_matches_local_chunk_geometry() {
+        let ds = slice_148_meta();
+        let input = ArrayD::from_shape_fn(IxDyn(&[4, 145, 384]), |d| (d[2] as f64) + 1.0);
+        let units = split_for_dim_split_dispatch(&input, &ds).unwrap();
+        assert_eq!(units.len(), 4 * 145 * 2);
+        assert_eq!(dim_split_unit_count(4 * 145, &ds), units.len());
+        assert!(units.iter().all(|u| u.len() == 192));
+        assert_eq!(units[0][0], 1.0);
+        assert_eq!(units[0][191], 192.0);
+        assert_eq!(units[1][0], 193.0);
+        assert_eq!(units[1][191], 384.0);
+    }
+
+    #[test]
+    fn weight_chunk_partitions_full_weight_along_k() {
+        let ds = slice_148_meta();
+        let full: Vec<f32> = (0..ds.k_dim)
+            .flat_map(|k| std::iter::repeat(k as f32).take(ds.n_dim))
+            .collect();
+        let c0 = dim_split_weight_chunk(&full, &ds, 0, false);
+        let c1 = dim_split_weight_chunk(&full, &ds, 1, false);
+        assert_eq!(c0.len(), 192 * ds.n_dim);
+        assert_eq!(c1.len(), 192 * ds.n_dim);
+        assert_eq!(c0[0], 0.0);
+        assert_eq!(*c0.last().unwrap(), 191.0);
+        assert_eq!(c1[0], 192.0);
+        assert_eq!(*c1.last().unwrap(), 383.0);
+    }
+
+    #[test]
+    fn split_rejects_k_dim_mismatch() {
+        let ds = slice_148_meta();
+        let bad = ArrayD::zeros(IxDyn(&[4, 145, 256]));
+        assert!(split_for_dim_split_dispatch(&bad, &ds).is_err());
     }
 }

--- a/crates/dsperse/src/pipeline/incremental.rs
+++ b/crates/dsperse/src/pipeline/incremental.rs
@@ -5,7 +5,7 @@ use ndarray::ArrayD;
 use crate::error::{DsperseError, Result};
 use crate::schema::execution::{ExecutionChain, ExecutionInfo, ExecutionResultEntry, RunMetadata};
 use crate::schema::metadata::{BackendKind, ModelMetadata, RunSliceMetadata};
-use crate::schema::tiling::{ChannelSplitInfo, TilingInfo};
+use crate::schema::tiling::{ChannelSplitInfo, DimSplitInfo, TilingInfo};
 
 use super::runner::{build_execution_chain, build_run_metadata, load_model_metadata};
 use super::strategy::ExecutionStrategy;
@@ -19,6 +19,7 @@ pub struct SliceWork {
     pub use_circuit: bool,
     pub tiling: Option<TilingInfo>,
     pub channel_split: Option<ChannelSplitInfo>,
+    pub dim_split: Option<DimSplitInfo>,
     pub circuit_path: Option<String>,
     pub onnx_path: Option<String>,
     pub slice_meta: RunSliceMetadata,
@@ -121,6 +122,7 @@ impl IncrementalRun {
             use_circuit: node.use_circuit,
             tiling: meta.tiling.clone(),
             channel_split: meta.channel_split.clone(),
+            dim_split: meta.dim_split.clone(),
             circuit_path: node.circuit_path.clone(),
             onnx_path: node.onnx_path.clone(),
             slice_meta: meta.clone(),

--- a/crates/dsperse/src/pipeline/mod.rs
+++ b/crates/dsperse/src/pipeline/mod.rs
@@ -21,9 +21,13 @@ pub use compiler::{
     CompileReport, HolographicSetupReport, SliceAnalysisReport, analyze_slices, compile_slices,
     setup_holographic_for_slices,
 };
+pub use dim_split::{
+    dim_split_bound_inputs, dim_split_unit_count, dim_split_weight_and_transb,
+    dim_split_weight_chunk, split_for_dim_split_dispatch,
+};
 pub use incremental::{IncrementalRun, SliceExecutionResult, SliceWork};
 pub use prover::prove_run;
-pub use runner::{RunConfig, extract_onnx_initializers, run_inference};
+pub use runner::{RunConfig, extract_onnx_initializers, run_inference, split_inline_wai_inputs};
 pub use slice_cache::SliceAssets;
 pub use strategy::ExecutionStrategy;
 pub use tensor_store::TensorStore;

--- a/crates/dsperse/src/pipeline/runner.rs
+++ b/crates/dsperse/src/pipeline/runner.rs
@@ -1188,6 +1188,37 @@ fn is_activation_placeholder(name: &str) -> bool {
         || (name.starts_with("group_") && name.ends_with("_in"))
 }
 
+pub fn split_inline_wai_inputs(
+    params: &CircuitParams,
+    flat: &[f64],
+) -> Option<(Vec<f64>, Vec<(Vec<f64>, Vec<usize>)>)> {
+    if !params.weights_as_inputs {
+        return None;
+    }
+    let total: usize = params
+        .inputs
+        .iter()
+        .map(|io| io.shape.iter().product::<usize>())
+        .sum();
+    if total == 0 || flat.len() != total {
+        return None;
+    }
+    let mut activations: Vec<f64> = Vec::new();
+    let mut initializers: Vec<(Vec<f64>, Vec<usize>)> = Vec::new();
+    let mut cursor = 0usize;
+    for io in &params.inputs {
+        let n: usize = io.shape.iter().product();
+        let seg = &flat[cursor..cursor + n];
+        cursor += n;
+        if is_activation_placeholder(&io.name) {
+            activations.extend_from_slice(seg);
+        } else {
+            initializers.push((seg.to_vec(), io.shape.clone()));
+        }
+    }
+    Some((activations, initializers))
+}
+
 pub(crate) fn extract_initializers_from_map(
     init_map: &HashMap<String, &TensorProto>,
     params: &CircuitParams,

--- a/crates/dsperse/src/pipeline/runner.rs
+++ b/crates/dsperse/src/pipeline/runner.rs
@@ -1188,10 +1188,9 @@ fn is_activation_placeholder(name: &str) -> bool {
         || (name.starts_with("group_") && name.ends_with("_in"))
 }
 
-pub fn split_inline_wai_inputs(
-    params: &CircuitParams,
-    flat: &[f64],
-) -> Option<(Vec<f64>, Vec<(Vec<f64>, Vec<usize>)>)> {
+pub type WaiInputs = (Vec<f64>, Vec<(Vec<f64>, Vec<usize>)>);
+
+pub fn split_inline_wai_inputs(params: &CircuitParams, flat: &[f64]) -> Option<WaiInputs> {
     if !params.weights_as_inputs {
         return None;
     }


### PR DESCRIPTION
## Summary

Dim-split matmul slices compile to a single shared template circuit `(dim_tmpl_in, W)` whose weight is a runtime input, so one slice expands into a circuit instance per `(row, k-chunk)`, each with a distinct weight band. The distributed dispatch forwarded the full untiled activation tensor to this template, which the per-chunk circuit rejected on its activation-length contract (`expected 192, got 222720` style mismatches).

This expands a dim-split slice into its per-`(row, k-chunk)` units and dispatches each as the bound public-input vector `[dim_tmpl_in_chunk ++ W_chunk]`, with the weight band sliced on the dispatching side so the proof binds the dispatched weight rather than any value supplied at witness time.

## Changes

- `split_for_dim_split_dispatch` / `dim_split_weight_chunk` / `dim_split_bound_inputs` / `dim_split_weight_and_transb` / `dim_split_unit_count`: per-`(row, k-chunk)` activation + weight-band materialization.
- `split_inline_wai_inputs`: reconstructs the activation/initializer partition from the circuit's declared input shapes (weight inputs located by activation-placeholder naming), so a witness generates without re-reading the slice ONNX.
- `SliceWork.dim_split` carried through both work constructors so dispatch and verification can recognize the strategy.
- Local matmul executor shares `dim_split_weight_chunk` for its own weight slicing.

## Validation

- New unit tests: chunk geometry vs the local executor, weight-band partition, k_dim guard.
- End-to-end against the real `model-950b4647` slice_148 dim-template bundle: the inline `[192 ++ 192x1536]` split feeds the actual circuit and generates a valid witness; the prior activation-length gate is cleared.
- `cargo fmt` / `clippy` clean.

Paired with a subnet-2 change that adds the dim-split dispatch loop, preflight, unit counter, miner inline-split, and verification binding; that side re-pins to the tagged release of this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved dim-split support by carrying split configuration through slice work items.
  * Added new dim-splitting helpers for dispatch chunking and weight/activation chunk preparation.
  * Added support for splitting inline “weights as inputs” while preserving input shape metadata.
* **Bug Fixes**
  * Fixed dim-split slice-work metadata population and corrected transposed/non-transposed chunk geometry handling, including `k`-dimension validation.
* **Tests**
  * Added coverage for dispatch sizing/placement, weight chunk partitioning (including `trans_b=true`), and validation/error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->