### PR TITLE
Resolve slice work circuit and onnx paths against the slices directory

### DIFF
--- a/crates/dsperse/examples/shape_probe.rs
+++ b/crates/dsperse/examples/shape_probe.rs
@@ -1,0 +1,62 @@
+use dsperse::pipeline::CombinedRun;
+use ndarray::{ArrayD, IxDyn};
+
+fn main() {
+    let dir = std::env::args()
+        .nth(1)
+        .expect("usage: shape_probe <slices_dir>");
+    let dir = std::path::Path::new(&dir);
+    let meta = dsperse::pipeline::runner::load_model_metadata(dir).expect("metadata");
+    let input_shape: Vec<usize> = meta.input_shape[0].iter().map(|&d| d as usize).collect();
+    let input = ArrayD::from_elem(IxDyn(&input_shape), 0.5_f64);
+    let run = CombinedRun::new(dir, input).expect("combined run");
+    for slice_id in ["slice_11", "slice_393", "slice_354"] {
+        let work = match run.circuit_work_for(slice_id) {
+            Ok(w) => w,
+            Err(e) => {
+                println!("{slice_id}: {e}");
+                continue;
+            }
+        };
+        let meta_shapes = &work.slice_meta.input_shape;
+        println!("{slice_id}: circuit_path={:?}", work.circuit_path);
+        for (i, (name, t)) in work.named_inputs.iter().enumerate() {
+            let meta = meta_shapes.get(i).cloned().unwrap_or_default();
+            println!(
+                "  input {i} {name}: runtime={:?} metadata={:?}",
+                t.shape(),
+                meta
+            );
+        }
+        let Some(circuit_path) = work.circuit_path.as_ref() else {
+            println!("  -> circuit_path MISSING");
+            continue;
+        };
+        let backend = dsperse::backend::jstprove::JstproveBackend::new();
+        let params = match backend.load_params(std::path::Path::new(circuit_path)) {
+            Ok(Some(p)) => p,
+            other => {
+                println!("  -> load_params FAILED: {:?}", other.map(|o| o.is_some()));
+                continue;
+            }
+        };
+        let Some(ds) = work.slice_meta.dim_split.as_ref() else {
+            println!("  -> no dim_split");
+            continue;
+        };
+        let manifest_shapes: Vec<Vec<usize>> = work
+            .named_inputs
+            .iter()
+            .map(|(_, t)| t.shape().to_vec())
+            .collect();
+        let contract: Vec<(String, Vec<usize>)> = params
+            .inputs
+            .iter()
+            .map(|io| (io.name.clone(), io.shape.clone()))
+            .collect();
+        match dsperse::pipeline::plan_group_payload(&manifest_shapes, ds, &contract) {
+            Ok(plan) => println!("  -> PLAN OK: {plan:?}"),
+            Err(e) => println!("  -> PLAN ERR: {e}"),
+        }
+    }
+}

--- a/crates/dsperse/src/pipeline/combined.rs
+++ b/crates/dsperse/src/pipeline/combined.rs
@@ -183,10 +183,26 @@ impl CombinedRun {
             dim_split: matches!(strategy, ExecutionStrategy::DimSplit(_))
                 .then(|| meta.dim_split.clone())
                 .flatten(),
-            circuit_path: node.circuit_path.clone(),
-            onnx_path: node.onnx_path.clone(),
+            circuit_path: node
+                .circuit_path
+                .as_deref()
+                .map(|p| self.absolute_work_path(p))
+                .transpose()?,
+            onnx_path: node
+                .onnx_path
+                .as_deref()
+                .map(|p| self.absolute_work_path(p))
+                .transpose()?,
             slice_meta: meta.clone(),
         })
+    }
+
+    fn absolute_work_path(&self, path: &str) -> Result<String> {
+        if Path::new(path).is_absolute() {
+            return Ok(path.to_string());
+        }
+        crate::utils::paths::resolve_relative_path(&self.slices_dir, path)
+            .map(|p| p.to_string_lossy().into_owned())
     }
 
     pub fn all_circuit_work(&self) -> Result<Vec<SliceWork>> {


### PR DESCRIPTION
Slice work records carried circuit and onnx paths verbatim from run metadata, where they are stored relative to the slices directory. Any consumer resolving them from a different working directory failed to open the bundle: dispatch preflight silently skipped its contract check for every grouped slice, and contract planning refused to dispatch them. Reproduced directly by loading a production model run from an unrelated working directory.

Paths are now resolved against the slices directory at slice work construction, passing already absolute values through unchanged since materialization rewrites some entries in place. The shape probe example loads a production run and executes parameter loading plus contract planning end to end, and all structural classes plan correctly from an arbitrary working directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new example that probes slice-specific model inputs, prints runtime and metadata shapes, and attempts payload planning for several sample slices.

* **Bug Fixes**
  * Improved path handling so model and circuit paths can be resolved correctly when stored as relative paths, reducing failures caused by path mismatches.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->