### PR TITLE
Resolve shared-axis secondary inputs in dim-split group payloads

### DIFF
--- a/crates/dsperse/examples/witness_group.rs
+++ b/crates/dsperse/examples/witness_group.rs
@@ -14,7 +14,10 @@ fn main() {
     let input = ArrayD::from_elem(IxDyn(&input_shape), 0.5_f64);
     let run = CombinedRun::new(dir, input).expect("combined run");
 
-    let work = run.circuit_work_for("slice_11").expect("slice_11");
+    let slice_id = std::env::args()
+        .nth(2)
+        .unwrap_or_else(|| "slice_11".to_string());
+    let work = run.circuit_work_for(&slice_id).expect("slice work");
     let ds = work
         .slice_meta
         .dim_split
@@ -47,8 +50,9 @@ fn main() {
     );
 
     let backend = JstproveBackend::new();
-    let bundle = dir.join("slice_11/jstprove/circuit.bundle");
-    for g in [0usize, 14, 28] {
+    let bundle = dir.join(&slice_id).join("jstprove/circuit.bundle");
+    let last = payloads.len() - 1;
+    for g in [0usize, last / 2, last] {
         let result = backend.witness_f64(&bundle, &payloads[g], &[]);
         match result {
             Ok(w) => println!("group {g}: WITNESS OK ({} bytes)", w.len()),

--- a/crates/dsperse/src/pipeline/dim_split.rs
+++ b/crates/dsperse/src/pipeline/dim_split.rs
@@ -690,21 +690,35 @@ pub fn dim_split_group_payloads(
         )));
     }
 
-    let mut secondary_flat: Vec<f64> = Vec::new();
-    for s in secondaries {
-        secondary_flat.extend(s.as_standard_layout().iter());
-    }
-
     let axis = ndarray::Axis(ds.split_dim);
+    let shares_axis = |t: &ndarray::ArrayD<f64>| {
+        ds.split_dim < t.ndim() && t.shape()[ds.split_dim] == ds.dim_size
+    };
+
+    let whole_secondaries: Vec<Vec<f64>> = secondaries
+        .iter()
+        .map(|t| {
+            if shares_axis(t) {
+                Vec::new()
+            } else {
+                t.as_standard_layout().iter().copied().collect()
+            }
+        })
+        .collect();
+
     let mut payloads = Vec::with_capacity(ds.num_groups);
     for g in 0..ds.num_groups {
         let start = g * ds.elements_per_group;
-        let group = primary.slice_axis(
-            axis,
-            ndarray::Slice::from(start..start + ds.elements_per_group),
-        );
-        let mut payload = secondary_flat.clone();
-        payload.extend(group.as_standard_layout().iter());
+        let range = ndarray::Slice::from(start..start + ds.elements_per_group);
+        let mut payload: Vec<f64> = Vec::new();
+        for (t, whole) in secondaries.iter().zip(&whole_secondaries) {
+            if shares_axis(t) {
+                payload.extend(t.slice_axis(axis, range).as_standard_layout().iter());
+            } else {
+                payload.extend_from_slice(whole);
+            }
+        }
+        payload.extend(primary.slice_axis(axis, range).as_standard_layout().iter());
         payloads.push(payload);
     }
     Ok(payloads)
@@ -725,6 +739,26 @@ mod group_payload_tests {
             elements_per_group: epg,
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn shared_axis_secondaries_are_split_with_the_primary() {
+        let primary =
+            ArrayD::from_shape_vec(IxDyn(&[2, 4, 3]), (0..24).map(|v| v as f64).collect()).unwrap();
+        let shared =
+            ArrayD::from_shape_vec(IxDyn(&[1, 4, 3]), (100..112).map(|v| v as f64).collect())
+                .unwrap();
+        let payloads = dim_split_group_payloads(&primary, &[&shared], &ds(1, 4, 2, 2)).unwrap();
+        assert_eq!(payloads.len(), 2);
+        assert_eq!(payloads[0].len(), 6 + 12);
+        assert_eq!(
+            &payloads[0][..6],
+            &[100.0, 101.0, 102.0, 103.0, 104.0, 105.0]
+        );
+        assert_eq!(
+            &payloads[1][..6],
+            &[106.0, 107.0, 108.0, 109.0, 110.0, 111.0]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Group payload construction carried every secondary activation tensor whole. That matches contraction-style slices (attention QK and AV, where the counterpart tensor is consumed fully by every group) but not elementwise or broadcast slices where secondaries share the split axis: their group circuits are compiled against correspondingly sliced secondaries, so whole-secondary payloads failed witness generation and those slices were excluded after dispatch.

Secondaries whose size at the split axis equals the split dimension are now sliced with the primary; others ride whole, preserving the verified contraction behavior byte for byte. Verified against production circuits: the shared-axis slice witnesses on both groups with exactly the compiled contract, the contraction regression case still witnesses identically, and the all-split multi-input case produces the exact activation prefix its circuit declares, with trailing onnx initializers appended by the existing prover-side fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for choosing a slice ID from the command line in the example workflow, rather than always using the default slice.
  * Witness-group processing now adapts to the selected slice and iterates over payload groups more flexibly.

* **Bug Fixes**
  * Improved payload splitting so secondary data that shares the split axis is now partitioned consistently with the primary data.
  * Non-splitting secondary data continues to be reused across groups without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->