### PR TITLE
Resolve multi-input split slices deriving only their primary activation tensor

### DIFF
--- a/crates/dsperse/src/pipeline/combined.rs
+++ b/crates/dsperse/src/pipeline/combined.rs
@@ -174,9 +174,15 @@ impl CombinedRun {
             named_inputs,
             backend: node.backend,
             use_circuit: node.use_circuit,
-            tiling: meta.tiling.clone(),
-            channel_split: meta.channel_split.clone(),
-            dim_split: meta.dim_split.clone(),
+            tiling: matches!(strategy, ExecutionStrategy::Tiled(_))
+                .then(|| meta.tiling.clone())
+                .flatten(),
+            channel_split: matches!(strategy, ExecutionStrategy::ChannelSplit(_))
+                .then(|| meta.channel_split.clone())
+                .flatten(),
+            dim_split: matches!(strategy, ExecutionStrategy::DimSplit(_))
+                .then(|| meta.dim_split.clone())
+                .flatten(),
             circuit_path: node.circuit_path.clone(),
             onnx_path: node.onnx_path.clone(),
             slice_meta: meta.clone(),

--- a/crates/dsperse/src/pipeline/incremental.rs
+++ b/crates/dsperse/src/pipeline/incremental.rs
@@ -120,9 +120,15 @@ impl IncrementalRun {
             named_inputs,
             backend: node.backend,
             use_circuit: node.use_circuit,
-            tiling: meta.tiling.clone(),
-            channel_split: meta.channel_split.clone(),
-            dim_split: meta.dim_split.clone(),
+            tiling: matches!(strategy, ExecutionStrategy::Tiled(_))
+                .then(|| meta.tiling.clone())
+                .flatten(),
+            channel_split: matches!(strategy, ExecutionStrategy::ChannelSplit(_))
+                .then(|| meta.channel_split.clone())
+                .flatten(),
+            dim_split: matches!(strategy, ExecutionStrategy::DimSplit(_))
+                .then(|| meta.dim_split.clone())
+                .flatten(),
             circuit_path: node.circuit_path.clone(),
             onnx_path: node.onnx_path.clone(),
             slice_meta: meta.clone(),

--- a/crates/dsperse/src/pipeline/strategy.rs
+++ b/crates/dsperse/src/pipeline/strategy.rs
@@ -23,10 +23,30 @@ impl<'a> ExecutionStrategy<'a> {
                 meta.path
             )));
         }
+        let multi_input = meta.dependencies.filtered_inputs.len() > 1;
         match meta.split_strategy() {
-            Some(SplitStrategy::ChannelSplit(cs)) => Ok(Self::ChannelSplit(cs)),
+            Some(SplitStrategy::ChannelSplit(cs)) => {
+                if multi_input {
+                    tracing::debug!(
+                        path = ?meta.path,
+                        inputs = meta.dependencies.filtered_inputs.len(),
+                        "channel_split slice consumes multiple activation inputs, falling back to single execution"
+                    );
+                    Ok(Self::Single { use_circuit })
+                } else {
+                    Ok(Self::ChannelSplit(cs))
+                }
+            }
             Some(SplitStrategy::DimSplit(ds)) => {
-                if ds.template_path.is_none() {
+                if multi_input {
+                    tracing::debug!(
+                        path = ?meta.path,
+                        split_kind = ?ds.split_kind,
+                        inputs = meta.dependencies.filtered_inputs.len(),
+                        "dim_split slice consumes multiple activation inputs, falling back to single execution"
+                    );
+                    Ok(Self::Single { use_circuit })
+                } else if ds.template_path.is_none() {
                     // Template creation may have been rejected (axis-
                     // separability, unsupported split kind) or the template
                     // was not included in the bundle. Fall back to the
@@ -66,5 +86,44 @@ impl<'a> ExecutionStrategy<'a> {
             Self::Tiled(tiling) => Some(&tiling.output_name),
             Self::Single { .. } => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::metadata::{Dependencies, RunSliceMetadata};
+    use crate::schema::tiling::{DimSplitInfo, DimSplitKind};
+
+    fn dim_split_meta(inputs: Vec<String>) -> RunSliceMetadata {
+        RunSliceMetadata {
+            dependencies: Dependencies {
+                input: inputs.clone(),
+                output: vec!["out".to_string()],
+                filtered_inputs: inputs,
+            },
+            dim_split: Some(DimSplitInfo {
+                split_kind: DimSplitKind::BatchDim,
+                input_name: "a".to_string(),
+                output_name: "out".to_string(),
+                template_path: Some("t.onnx".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn multi_input_dim_split_falls_back_to_single() {
+        let meta = dim_split_meta(vec!["a".to_string(), "b".to_string()]);
+        let strategy = ExecutionStrategy::from_metadata(&meta, true).unwrap();
+        assert!(matches!(strategy, ExecutionStrategy::Single { .. }));
+    }
+
+    #[test]
+    fn single_input_dim_split_keeps_dim_split_strategy() {
+        let meta = dim_split_meta(vec!["a".to_string()]);
+        let strategy = ExecutionStrategy::from_metadata(&meta, true).unwrap();
+        assert!(matches!(strategy, ExecutionStrategy::DimSplit(_)));
     }
 }

--- a/crates/dsperse/src/schema/metadata.rs
+++ b/crates/dsperse/src/schema/metadata.rs
@@ -133,7 +133,7 @@ impl SliceMetadata {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct RunSliceMetadata {
     #[serde(default)]
     pub path: String,


### PR DESCRIPTION
Slices carrying dim-split or channel-split metadata derived their dispatch payload from the strategy's primary input tensor alone. A slice consuming two activation inputs (every attention QK and AV matmul in transformer detection models) therefore produced half the elements its manifest and compiled circuit expect, and consumers discarded it as unsatisfiable. Analysis of a production model showed 31 of 460 slices affected, uniformly across attention blocks, matching miner reports of witness generation failures with activation length mismatches at exact 2x or missing-tensor deltas.

Split strategies now fall back to single execution when a slice consumes more than one activation input, mirroring the existing template-less dim-split fallback, and SliceWork split-metadata fields mirror the chosen strategy rather than raw manifest metadata so downstream dispatchers see a plain slice with the full concatenated payload its circuit was compiled for. Replayed against the affected production manifest, unsatisfiable slices drop from 31 to 0 with no artifact changes required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved strategy selection so multi-input slices now automatically fall back to a compatible execution path instead of using an unsupported split mode.
  * Slice processing now carries only the relevant split settings for the active strategy, reducing incorrect configuration data.

* **Tests**
  * Added coverage for strategy fallback behavior to ensure split selection works consistently for single-input and multi-input cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->