### PR TITLE
Introduce shaped output tensor accessor for named circuit outputs

### DIFF
--- a/crates/dsperse/src/pipeline/combined.rs
+++ b/crates/dsperse/src/pipeline/combined.rs
@@ -261,6 +261,14 @@ impl CombinedRun {
         self.outputs_for_names(output_names)
     }
 
+    pub fn output_arrays_for_names(&self, names: &[String]) -> Option<Vec<ArrayD<f64>>> {
+        let mut arrays = Vec::with_capacity(names.len());
+        for name in names {
+            arrays.push(self.tensor_cache.try_get(name)?.clone());
+        }
+        if arrays.is_empty() { None } else { Some(arrays) }
+    }
+
     pub fn outputs_for_names(&self, names: &[String]) -> Option<Vec<f64>> {
         let mut flat = Vec::new();
         for name in names {

--- a/crates/dsperse/src/pipeline/combined.rs
+++ b/crates/dsperse/src/pipeline/combined.rs
@@ -266,7 +266,11 @@ impl CombinedRun {
         for name in names {
             arrays.push(self.tensor_cache.try_get(name)?.clone());
         }
-        if arrays.is_empty() { None } else { Some(arrays) }
+        if arrays.is_empty() {
+            None
+        } else {
+            Some(arrays)
+        }
     }
 
     pub fn outputs_for_names(&self, names: &[String]) -> Option<Vec<f64>> {


### PR DESCRIPTION
Named circuit outputs were only retrievable as one flattened vector, which is insufficient for consumers that need to compare a partial result against the matching region of the expected tensor: group split dispatch returns one group's output, and validating it requires slicing the expected tensor along the concatenation axis, which needs shape information. Adds an accessor returning the shaped arrays per requested name alongside the existing flattened form.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new way to retrieve output tensors as arrays, making it easier to work with structured results directly.
  * Supports fetching multiple named outputs in one call and returns no result when no names are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->