### PR TITLE
Develop group payload construction for multi-input dim-split dispatch

### DIFF
--- a/crates/dsperse/examples/inspect_bundle.rs
+++ b/crates/dsperse/examples/inspect_bundle.rs
@@ -1,0 +1,28 @@
+use dsperse::backend::jstprove::JstproveBackend;
+use std::path::Path;
+
+fn main() {
+    let bundle = std::env::args()
+        .nth(1)
+        .expect("usage: inspect_bundle <circuit.bundle>");
+    let backend = JstproveBackend::new();
+    let params = backend
+        .load_params(Path::new(&bundle))
+        .expect("load")
+        .expect("present");
+    println!("weights_as_inputs={}", params.weights_as_inputs);
+    for (i, io) in params.inputs.iter().enumerate() {
+        println!(
+            "input[{i}]: shape={:?} elems={}",
+            io.shape,
+            io.shape.iter().product::<usize>()
+        );
+    }
+    for (i, io) in params.outputs.iter().enumerate() {
+        println!(
+            "output[{i}]: shape={:?} elems={}",
+            io.shape,
+            io.shape.iter().product::<usize>()
+        );
+    }
+}

--- a/crates/dsperse/examples/verify_derivation.rs
+++ b/crates/dsperse/examples/verify_derivation.rs
@@ -1,0 +1,79 @@
+use dsperse::backend::jstprove::JstproveBackend;
+use dsperse::pipeline::CombinedRun;
+use ndarray::{ArrayD, IxDyn};
+use std::path::Path;
+
+fn main() {
+    let dir = std::env::args()
+        .nth(1)
+        .expect("usage: verify_derivation <slices_dir>");
+    let dir = Path::new(&dir);
+
+    let meta = dsperse::pipeline::runner::load_model_metadata(dir).expect("metadata");
+    let input_shape: Vec<usize> = meta.input_shape[0].iter().map(|&d| d as usize).collect();
+    let input = ArrayD::from_elem(IxDyn(&input_shape), 0.5_f64);
+
+    let run = CombinedRun::new(dir, input).expect("combined run");
+
+    let mut checked = 0usize;
+    let mut mismatched = Vec::new();
+    let all_ids: Vec<String> = (0..meta.slices.len())
+        .map(|i| format!("slice_{}", meta.slices[i].index))
+        .collect();
+    for slice_id in all_ids {
+        let work = match run.circuit_work_for(&slice_id) {
+            Ok(w) => w,
+            Err(e) => {
+                mismatched.push((slice_id, 0usize, 0usize, format!("derive error: {e}")));
+                continue;
+            }
+        };
+        let expected: usize = work
+            .slice_meta
+            .input_shape
+            .iter()
+            .map(|shape| shape.iter().product::<i64>() as usize)
+            .sum();
+        let derived = work.input.len();
+        checked += 1;
+        if expected != 0 && expected != derived {
+            mismatched.push((slice_id, expected, derived, String::new()));
+        }
+    }
+    println!("checked={checked} mismatched={}", mismatched.len());
+    for (id, e, d, err) in mismatched.iter().take(8) {
+        println!("  {id}: expected={e} derived={d} {err}");
+    }
+
+    let bundle = dir.join("slice_11/jstprove/circuit.bundle");
+    if bundle.exists() {
+        let backend = JstproveBackend::new();
+        let params = backend
+            .load_params(&bundle)
+            .expect("load params")
+            .expect("params present");
+        let work = run.circuit_work_for("slice_11").expect("slice_11 work");
+        let initializer_count = if params.weights_as_inputs {
+            let onnx = work.onnx_path.as_ref().expect("onnx path");
+            dsperse::pipeline::extract_onnx_initializers(Path::new(onnx), &params)
+                .expect("initializers")
+                .len()
+        } else {
+            0
+        };
+        let activation_entries = params.inputs.len() - initializer_count;
+        let bundle_expected: usize = params.inputs[..activation_entries]
+            .iter()
+            .map(|io| io.shape.iter().product::<usize>())
+            .sum();
+        println!(
+            "slice_11 validator-preflight contract: weights_as_inputs={} total_entries={} initializers={} activation_expected={} derived_payload={} match={}",
+            params.weights_as_inputs,
+            params.inputs.len(),
+            initializer_count,
+            bundle_expected,
+            work.input.len(),
+            bundle_expected == work.input.len()
+        );
+    }
+}

