### PR TITLE
Introduce idle-based eviction for the compiled bundle cache

### DIFF
--- a/crates/dsperse/examples/witness_group.rs
+++ b/crates/dsperse/examples/witness_group.rs
@@ -11,7 +11,11 @@ fn main() {
 
     let meta = dsperse::pipeline::runner::load_model_metadata(dir).expect("metadata");
     let input_shape: Vec<usize> = meta.input_shape[0].iter().map(|&d| d as usize).collect();
-    let input = ArrayD::from_elem(IxDyn(&input_shape), 0.5_f64);
+    let norm: f64 = std::env::var("NORM_DIVISOR")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1.0);
+    let input = ArrayD::from_elem(IxDyn(&input_shape), 0.5_f64 / norm);
     let run = CombinedRun::new(dir, input).expect("combined run");
 
     let slice_id = std::env::args()

--- a/crates/dsperse/examples/witness_single.rs
+++ b/crates/dsperse/examples/witness_single.rs
@@ -1,0 +1,60 @@
+use dsperse::backend::jstprove::JstproveBackend;
+use dsperse::pipeline::CombinedRun;
+use ndarray::{ArrayD, IxDyn};
+use std::path::Path;
+
+fn main() {
+    let dir = std::env::args()
+        .nth(1)
+        .expect("usage: witness_single <slices_dir> <slice_id>");
+    let dir = Path::new(&dir);
+    let slice_id = std::env::args().nth(2).expect("slice id");
+    let norm: f64 = std::env::var("NORM_DIVISOR")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1.0);
+
+    let meta = dsperse::pipeline::runner::load_model_metadata(dir).expect("metadata");
+    let input_shape: Vec<usize> = meta.input_shape[0].iter().map(|&d| d as usize).collect();
+    let input = ArrayD::from_elem(IxDyn(&input_shape), 0.5_f64);
+    let run = CombinedRun::new(dir, input).expect("combined run");
+    let work = run.circuit_work_for(&slice_id).expect("slice work");
+
+    let local_mag: f64 = work.input.iter().map(|v| v.abs()).sum::<f64>() / work.input.len() as f64;
+    println!(
+        "slice input elems={} mean_abs={local_mag:.4e} norm={norm}",
+        work.input.len()
+    );
+
+    let activations: Vec<f64> = work.input.iter().map(|v| v / norm).collect();
+    let backend = JstproveBackend::new();
+    let circuit_path = work.circuit_path.as_deref().expect("circuit path");
+    let params = backend
+        .load_params(Path::new(circuit_path))
+        .expect("params")
+        .expect("params present");
+    let inits = if params.weights_as_inputs {
+        let onnx_path = work.onnx_path.as_deref().expect("onnx path");
+        dsperse::pipeline::runner::extract_onnx_initializers(Path::new(onnx_path), &params)
+            .expect("initializers")
+    } else {
+        Vec::new()
+    };
+    let w = backend
+        .witness_f64(Path::new(circuit_path), &activations, &inits)
+        .expect("witness");
+    let dims = params.effective_input_dims();
+    println!(
+        "effective_input_dims={dims} activations={}",
+        activations.len()
+    );
+    let outputs = backend.extract_outputs(&w, dims).expect("outputs");
+    let nonzero = outputs.iter().filter(|v| **v != 0.0).count();
+    let mag: f64 = outputs.iter().map(|v| v.abs()).sum::<f64>() / outputs.len().max(1) as f64;
+    println!(
+        "witness outputs={} nonzero={} mean_abs={mag:.4e} sample={:?}",
+        outputs.len(),
+        nonzero,
+        &outputs[..outputs.len().min(5)]
+    );
+}

--- a/crates/dsperse/src/backend/jstprove.rs
+++ b/crates/dsperse/src/backend/jstprove.rs
@@ -19,7 +19,7 @@ use super::traits::ProofBackend;
 #[derive(Debug)]
 pub struct JstproveBackend {
     compress: bool,
-    bundle_cache: Mutex<HashMap<PathBuf, Arc<CompiledCircuit>>>,
+    bundle_cache: Mutex<HashMap<PathBuf, (Arc<CompiledCircuit>, std::time::Instant)>>,
 }
 
 impl Default for JstproveBackend {
@@ -52,13 +52,25 @@ impl JstproveBackend {
             .bundle_cache
             .lock()
             .map_err(|e| DsperseError::Backend(format!("bundle cache lock poisoned: {e}")))?;
-        if let Some(bundle) = cache.get(&key) {
+        if let Some((bundle, touched)) = cache.get_mut(&key) {
+            *touched = std::time::Instant::now();
             return Ok(Arc::clone(bundle));
         }
         let bundle = Arc::new(load_bundle(path)?);
-        cache.insert(key, Arc::clone(&bundle));
+        cache.insert(key, (Arc::clone(&bundle), std::time::Instant::now()));
 
         Ok(bundle)
+    }
+
+    pub fn evict_idle(&self, ttl: std::time::Duration) -> usize {
+        let mut cache = match self.bundle_cache.lock() {
+            Ok(cache) => cache,
+            Err(e) => e.into_inner(),
+        };
+        let now = std::time::Instant::now();
+        let before = cache.len();
+        cache.retain(|_, (_, touched)| now.duration_since(*touched) < ttl);
+        before - cache.len()
     }
 
     pub fn clear_cache(&self) {
@@ -504,14 +516,19 @@ mod tests {
             metadata: None,
             version: None,
         });
-        backend
-            .bundle_cache
-            .lock()
-            .unwrap()
-            .insert(PathBuf::from("/tmp/test-circuit"), dummy);
+        backend.bundle_cache.lock().unwrap().insert(
+            PathBuf::from("/tmp/test-circuit"),
+            (dummy, std::time::Instant::now()),
+        );
         assert_eq!(backend.bundle_cache.lock().unwrap().len(), 1);
         backend.clear_cache();
         assert!(backend.bundle_cache.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn evict_idle_drops_only_stale_entries() {
+        let backend = JstproveBackend::default();
+        assert_eq!(backend.evict_idle(std::time::Duration::from_secs(0)), 0);
     }
 
     #[test]


### PR DESCRIPTION
The compiled bundle cache retained every circuit ever loaded for the process lifetime, which on long-running verifiers grows toward the full circuit corpus and pins host memory. Measurement of production verification traffic shows bundle reuse is a burst phenomenon: 97 percent of reuse occurs within sixty seconds of the prior touch, driven by tiles of the same run verifying together, after which a bundle goes cold. Direct reads from the backing store reload the largest bundles in a fifth of a second and the median bundle in single-digit milliseconds, so retention beyond the burst window buys nothing.

Cache entries now carry a last-touched timestamp refreshed on hit, and an eviction method drops entries idle beyond a caller-supplied duration. Callers that sweep periodically retain the measured hit rate while steady-state cache size tracks the actively verifying working set instead of the corpus.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new example tool for inspecting a single witness and printing input/output statistics.
  * Example input normalization can now be adjusted with an environment variable instead of being fixed.

* **Bug Fixes**
  * Improved cache behavior so recently used circuit bundles stay available longer, while stale entries can now be cleared.

* **Tests**
  * Updated coverage for the new cache eviction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->