### PR TITLE
Introduce tensor store occupancy accounting for host memory observability

### DIFF
--- a/crates/dsperse/src/pipeline/combined.rs
+++ b/crates/dsperse/src/pipeline/combined.rs
@@ -394,6 +394,13 @@ impl CombinedRun {
     pub fn pending_count(&self) -> usize {
         self.pending_slices.len()
     }
+
+    /// Occupancy of the run's activation tensor cache as (tensor count,
+    /// total f64 elements), for host memory accounting. Elements times eight
+    /// approximates resident bytes.
+    pub fn tensor_store_stats(&self) -> (usize, usize) {
+        (self.tensor_cache.len(), self.tensor_cache.total_elements())
+    }
 }
 
 fn run_combined_onnx(


### PR DESCRIPTION
Hosts embedding combined runs have no visibility into the activation tensor cache each run carries, which is the last unmeasured large consumer in the validator's process footprint. This exposes a read-only accessor reporting the cache's tensor count and total element count so a host can convert occupancy to approximate resident bytes and chart it against the process resident set. No behavioral change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visibility into activation tensor cache usage, including the number of cached tensors and total stored elements.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->