--- a/crates/dsperse/examples/witness_group.rs
+++ b/crates/dsperse/examples/witness_group.rs
@@ -1,0 +1,58 @@
+use dsperse::backend::jstprove::JstproveBackend;
+use dsperse::pipeline::{CombinedRun, dim_split_group_payloads};
+use ndarray::{ArrayD, IxDyn};
+use std::path::Path;
+
+fn main() {
+    let dir = std::env::args()
+        .nth(1)
+        .expect("usage: witness_group <slices_dir>");
+    let dir = Path::new(&dir);
+
+    let meta = dsperse::pipeline::runner::load_model_metadata(dir).expect("metadata");
+    let input_shape: Vec<usize> = meta.input_shape[0].iter().map(|&d| d as usize).collect();
+    let input = ArrayD::from_elem(IxDyn(&input_shape), 0.5_f64);
+    let run = CombinedRun::new(dir, input).expect("combined run");
+
+    let work = run.circuit_work_for("slice_11").expect("slice_11");
+    let ds = work
+        .slice_meta
+        .dim_split
+        .as_ref()
+        .expect("dim_split metadata");
+
+    let primary = work
+        .named_inputs
+        .iter()
+        .find(|(n, _)| n == &ds.input_name)
+        .map(|(_, t)| t)
+        .expect("primary tensor in named_inputs");
+    let secondaries: Vec<&ArrayD<f64>> = work
+        .named_inputs
+        .iter()
+        .filter(|(n, _)| n != &ds.input_name)
+        .map(|(_, t)| t)
+        .collect();
+    println!(
+        "primary={:?} secondaries={}",
+        primary.shape(),
+        secondaries.len()
+    );
+
+    let payloads = dim_split_group_payloads(primary, &secondaries, ds).expect("group payloads");
+    println!(
+        "groups={} payload_len={}",
+        payloads.len(),
+        payloads[0].len()
+    );
+
+    let backend = JstproveBackend::new();
+    let bundle = dir.join("slice_11/jstprove/circuit.bundle");
+    for g in [0usize, 14, 28] {
+        let result = backend.witness_f64(&bundle, &payloads[g], &[]);
+        match result {
+            Ok(w) => println!("group {g}: WITNESS OK ({} bytes)", w.len()),
+            Err(e) => println!("group {g}: WITNESS FAILED: {e}"),
+        }
+    }
+}

--- a/crates/dsperse/src/pipeline/dim_split.rs
+++ b/crates/dsperse/src/pipeline/dim_split.rs
@@ -661,3 +661,96 @@ mod tests {
         assert!(split_for_dim_split_dispatch(&bad, &ds).is_err());
     }
 }
+
+pub fn dim_split_group_payloads(
+    primary: &ndarray::ArrayD<f64>,
+    secondaries: &[&ndarray::ArrayD<f64>],
+    ds: &crate::schema::tiling::DimSplitInfo,
+) -> Result<Vec<Vec<f64>>> {
+    let shape = primary.shape();
+    if ds.split_dim >= shape.len() {
+        return Err(DsperseError::Pipeline(format!(
+            "dim-split slice {}: split_dim {} out of range for shape {:?}",
+            ds.slice_idx, ds.split_dim, shape
+        )));
+    }
+    if shape[ds.split_dim] != ds.dim_size {
+        return Err(DsperseError::Pipeline(format!(
+            "dim-split slice {}: runtime dim {} does not match metadata dim_size {}",
+            ds.slice_idx, shape[ds.split_dim], ds.dim_size
+        )));
+    }
+    if ds.num_groups == 0
+        || ds.elements_per_group == 0
+        || ds.num_groups * ds.elements_per_group != ds.dim_size
+    {
+        return Err(DsperseError::Pipeline(format!(
+            "dim-split slice {}: groups {}x{} do not cover dim_size {}",
+            ds.slice_idx, ds.num_groups, ds.elements_per_group, ds.dim_size
+        )));
+    }
+
+    let mut secondary_flat: Vec<f64> = Vec::new();
+    for s in secondaries {
+        secondary_flat.extend(s.as_standard_layout().iter());
+    }
+
+    let axis = ndarray::Axis(ds.split_dim);
+    let mut payloads = Vec::with_capacity(ds.num_groups);
+    for g in 0..ds.num_groups {
+        let start = g * ds.elements_per_group;
+        let group = primary.slice_axis(
+            axis,
+            ndarray::Slice::from(start..start + ds.elements_per_group),
+        );
+        let mut payload = secondary_flat.clone();
+        payload.extend(group.as_standard_layout().iter());
+        payloads.push(payload);
+    }
+    Ok(payloads)
+}
+
+#[cfg(test)]
+mod group_payload_tests {
+    use super::*;
+    use crate::schema::tiling::{DimSplitInfo, DimSplitKind};
+    use ndarray::{ArrayD, IxDyn};
+
+    fn ds(split_dim: usize, dim_size: usize, num_groups: usize, epg: usize) -> DimSplitInfo {
+        DimSplitInfo {
+            split_kind: DimSplitKind::BatchDim,
+            split_dim,
+            dim_size,
+            num_groups,
+            elements_per_group: epg,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn group_payloads_place_secondaries_first_and_cover_dim() {
+        let primary =
+            ArrayD::from_shape_vec(IxDyn(&[2, 4, 3]), (0..24).map(|v| v as f64).collect()).unwrap();
+        let secondary = ArrayD::from_elem(IxDyn(&[5]), 9.0);
+        let payloads = dim_split_group_payloads(&primary, &[&secondary], &ds(1, 4, 2, 2)).unwrap();
+        assert_eq!(payloads.len(), 2);
+        for p in &payloads {
+            assert_eq!(p.len(), 5 + 12);
+            assert!(p[..5].iter().all(|&v| v == 9.0));
+        }
+        assert_eq!(&payloads[0][5..11], &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0]);
+        assert_eq!(&payloads[1][5..11], &[6.0, 7.0, 8.0, 9.0, 10.0, 11.0]);
+    }
+
+    #[test]
+    fn group_payloads_reject_uncovered_dim() {
+        let primary = ArrayD::from_elem(IxDyn(&[2, 5, 3]), 1.0);
+        assert!(dim_split_group_payloads(&primary, &[], &ds(1, 5, 2, 2)).is_err());
+    }
+
+    #[test]
+    fn group_payloads_reject_shape_mismatch() {
+        let primary = ArrayD::from_elem(IxDyn(&[2, 4, 3]), 1.0);
+        assert!(dim_split_group_payloads(&primary, &[], &ds(1, 5, 1, 5)).is_err());
+    }
+}

--- a/crates/dsperse/src/pipeline/mod.rs
+++ b/crates/dsperse/src/pipeline/mod.rs
@@ -22,8 +22,8 @@ pub use compiler::{
     setup_holographic_for_slices,
 };
 pub use dim_split::{
-    dim_split_bound_inputs, dim_split_unit_count, dim_split_weight_and_transb,
-    dim_split_weight_chunk, split_for_dim_split_dispatch,
+    dim_split_bound_inputs, dim_split_group_payloads, dim_split_unit_count,
+    dim_split_weight_and_transb, dim_split_weight_chunk, split_for_dim_split_dispatch,
 };
 pub use incremental::{IncrementalRun, SliceExecutionResult, SliceWork};
 pub use prover::prove_run;


### PR DESCRIPTION
Introduces dim_split_group_payloads: for a slice whose circuits are compiled per group, each payload is the concatenation of the slice's secondary activation tensors followed by one group of the primary tensor along the split dimension, matching the published circuit contract (verified by loading a production group circuit's parameters: secondary tensors occupy the leading input entries, the primary group the trailing one).

Verified end-to-end locally against production artifacts: for an affected attention matmul slice, all 29 derived group payloads match the compiled contract exactly, and witness generation against the published circuit bundle succeeds for the first, middle, and last groups using tensors derived from real model inference. Example harnesses for bundle inspection, derivation verification, and group witness testing are included.

Groups must cover the split dimension exactly; uncovered or mismatched shapes are rejected. This is the dsperse half of inference-labs-inc/subnet-2#572; the dispatcher integration follows separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added example tools for inspecting bundles, verifying derivation outputs, and generating witness data for grouped inputs.
  * Added a helper for splitting tensor inputs into per-group payloads, including support for secondary inputs.

* **Bug Fixes**
  * Added validation to catch mismatched split dimensions, incomplete group coverage, and inconsistent shape metadata.

* **Tests**
  * Added coverage for payload ordering and validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->